### PR TITLE
Massgov 1135 better skip navigation text

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-template/header.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/header.twig
@@ -1,6 +1,6 @@
 <!-- Begin .header -->
 <header class="ma__header">
-  <a class="ma__header__skip-nav" href="#main-content">skip navigation</a>
+  <a class="ma__header__skip-nav" href="#main-content">skip to main content</a>
   <div class="ma__header__container">
     <div class="ma__header__logo">
       {% include "@atoms/09-media/site-logo.twig" %}

--- a/styleguide/source/_patterns/06-pilot/header.twig
+++ b/styleguide/source/_patterns/06-pilot/header.twig
@@ -4,7 +4,7 @@
 <link href="/{{ directory }}/css/pilot-generated.css" rel="stylesheet" />
 <!-- Begin .header -->
 <header class="ma__header">
-  <a class="ma__header__skip-nav" href="#main-content">skip navigation</a>
+  <a class="ma__header__skip-nav" href="#main-content">skip to main content</a>
   <div class="ma__header__backto">
     <a href="http://www.mass.gov">Back to Mass.Gov</a>
   </div>


### PR DESCRIPTION
Changed the skip link text, "skip navigation", to "skip to main content" which describes where actually the link points to.
This change affect AT device users about how the link is announced, but doens't affect the functionality of the link itself.

## Current 

```
<header class="ma__header">
  <a class="ma__header__skip-nav" href="#main-content">skip navigation</a>
```
  
## Changed to 
```
<header class="ma__header">
  <a class="ma__header__skip-nav" href="#main-content">skip to main content</a>  
```
## The change was made in the following templates:
- styleguide/source/_patterns/03-organisms/by-template/header.twig
- styleguide/source/_patterns/06-pilot/header.twig