### PR TITLE
Sprint7 bugs

### DIFF
--- a/styleguide/source/_patterns/02-molecules/contact-group.twig
+++ b/styleguide/source/_patterns/02-molecules/contact-group.twig
@@ -9,7 +9,7 @@
         <span class="ma__contact-group__label">{{item.label}}:</span>
       {% endif %}
       {% if item.type == "phone" %}
-        <a href="tel:+{{item.link}}" class="ma__content-link ma__content-link--phone">{{item.value}}</a>
+        <a href="tel:{{item.link}}" class="ma__content-link ma__content-link--phone">{{item.value}}</a>
       {% elseif item.type == "email" %}
         <a href="mailto:{{item.link}}" class="ma__content-link">{{item.value}}</a>
       {% elseif item.type == "address" %}

--- a/styleguide/source/assets/scss/02-molecules/_callout-link.scss
+++ b/styleguide/source/assets/scss/02-molecules/_callout-link.scss
@@ -1,7 +1,7 @@
 .ma__callout-link {
   border: 3px solid;
   cursor: pointer;
-  margin-bottom: 1.75rem;
+  margin-bottom: 40px;
   padding: 20px 30px;
 
   &:last-child {

--- a/styleguide/source/assets/scss/03-organisms/_rich-text.scss
+++ b/styleguide/source/assets/scss/03-organisms/_rich-text.scss
@@ -26,7 +26,7 @@ $rich-text-spacing: 1.75rem;
     @include ma-container;
   }
 
-  .ma__split-columns > &,
+  .ma__split-columns__column > &,
   .main-content--two .page-content > & {
     padding-left: 0;
     padding-right: 0;


### PR DESCRIPTION
this will be the last pull request for Sprint 7.

1. RTE - removing l/r padding within a split column
2. Callout Link - increasing the bottom margin to match other components
3. Contact Group - removed the + from the phone link