### PR TITLE
Add <nav> and aria labels for footer links

### DIFF
--- a/styleguide/source/_patterns/02-molecules/footer-links.twig
+++ b/styleguide/source/_patterns/02-molecules/footer-links.twig
@@ -1,5 +1,6 @@
-
-  <section class="ma__footer-links">
+<section class="ma__footer-links">
+  <nav role="navigation" aria-labeledby="footer-links-1">
+    <h2 class="visually-hidden" id="footer-links-1">Footer Links 1</h2>
     <ul class="ma__footer-links__items">
       <li class="ma__footer-links__item"><a href="#" class="ma__footer-links__link">Living</a></li>
       <li class="ma__footer-links__item"><a href="#" class="ma__footer-links__link">Working</a></li>
@@ -7,16 +8,23 @@
       <li class="ma__footer-links__item"><a href="#" class="ma__footer-links__link">Visiting &amp; Exploring</a></li>
       <li class="ma__footer-links__item"><a href="#" class="ma__footer-links__link">Your Government</a></li>
     </ul>
+  </nav>
+  <nav role="navigation" aria-labeledby="footer-links-2">
+    <h2 class="visually-hidden" id="footer-links-2">Footer Links 2</h2>
     <ul class="ma__footer-links__items">
       <li class="ma__footer-links__item"><a href="#" class="ma__footer-links__link">Contact Us</a></li>
       <li class="ma__footer-links__item"><a href="#" class="ma__footer-links__link">State Data</a></li>
       <li class="ma__footer-links__item"><a href="#" class="ma__footer-links__link">MassCareers</a></li>
       <li class="ma__footer-links__item"><a href="#" class="ma__footer-links__link">MassHR</a></li>
     </ul>
+  </nav>
+  <nav role="navigation" aria-labeledby="footer-links-3">
+    <h2 class="visually-hidden" id="footer-links-3">Footer Links 3</h2>
     <ul class="ma__footer-links__items">
       <li class="ma__footer-links__item"><a href="#" class="ma__footer-links__link">Sitemap</a></li>
       <li class="ma__footer-links__item"><a href="#" class="ma__footer-links__link">Disclaimer</a></li>
       <li class="ma__footer-links__item"><a href="#" class="ma__footer-links__link">Site Policies</a></li>
       <li class="ma__footer-links__item"><a href="#" class="ma__footer-links__link">Feedback</a></li>
     </ul>
+  </nav>
 </section>

--- a/styleguide/source/assets/scss/01-atoms/global/_elements.scss
+++ b/styleguide/source/assets/scss/01-atoms/global/_elements.scss
@@ -3,13 +3,13 @@
 //   outline-style: solid;
 
 //   // WebKit gets its native focus styles.
-  
+
 //   @media (-webkit-min-device-pixel-ratio:0) {
 //     outline-style: auto;
 //   }
 // }
 
-// WARNING: avoid nesting of elements, 
+// WARNING: avoid nesting of elements,
 // because it makes them harder to override
 
 body {
@@ -48,7 +48,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 h1 {
-  font-size: 2.75rem; 
+  font-size: 2.75rem;
   line-height: 1.07;
 
   @media ($bp-medium-min){
@@ -60,7 +60,7 @@ h1 {
   }
 
   @media ($bp-x-large-min){
-    font-size: 3.625rem; 
+    font-size: 3.625rem;
   }
 }
 
@@ -75,12 +75,12 @@ h2 {
 
 h3 {
   font-size: 1.75rem;
-  line-height: 1.214287; 
+  line-height: 1.214287;
 }
 
 h4 {
   font-size: 1.375rem;
-  line-height: 1.5; 
+  line-height: 1.5;
 }
 
 h5 {
@@ -94,3 +94,6 @@ h6 {
 
 // end heading styles
 
+.visually-hidden {
+  @include ma-visually-hidden;
+}


### PR DESCRIPTION
This ask arose from seeing how default Drupal menus work by default - & what they do to make menu regions accessible.

I added a `.visually-hidden` utility class to hide the `<h2>` so they're only visible on screen-readers since this is something that already exists in Drupal & thus no markup change would be needed. Let me know if you'd prefer to have something like `.ma__footer-links__title` though and I'll happily update this PR & change the Drupal markup to reflect the same.
