### PR TITLE
Sprint8 accessibility improvements

### DIFF
--- a/styleguide/source/_patterns/01-atoms/decorative-link.twig
+++ b/styleguide/source/_patterns/01-atoms/decorative-link.twig
@@ -1,9 +1,7 @@
 <span class="ma__decorative-link">
   {% if decorativeLink.type == "external" %}
-    <a href="{{decorativeLink.href}}" class="js-clickable-link">{{decorativeLink.text}}&nbsp;{% include "@atoms/05-icons/svg-external-link.twig" %}</a>
-  {% elseif decorativeLink.type == "info" %}
-	 <a href="{{decorativeLink.href}}">Learn More<span class="ma__decorative-link__info"> about {{decorativeLink.text}}</span>&nbsp;{% include "@atoms/05-icons/svg-arrow.twig" %}</a>  
+    <a href="{{decorativeLink.href}}" class="js-clickable-link">{{decorativeLink.text}}{% if decorativeLink.info %}<span class="ma__decorative-link__info">{{ decorativeLink.info }}</span>{% endif %}&nbsp;{% include "@atoms/05-icons/svg-external-link.twig" %}</a>
   {% else %}
-    <a href="{{decorativeLink.href}}" class="js-clickable-link">{{decorativeLink.text}}&nbsp;{% include "@atoms/05-icons/svg-arrow.twig" %}</a>
+    <a href="{{decorativeLink.href}}" class="js-clickable-link">{{decorativeLink.text}}{% if decorativeLink.info %}<span class="ma__decorative-link__info">{{ decorativeLink.info }}</span>{% endif %}&nbsp;{% include "@atoms/05-icons/svg-arrow.twig" %}</a>
   {% endif %}
 </span>

--- a/styleguide/source/_patterns/01-atoms/decorative-link~read-more.json
+++ b/styleguide/source/_patterns/01-atoms/decorative-link~read-more.json
@@ -2,7 +2,7 @@
   "decorativeLink": {
     "type": "",
     "href": "#",
-    "text": "Lorem ipsum dolor sit amet.",
-    "info": ""
+    "text": "read more",
+    "info": "Fishing Licenses"
   }
 }

--- a/styleguide/source/_patterns/02-molecules/section-links.json
+++ b/styleguide/source/_patterns/02-molecules/section-links.json
@@ -1,5 +1,6 @@
 {
   "sectionLinks": {
+    "id": "GUIDasjdhf1",
     "catIcon": {
       "svg":"@atoms/07-user-added-icons/svg-camping.twig",
       "small":"true"

--- a/styleguide/source/_patterns/02-molecules/section-links.twig
+++ b/styleguide/source/_patterns/02-molecules/section-links.twig
@@ -1,3 +1,12 @@
+{% set decorativeLink = { 
+  "type": "", 
+  "href": sectionLinks.title.href, 
+  "text": sectionLinks.title.text, 
+  "info": "" } 
+%}
+{% set titleClass = "ma__section-links__title js-accordion-link" %}
+{% set titleId = "section_titles_" ~ sectionLinks.id %}
+
 <section class="ma__section-links js-accordion">
   <div class="ma__section-links__content">
     {% if sectionLinks.catIcon %}
@@ -6,15 +15,26 @@
         {% include "@atoms/05-icons/cat-icon.twig" %}
       </div>
     {% endif %}
-
-    <h{% if sectionThreeUp.title %}3{% else %}2{% endif %} class="ma__section-links__title js-accordion-link" id="section_titles_{{sectionLinks.title.text|lower|replace({' ':'-'})}}">
-      <a href="{{sectionLinks.title.href}}">{{sectionLinks.title.text}}&nbsp;{% include "@atoms/05-icons/svg-arrow.twig" %}</a>
-    </h{% if sectionThreeUp.title %}3{% else %}2{% endif %}>
-    <nav class="ma__section-links__toggle-content js-accordion-body" aria-labelledby="section_titles_{{sectionLinks.title.text|lower|replace({' ':'-'})}}">
+    {% if sectionLinks.sub %}
+      <h3 class="{{ titleClass }}" id="{{ titleId }}">
+        {% include "@atoms/decorative-link.twig" %}
+      </h3>
+    {% else %}
+      <h2 class="{{ titleClass }}" id="{{ titleId }}">
+        {% include "@atoms/decorative-link.twig" %}
+      </h2>
+    {% endif %}
+    <nav class="ma__section-links__toggle-content js-accordion-body" aria-labelledby="{{ titleId }}">
       {% if sectionLinks.description %}
         <p class="ma__section-links__description">{{sectionLinks.description}}</p>
       {% endif %}
       <div class="ma__section-links__mobile-title">
+        {% set decorativeLink = { 
+          "type": "", 
+          "href": sectionLinks.title.href, 
+          "text": "Learn More", 
+          "info": "about " ~ sectionLinks.title.text } 
+        %}
         {% include "@atoms/decorative-link.twig" %}
       </div>
       <ul class="ma__section-links__items">

--- a/styleguide/source/_patterns/03-organisms/by-author/sections-three-up.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/sections-three-up.json
@@ -2,6 +2,7 @@
   "sectionThreeUp" : {
     "title": "More in Visiting & Exploring",
     "sections": [{
+      "id": "GUIDasjdhf1",
       "catIcon": {
         "svg":"atoms-svg-id-card",
         "small":"true"
@@ -25,6 +26,7 @@
       }]
     },
     {
+      "id": "GUIDasjdhf2",
       "catIcon": {
         "svg":"atoms-svg-campfire",
         "small":"true"
@@ -52,6 +54,7 @@
       }]
     }, 
     {
+      "id": "GUIDasjdhf3",
       "catIcon": {
         "svg":"atoms-svg-map",
         "small":"true"
@@ -79,6 +82,7 @@
       }]
     },
     {
+      "id": "GUIDasjdhf4",
       "catIcon": {
         "svg":"atoms-svg-theater",
         "small":"true"

--- a/styleguide/source/_patterns/03-organisms/by-author/sections-three-up.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/sections-three-up.twig
@@ -1,9 +1,12 @@
+{% set sub = "" %}
 <section class="ma__sections-3up">
   {% if sectionThreeUp.title %}
+    {% set sub = "true" %}
     <h2 class="ma__sections-3up__title">{{sectionThreeUp.title}}</h2>
   {% endif %}
   <div class="ma__sections-3up__container">
     {% for sectionLinks in sectionThreeUp.sections %}
+      {% set sectionLinks = sectionLinks|merge({'sub': sub }) %}
       {% include "@molecules/section-links.twig" with sectionLinks %}
     {% endfor %}
   </div>

--- a/styleguide/source/_patterns/05-pages/L0-visiting-and-exploring.json
+++ b/styleguide/source/_patterns/05-pages/L0-visiting-and-exploring.json
@@ -22,6 +22,7 @@
   "sectionThreeUp" : {
     "title": "",
     "sections": [{
+      "id": "GUIDasjdhf1",
       "catIcon": {
         "svg":"atoms-svg-id-card",
         "small":"true"
@@ -45,6 +46,7 @@
       }]
     },
     {
+      "id": "GUIDasjdhf2",
       "catIcon": {
         "svg":"atoms-svg-campfire",
         "small":"true"
@@ -72,6 +74,7 @@
       }]
     }, 
     {
+      "id": "GUIDasjdhf3",
       "catIcon": {
         "svg":"atoms-svg-map",
         "small":"true"
@@ -99,6 +102,7 @@
       }]
     },
     {
+      "id": "GUIDasjdhf4",
       "catIcon": {
         "svg":"atoms-svg-theater",
         "small":"true"

--- a/styleguide/source/_patterns/05-pages/L1-state-parks-and-recreation.json
+++ b/styleguide/source/_patterns/05-pages/L1-state-parks-and-recreation.json
@@ -54,6 +54,7 @@
   "sectionThreeUp" : {
     "title": "More in State Parks & Recreation",
     "sections": [{
+      "id": "GUIDasjdhf1",
       "catIcon": "",
       "title" : {
         "href" : "#",
@@ -78,6 +79,7 @@
       }]
     },
     {
+      "id": "GUIDasjdhf2",
       "catIcon": "",
       "title" : {
         "href" : "#",
@@ -102,6 +104,7 @@
       }]
     }, 
     {
+      "id": "GUIDasjdhf3",
       "catIcon": "",
       "title" : {
         "href" : "#",
@@ -126,6 +129,7 @@
       }]
     },
     {
+      "id": "GUIDasjdhf4",
       "catIcon": "",
       "title" : {
         "href" : "#",

--- a/styleguide/source/assets/scss/01-atoms/_decorative-link.scss
+++ b/styleguide/source/assets/scss/01-atoms/_decorative-link.scss
@@ -4,6 +4,6 @@
   vertical-align: middle;
 
   &__info {
-  	 @include ma-visually-hidden;
+    @include ma-visually-hidden;
   }
 }

--- a/styleguide/source/assets/scss/02-molecules/_section-links.scss
+++ b/styleguide/source/assets/scss/02-molecules/_section-links.scss
@@ -62,8 +62,10 @@
       display: none;
     }
 
-    svg {
+    & a > svg {
+      height: .75em;
       margin-right: -16px;
+      width: .75em;
     }
 
     a {
@@ -73,9 +75,15 @@
   }
 
   &__title {
+    @include ma-h3;
     margin-bottom: 15px;
 
+    a {
+      border: none;
+    }
+
     a:hover {
+      border: none;
       opacity: .6;
     }
 
@@ -101,7 +109,7 @@
         }
       }
 
-      svg {
+      a > svg {
         display: none;
       }
     }
@@ -160,9 +168,4 @@
       }
     }
   }
-}
-
-// when the page doesn't have h2 for the section, h3 shifted up to h2 with the h3's style
-h2.ma__section-links__title {
-    @include ma-h3;
 }


### PR DESCRIPTION
1. New optional "info" variable added to the "decorative links" atom 
  * this contains hidden text for screen reads that is added to the link in cases where the link's text is too generic like "learn more"
2. New optional "sub" variable added to "section links" molecule
  * if sub equals "true" then the section link title will be rendered as an h3, otherwise an h2 will be used.
  * this change is "mostly" backward compatible.  You can have an h2 followed by another h2, but it is not semantic.
3. New optional "id" variable added to the "sections links" molecule
  * this value is used to connect the title and nav elements
  * this value has to be unique for each section links molecule used on the page.
