### PR TITLE
Adjust <main> tag placement

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-author/multi-row-section.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/multi-row-section.twig
@@ -3,12 +3,12 @@
     <h2 class="ma__multi-row-section__title"><a name="{{multiRowSection.id}}" id="{{multiRowSection.id}}">{{multiRowSection.title}}</a></h2>
   </div>
   <div class="main-content {{ multiRowSection.sideBar|length != 'single' ? 'main-content--two' : '' }}">
-    <main class="page-content">
+    <div class="page-content">
       {% for content in multiRowSection.pageContent %}
         {% include content.path with content.data %}
       {% endfor %}
-    </main>
-    {% if multiRowSection.sideBar|length %} 
+    </div>
+    {% if multiRowSection.sideBar|length %}
       <aside class="sidebar">
         {% for sidebar in multiRowSection.sideBar %}
           {% include sidebar.path with sidebar.data %}
@@ -16,5 +16,5 @@
       </aside>
     {% endif %}
   </div>
-</section> 
+</section>
 

--- a/styleguide/source/_patterns/03-organisms/by-template/header.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/header.twig
@@ -31,4 +31,3 @@
   </nav>
 </header>
 <!-- end .header -->
-<a name="main-content"></a>

--- a/styleguide/source/_patterns/04-templates/multi-row-template.twig
+++ b/styleguide/source/_patterns/04-templates/multi-row-template.twig
@@ -1,21 +1,22 @@
 {% include "@organisms/by-template/header.twig" %}
-<div class="pre-content">
-  {% block preContent %}
-    {% include "@base/placeholder.twig" with {'placeholder':{'text':'Pre Content'}} %}
-  {% endblock %}
-</div>
-<div class="multi-row-content">
-  {% block multiRowContent %}
-    {% include "@organisms/by-template/jump-links.twig" %}
-    {% for multiRowSection in multiRowSections %}
-      {% include "@organisms/by-author/multi-row-section.twig" %}
-    {% endfor %}
-  {% endblock %}
-</div>
-<div class="post-content">
-  {% block postContent %}
-    {% include "@base/placeholder.twig" with {'placeholder':{'text':'Post Content'}} %}
-  {% endblock %}
-</div>
-
+<main id="main-content" tabindex="-1">
+  <div class="pre-content">
+    {% block preContent %}
+      {% include "@base/placeholder.twig" with {'placeholder':{'text':'Pre Content'}} %}
+    {% endblock %}
+  </div>
+  <div class="multi-row-content">
+    {% block multiRowContent %}
+      {% include "@organisms/by-template/jump-links.twig" %}
+      {% for multiRowSection in multiRowSections %}
+        {% include "@organisms/by-author/multi-row-section.twig" %}
+      {% endfor %}
+    {% endblock %}
+  </div>
+  <div class="post-content">
+    {% block postContent %}
+      {% include "@base/placeholder.twig" with {'placeholder':{'text':'Post Content'}} %}
+    {% endblock %}
+  </div>
+</main>
 {% include "@organisms/by-template/footer.twig" %}

--- a/styleguide/source/_patterns/04-templates/single-column.twig
+++ b/styleguide/source/_patterns/04-templates/single-column.twig
@@ -1,20 +1,21 @@
 {% include "@organisms/by-template/header.twig" %}
-<div class="pre-content">
-  {% block preContent %}
-    {% include "@base/placeholder.twig" with {'placeholder':{'text':'Pre Content'}} %}
-  {% endblock %}
-</div>
-<div class="main-content">
-  <main class="page-content">
-    {% block pageContent %}
-      {% include "@base/placeholder.twig" with {'placeholder':{'text':'Page content'}} %}
+<main id="main-content" tabindex="-1">
+  <div class="pre-content">
+    {% block preContent %}
+      {% include "@base/placeholder.twig" with {'placeholder':{'text':'Pre Content'}} %}
     {% endblock %}
-  </main>
-</div>
-<div class="post-content">
-  {% block postContent %}
-    {% include "@base/placeholder.twig" with {'placeholder':{'text':'Post Content'}} %}
-  {% endblock %}
-</div>
-
+  </div>
+  <div class="main-content">
+    <div class="page-content">
+      {% block pageContent %}
+        {% include "@base/placeholder.twig" with {'placeholder':{'text':'Page content'}} %}
+      {% endblock %}
+    </div>
+  </div>
+  <div class="post-content">
+    {% block postContent %}
+      {% include "@base/placeholder.twig" with {'placeholder':{'text':'Post Content'}} %}
+    {% endblock %}
+  </div>
+</main>
 {% include "@organisms/by-template/footer.twig" %}

--- a/styleguide/source/_patterns/04-templates/two-column.twig
+++ b/styleguide/source/_patterns/04-templates/two-column.twig
@@ -1,24 +1,26 @@
 {% include "@organisms/by-template/header.twig" %}
-<div class="pre-content">
-  {% block preContent %}
-    {% include "@base/placeholder.twig" with {'placeholder':{'text':'Pre Content'}} %}
-  {% endblock %}
-</div>
-<div class="main-content main-content--two">
-  <main class="page-content">
-    {% block pageContent %}
-      {% include "@base/placeholder.twig" with {'placeholder':{'text':'Page content'}} %}
+<main id="main-content" tabindex="-1">
+  <div class="pre-content">
+    {% block preContent %}
+      {% include "@base/placeholder.twig" with {'placeholder':{'text':'Pre Content'}} %}
     {% endblock %}
-  </main>
-  <aside class="sidebar">
-    {% block sidebar %}
-      {% include "@base/placeholder.twig" with {'placeholder':{'text':'sidebar'}} %}
+  </div>
+  <div class="main-content main-content--two">
+    <div class="page-content">
+      {% block pageContent %}
+        {% include "@base/placeholder.twig" with {'placeholder':{'text':'Page content'}} %}
+      {% endblock %}
+    </div>
+    <aside class="sidebar">
+      {% block sidebar %}
+        {% include "@base/placeholder.twig" with {'placeholder':{'text':'sidebar'}} %}
+      {% endblock %}
+    </aside>
+  </div>
+  <div class="post-content">
+    {% block postContent %}
+      {% include "@base/placeholder.twig" with {'placeholder':{'text':'Post Content'}} %}
     {% endblock %}
-  </aside>
-</div>
-<div class="post-content">
-  {% block postContent %}
-    {% include "@base/placeholder.twig" with {'placeholder':{'text':'Post Content'}} %}
-  {% endblock %}
-</div>
+  </div>
+</main>
 {% include "@organisms/by-template/footer.twig" %}

--- a/styleguide/source/_patterns/06-pilot/header.twig
+++ b/styleguide/source/_patterns/06-pilot/header.twig
@@ -39,4 +39,4 @@
   </nav>
 </header>
 <!-- end .header -->
-<a name="main-content"></a>
+

--- a/styleguide/source/_patterns/06-pilot/single-column-template.twig
+++ b/styleguide/source/_patterns/06-pilot/single-column-template.twig
@@ -1,21 +1,22 @@
 {# For Pilot, I need to include a header with different data #}
 {% include "@pilot/header.twig" %}
-<div class="pre-content">
-  {% block preContent %}
-    {% include "@base/placeholder.twig" with {'placeholder':{'text':'Pre Content'}} %}
-  {% endblock %}
-</div>
-<div class="main-content">
-  <main class="page-content">
-    {% block pageContent %}
-      {% include "@base/placeholder.twig" with {'placeholder':{'text':'Page content'}} %}
+<main id="main-content" tabindex="-1">
+  <div class="pre-content">
+    {% block preContent %}
+      {% include "@base/placeholder.twig" with {'placeholder':{'text':'Pre Content'}} %}
     {% endblock %}
-  </main>
-</div>
-<div class="post-content">
-  {% block postContent %}
-    {% include "@base/placeholder.twig" with {'placeholder':{'text':'Post Content'}} %}
-  {% endblock %}
-</div>
-
+  </div>
+  <div class="main-content">
+    <div class="page-content">
+      {% block pageContent %}
+        {% include "@base/placeholder.twig" with {'placeholder':{'text':'Page content'}} %}
+      {% endblock %}
+    </div>
+  </div>
+  <div class="post-content">
+    {% block postContent %}
+      {% include "@base/placeholder.twig" with {'placeholder':{'text':'Post Content'}} %}
+    {% endblock %}
+  </div>
+</main>
 {% include "@organisms/by-template/footer.twig" %}


### PR DESCRIPTION
Unify use of <main> tag to surround all main page content (i.e not header or footer)
Also adding the ID of main-content and tabindex -1 to pave the way for https://jira.state.ma.us/browse/MASSGOV-1141