### PR TITLE
Add pilot-specific js module to handle the following:

### DIFF
--- a/styleguide/source/_patterns/02-molecules/main-nav.twig
+++ b/styleguide/source/_patterns/02-molecules/main-nav.twig
@@ -2,7 +2,7 @@
   <ul class="ma__main-nav__items js-main-nav">
     {% for nav in mainNav %}
       <li class="ma__main-nav__item {{ nav.active ? 'is-active' : '' }} {{ nav.subNav ? 'has-subnav js-main-nav-toggle' : '' }}">
-        <a class="ma__main-nav__top-link" href="{{nav.href}}" title="{{nav.text}}">{{nav.text}}</a>
+        <a class="ma__main-nav__top-link js-main-nav-top-link" href="{{nav.href}}" title="{{nav.text}}">{{nav.text}}</a>
         {% if nav.subNav %}
           <div class="ma__main-nav__subitems js-main-nav-content is-closed">
             <ul class="ma__main-nav__container">

--- a/styleguide/source/_patterns/02-molecules/main-nav.twig
+++ b/styleguide/source/_patterns/02-molecules/main-nav.twig
@@ -1,8 +1,8 @@
 <section class="ma__main-nav">
   <ul class="ma__main-nav__items js-main-nav">
     {% for nav in mainNav %}
-      <li class="ma__main-nav__item {{ nav.active ? 'is-active' : '' }} {{ nav.subNav ? 'has-subnav js-main-nav-toggle' : '' }}">
-        <a class="ma__main-nav__top-link js-main-nav-top-link" href="{{nav.href}}" title="{{nav.text}}">{{nav.text}}</a>
+      <li class="ma__main-nav__item {{ nav.active ? 'is-active' : '' }} {{ nav.subNav ? 'has-subnav js-main-nav-toggle' : 'js-main-nav-top-link' }}">
+        <a class="ma__main-nav__top-link" href="{{nav.href}}" title="{{nav.text}}">{{nav.text}}</a>
         {% if nav.subNav %}
           <div class="ma__main-nav__subitems js-main-nav-content is-closed">
             <ul class="ma__main-nav__container">

--- a/styleguide/source/_patterns/06-pilot/main-nav.twig
+++ b/styleguide/source/_patterns/06-pilot/main-nav.twig
@@ -1,8 +1,8 @@
 <section class="ma__main-nav">
   <ul class="ma__main-nav__items js-main-nav">
     {% for nav in mainNavPilot %}
-      <li class="ma__main-nav__item {{ nav.active ? 'is-active' : '' }} {{ nav.subNav ? 'has-subnav js-main-nav-toggle' : '' }}">
-        <a class="ma__main-nav__top-link js-main-nav-top-link" href="{{nav.href}}" title="{{nav.text}}">{{nav.text}}</a>
+      <li class="ma__main-nav__item {{ nav.active ? 'is-active' : '' }} {{ nav.subNav ? 'has-subnav js-main-nav-toggle' : 'js-main-nav-top-link' }}">
+        <a class="ma__main-nav__top-link" href="{{nav.href}}" title="{{nav.text}}">{{nav.text}}</a>
         {% if nav.subNav %}
           <div class="ma__main-nav__subitems js-main-nav-content is-closed">
             <ul class="ma__main-nav__container">

--- a/styleguide/source/_patterns/06-pilot/main-nav.twig
+++ b/styleguide/source/_patterns/06-pilot/main-nav.twig
@@ -2,7 +2,7 @@
   <ul class="ma__main-nav__items js-main-nav">
     {% for nav in mainNavPilot %}
       <li class="ma__main-nav__item {{ nav.active ? 'is-active' : '' }} {{ nav.subNav ? 'has-subnav js-main-nav-toggle' : '' }}">
-        <a class="ma__main-nav__top-link" href="{{nav.href}}" title="{{nav.text}}">{{nav.text}}</a>
+        <a class="ma__main-nav__top-link js-main-nav-top-link" href="{{nav.href}}" title="{{nav.text}}">{{nav.text}}</a>
         {% if nav.subNav %}
           <div class="ma__main-nav__subitems js-main-nav-content is-closed">
             <ul class="ma__main-nav__container">

--- a/styleguide/source/assets/js/index.js
+++ b/styleguide/source/assets/js/index.js
@@ -9,6 +9,7 @@ import formValidation   from "./modules/formValidation.js";
 import hideAlert        from "./modules/hideAlert.js";
 import keywordSearch    from "./modules/keywordSearch.js";
 import mainNav          from "./modules/mainNav.js";
+import mainNavPilot     from "./modules/mainNavPilot.js";
 import mobileNav        from "./modules/mobileNav.js";
 import responsiveVideo  from "./modules/responsiveVideo.js";
 import richText         from "./modules/richText.js";

--- a/styleguide/source/assets/js/modules/mainNav.js
+++ b/styleguide/source/assets/js/modules/mainNav.js
@@ -154,7 +154,7 @@ export default function (window,document,$,undefined) {
         hide($openContent);
       }
     });
-    $mainNavToggle .on('click', function(e) {
+    $mainNavToggle.on('click', function(e) {
       if(windowWidth <= breakpoint) {
         e.preventDefault();
 

--- a/styleguide/source/assets/js/modules/mainNav.js
+++ b/styleguide/source/assets/js/modules/mainNav.js
@@ -182,6 +182,12 @@ export default function (window,document,$,undefined) {
       hide($openContent);
     });
 
+    // Hide any open submenu content when the sidebar menu is closed
+    $('.js-header-menu-button').click(function() {
+      let $openContent = $parent.find('.js-main-nav-content.' + openClass);
+      hide($openContent);
+    });
+
 
     function hide($content) {
       $('body').removeClass(submenuClass);

--- a/styleguide/source/assets/js/modules/mainNavPilot.js
+++ b/styleguide/source/assets/js/modules/mainNavPilot.js
@@ -1,0 +1,57 @@
+export default function (window,document,$,undefined) {
+
+  let windowWidth = window.innerWidth;
+
+  $(window).resize(function(){
+    windowWidth = window.innerWidth;
+  });
+
+  $('.js-main-nav').each(function() {
+    let openClass = "is-open",
+        closeClass = "is-closed",
+        submenuClass = "show-submenu",
+        $parent = $(this),
+        $mainNavToggle = $parent.find('.js-main-nav-toggle'),
+        previousKey = null,
+        breakpoint = 800; // matches CSS breakpoint for Main Nav
+
+    // duplicated from mainNav.js
+    function hide($content) {
+      $('body').removeClass(submenuClass);
+      $parent.find("." + openClass).removeClass(openClass);
+
+      if(windowWidth <= breakpoint) {
+        $content.addClass(closeClass);
+      } else {
+        $content
+        .stop( true, true )
+        .slideUp('fast',function() {
+          $content
+            .addClass(closeClass)
+            .slideDown(0);
+        });
+      }
+    }
+
+    // make root top-level links inert for pilot
+    $parent.find('.has-subnav .js-main-nav-top-link').click(function(e) {
+      e.preventDefault();
+    });
+
+    // Ensure top-level links that are potential anchor links close the sidebar on mobile
+    $parent.find('.ma__main-nav__item:not(.has-subnav) .js-main-nav-top-link').click(function() {
+      $('body').removeClass('show-menu');
+    });
+
+    // Hide any open submenu content when the sidebar menu is closed
+    $('.js-header-menu-button').click(function() {
+      let $openContent = $parent.find('.js-main-nav-content.' + openClass);
+      hide($openContent);
+    });
+
+
+
+  });
+
+}(window,document,jQuery);
+

--- a/styleguide/source/assets/js/modules/mainNavPilot.js
+++ b/styleguide/source/assets/js/modules/mainNavPilot.js
@@ -1,55 +1,18 @@
 export default function (window,document,$,undefined) {
 
-  let windowWidth = window.innerWidth;
-
-  $(window).resize(function(){
-    windowWidth = window.innerWidth;
-  });
-
   $('.js-main-nav').each(function() {
-    let openClass = "is-open",
-        closeClass = "is-closed",
-        submenuClass = "show-submenu",
-        $parent = $(this),
-        $mainNavToggle = $parent.find('.js-main-nav-toggle'),
-        previousKey = null,
-        breakpoint = 800; // matches CSS breakpoint for Main Nav
-
-    // duplicated from mainNav.js
-    function hide($content) {
-      $('body').removeClass(submenuClass);
-      $parent.find("." + openClass).removeClass(openClass);
-
-      if(windowWidth <= breakpoint) {
-        $content.addClass(closeClass);
-      } else {
-        $content
-        .stop( true, true )
-        .slideUp('fast',function() {
-          $content
-            .addClass(closeClass)
-            .slideDown(0);
-        });
-      }
-    }
+    let $parent = $(this),
+      $mainNavToggle = $parent.find('.js-main-nav-toggle');
 
     // make root top-level links inert for pilot
-    $parent.find('.has-subnav .js-main-nav-top-link').click(function(e) {
+    $mainNavToggle.find('a').on('click', function(e) {
       e.preventDefault();
     });
 
     // Ensure top-level links that are potential anchor links close the sidebar on mobile
-    $parent.find('.ma__main-nav__item:not(.has-subnav) .js-main-nav-top-link').click(function() {
-      $('body').removeClass('show-menu');
+    $parent.find('.js-main-nav-top-link').find('a').on('click', function() {
+      $('.js-header-menu-button').trigger('click');
     });
-
-    // Hide any open submenu content when the sidebar menu is closed
-    $('.js-header-menu-button').click(function() {
-      let $openContent = $parent.find('.js-main-nav-content.' + openClass);
-      hide($openContent);
-    });
-
-
 
   });
 


### PR DESCRIPTION
- keep top-level-links that have sub-menus inert when clicked
- clear out open submenus when mobile sidebar is closed
- anchor links that are top-level-links close sidebar when clicked