### PR TITLE
Change <h3> in header banner to be a <p> w/ class.

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-template/collage-header.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/collage-header.twig
@@ -35,10 +35,10 @@
         <h1>Welcome to the Mass.Gov Pilot</h1>
       </div>
       <div class="ma__collage-header__details">
-        <p class="ma__collage-header__details__lead">We're redesigning this website to make it easier to find the things you need.</p>
-        <p class="ma__collage-header__details__content">This is a big project, so we’re going public bit by bit, right here where you can see it and be a part of it. We hope you’ll explore the new site and provide some feedback so we can keep improving it as we add more information and features.</p>
+        <p class="ma__collage-header__lead">We're redesigning this website to make it easier to find the things you need.</p>
+        <p class="ma__collage-header__description">This is a big project, so we’re going public bit by bit, right here where you can see it and be a part of it. We hope you’ll explore the new site and provide some feedback so we can keep improving it as we add more information and features.</p>
 
-        <p class="ma__collage-header__details__content">Thank you for being a part of this project!</p>
+        <p class="ma__collage-header__description">Thank you for being a part of this project!</p>
       </div>
     </div>
   </div>

--- a/styleguide/source/_patterns/03-organisms/by-template/collage-header.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/collage-header.twig
@@ -36,9 +36,9 @@
       </div>
       <div class="ma__collage-header__details">
         <p class="ma__collage-header__details__lead">We're redesigning this website to make it easier to find the things you need.</p>
-        <p>This is a big project, so we’re going public bit by bit, right here where you can see it and be a part of it. We hope you’ll explore the new site and provide some feedback so we can keep improving it as we add more information and features.</p>
+        <p class="ma__collage-header__details__content">This is a big project, so we’re going public bit by bit, right here where you can see it and be a part of it. We hope you’ll explore the new site and provide some feedback so we can keep improving it as we add more information and features.</p>
 
-        <p>Thank you for being a part of this project!</p>
+        <p class="ma__collage-header__details__content">Thank you for being a part of this project!</p>
       </div>
     </div>
   </div>

--- a/styleguide/source/_patterns/03-organisms/by-template/collage-header.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/collage-header.twig
@@ -35,7 +35,7 @@
         <h1>Welcome to the Mass.Gov Pilot</h1>
       </div>
       <div class="ma__collage-header__details">
-        <h3>We're redesigning this website to make it easier to find the things you need.</h3>
+        <p class="ma__collage-header__details__lead">We're redesigning this website to make it easier to find the things you need.</p>
         <p>This is a big project, so we’re going public bit by bit, right here where you can see it and be a part of it. We hope you’ll explore the new site and provide some feedback so we can keep improving it as we add more information and features.</p>
 
         <p>Thank you for being a part of this project!</p>

--- a/styleguide/source/assets/scss/00-base/_mixins.scss
+++ b/styleguide/source/assets/scss/00-base/_mixins.scss
@@ -1,3 +1,4 @@
+@import "mixins/ma-typography";
 @import "mixins/ma-border-decorative";
 @import "mixins/ma-button";
 @import "mixins/ma-button-base";

--- a/styleguide/source/assets/scss/00-base/mixins/_ma-typography.scss
+++ b/styleguide/source/assets/scss/00-base/mixins/_ma-typography.scss
@@ -1,0 +1,46 @@
+@mixin ma-h1 {
+  font-size: 3rem;
+  line-height: 1.07;
+
+  @media ($bp-medium-min){
+    font-size: 3.25rem;
+  }
+
+  @media ($bp-large-min){
+    font-size: 4rem;
+  }
+
+  @media ($bp-x-large-min){
+    font-size: 4.375rem;
+  }
+}
+
+@mixin ma-h2 {
+  font-size: 2.25rem;
+  line-height: 1.222222;
+
+  @media ($bp-small-min){
+    font-size: 2.688rem;
+  }
+}
+
+@mixin ma-h3 {
+  font-size: 2.188rem;
+  line-height: 1.1;
+}
+
+@mixin ma-h4 {
+  font-size: 1.813rem;
+  line-height: 1.2;
+}
+
+@mixin ma-h5 {
+  font-size: 1.625rem;
+  line-height: 1.3;
+  margin-bottom: .5em;
+}
+
+@mixin ma-h6 {
+  font-size: 1.4rem;
+  margin-bottom: .25em;
+}

--- a/styleguide/source/assets/scss/01-atoms/global/_elements.scss
+++ b/styleguide/source/assets/scss/01-atoms/global/_elements.scss
@@ -36,52 +36,23 @@ ul, ol {
 h1, h2, h3, h4, h5, h6 {
   margin-top: 0;
 }
-
 h1 {
-  font-size: 3rem;
-  line-height: 1.07;
-
-  @media ($bp-medium-min){
-    font-size: 3.25rem;
-  }
-
-  @media ($bp-large-min){
-    font-size: 4rem;
-  }
-
-  @media ($bp-x-large-min){
-    font-size: 4.375rem;
-  }
+  @include ma-h1;
 }
-
 h2 {
-  font-size: 2.25rem;
-  line-height: 1.222222;
-
-  @media ($bp-small-min){
-    font-size: 2.688rem;
-  }
+  @include ma-h2;
 }
-
 h3 {
-  font-size: 2.188rem;
-  line-height: 1.1;
+  @include ma-h3;
 }
-
 h4 {
-  font-size: 1.813rem;
-  line-height: 1.2;
+  @include ma-h4;
 }
-
 h5 {
-  font-size: 1.625rem;
-  line-height: 1.3;
-  margin-bottom: .5em;
+  @include ma-h5;
 }
-
 h6 {
-  font-size: 1.4rem;
-  margin-bottom: .25em;
+  @include ma-h6;
 }
 
 // end heading styles

--- a/styleguide/source/assets/scss/03-organisms/_collage-header.scss
+++ b/styleguide/source/assets/scss/03-organisms/_collage-header.scss
@@ -137,7 +137,9 @@ $collage-header-bp-min: "min-width: 701px";
   &__details {
     @media ($collage-header-bp-min) {
       width: 370px;
-      font-size: 1.625rem;
+      &__content {
+        font-size: 1.625rem;
+      }
       &__lead {
         @include ma-h3;
       }

--- a/styleguide/source/assets/scss/03-organisms/_collage-header.scss
+++ b/styleguide/source/assets/scss/03-organisms/_collage-header.scss
@@ -137,12 +137,15 @@ $collage-header-bp-min: "min-width: 701px";
   &__details {
     @media ($collage-header-bp-min) {
       width: 370px;
-      &__content {
-        font-size: 1.625rem;
-      }
-      &__lead {
-        @include ma-h3;
-      }
+    }
+  }
+
+  @media ($collage-header-bp-min) {
+    &__description {
+      font-size: 1.625rem;
+    }
+    &__lead {
+      @include ma-h3;
     }
   }
 }

--- a/styleguide/source/assets/scss/03-organisms/_collage-header.scss
+++ b/styleguide/source/assets/scss/03-organisms/_collage-header.scss
@@ -107,7 +107,7 @@ $collage-header-bp-min: "min-width: 701px";
       @media ($bp-medium-min) {
         right: calc(100% - 550px);
       }
-      
+
       @media ($bp-large-min) {
         right: calc(100% - 620px);
       }
@@ -137,13 +137,9 @@ $collage-header-bp-min: "min-width: 701px";
   &__details {
     @media ($collage-header-bp-min) {
       width: 370px;
-
-      h3 {
-        line-height: 1.3;
-      }
-
-      p {
-        font-size: 1.625rem;
+      font-size: 1.625rem;
+      &__lead {
+        @include ma-h3;
       }
     }
   }

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_collage-header.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_collage-header.scss
@@ -21,9 +21,9 @@ $collage-header-bp-max: "max-width: 700px";
 
   &__details {
     font-weight: 300;
+  }
 
-    &__lead {
-      font-weight: 400;
-    }
+  &__lead {
+    font-weight: 400;
   }
 }

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_collage-header.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_collage-header.scss
@@ -20,13 +20,10 @@ $collage-header-bp-max: "max-width: 700px";
   }
 
   &__details {
+    font-weight: 300;
 
-    h3 {
+    &__lead {
       font-weight: 400;
-    }
-
-    p {
-      font-weight: 300;
     }
   }
 }

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_collage-header.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_collage-header.scss
@@ -19,7 +19,7 @@ $collage-header-bp-max: "max-width: 700px";
     }
   }
 
-  &__details {
+  &__description {
     font-weight: 300;
   }
 


### PR DESCRIPTION
- Change `<h3>` in header banner to be a `<p>` w/ class.
- Make headline sizing mixin-based for re-use, to decouple semantics from styles

@legostud I'm not sure I like how I've accomplished this, entirely. 
I went back & forth between using placeholders & mixins, and went w/ mixins because of placeholders limitations in media queries & I don't *think* we can get around that. 
Let me know if what I've done jives with how you imagined this working & if you're into it, if not I'd love some feedback! 
