### PR TITLE
Massgov 1158 hours semantic markup

### DIFF
--- a/styleguide/source/_patterns/05-pages/LOC-Mt-Greylock-State-Park.json
+++ b/styleguide/source/_patterns/05-pages/LOC-Mt-Greylock-State-Park.json
@@ -163,9 +163,9 @@
           }
         },
         {
-          "path": "atoms-heading-5",
+          "path": "atoms-heading-4",
           "data": {
-            "heading5" : {
+            "heading4" : {
                 "text": "Park"
             }
           }
@@ -179,9 +179,9 @@
           }
         },
         {
-          "path": "atoms-heading-5",
+          "path": "atoms-heading-4",
           "data": {
-            "heading5" : {
+            "heading4" : {
                 "text": "Museum"
             }
           }
@@ -195,9 +195,9 @@
           }
         },
         {
-          "path": "atoms-heading-5",
+          "path": "atoms-heading-4",
           "data": {
-            "heading5" : {
+            "heading4" : {
                 "text": "Beach"
             }
           }

--- a/styleguide/source/_patterns/05-pages/LOC-Southbridge-RMV.json
+++ b/styleguide/source/_patterns/05-pages/LOC-Southbridge-RMV.json
@@ -113,9 +113,9 @@
           }
         },
         {
-          "path": "atoms-heading-5",
+          "path": "atoms-heading-4",
           "data": {
-            "heading5" : {
+            "heading4" : {
                 "text": "Park"
             }
           }
@@ -129,9 +129,9 @@
           }
         },
         {
-          "path": "atoms-heading-5",
+          "path": "atoms-heading-4",
           "data": {
-            "heading5" : {
+            "heading4" : {
                 "text": "Museum"
             }
           }
@@ -145,9 +145,9 @@
           }
         },
         {
-          "path": "atoms-heading-5",
+          "path": "atoms-heading-4",
           "data": {
-            "heading5" : {
+            "heading4" : {
                 "text": "Beach"
             }
           }


### PR DESCRIPTION
The "Hours markup in the `LOC` pages skips H4 tags. `MASSGOV-1158` fixes the correct the heading hierarchy (change H5 to H4).