### PR TITLE
Instead of targeting the navToggle root, target the direct <a>

### DIFF
--- a/styleguide/source/assets/js/modules/mainNav.js
+++ b/styleguide/source/assets/js/modules/mainNav.js
@@ -154,13 +154,12 @@ export default function (window,document,$,undefined) {
         hide($openContent);
       }
     });
-    $mainNavToggle.on('click', function(e) {
+    $mainNavToggle.children('a').on('click', function(e) {
       if(windowWidth <= breakpoint) {
         e.preventDefault();
-
-        let $content = $(this).find('.js-main-nav-content');
+        let $content = $(this).parent().find('.js-main-nav-content');
         // add open class to this item
-        $(this).addClass(openClass);
+        $(this).parent().addClass(openClass);
         show($content);
       }
     });


### PR DESCRIPTION
Since the click handler was set up on the parent of the <a> and the sub-menu items, the individual sub-menu links were getting triggered (& preventDefault'ed), too. 

This is starting to feel a little brittle, in terms of jumping around in DOM traversal a little more than I'd like. But, first and foremost I believe this fixes the issue.