### PR TITLE
MASSGOV-1201 Icons for section links in L0/Topic page

### DIFF
--- a/styleguide/source/_patterns/01-atoms/05-icons/cat-icon.twig
+++ b/styleguide/source/_patterns/01-atoms/05-icons/cat-icon.twig
@@ -1,4 +1,4 @@
 <figure class="ma__category-icon {{catIcon.small == "true" ? 'ma__category-icon--small' : ''}}">
-  {% include "@atoms/07-user-added-icons/svg-camping.twig" %}
+  {% include catIcon.svg %}
 </figure>
 

--- a/styleguide/source/assets/scss/01-atoms/_category-icon.scss
+++ b/styleguide/source/assets/scss/01-atoms/_category-icon.scss
@@ -36,7 +36,7 @@
     width: 60px;
 
     svg {
-      height: 32px;
+      height: 35px;
       width: 35px;
     }
   }


### PR DESCRIPTION
This affects section icons, `<figure class="ma__category-icon ma__category-icon--small">
<svg>` in `<section class="ma__section-links js-accordion">` in [L0 page] (http://localhost:3000/patterns/05-pages-L0-visiting-and-exploring/05-pages-L0-visiting-and-exploring.html).

In cat-icon.twig, the hardcoded icon, presented as a sample, is replaced to `catIcon.svg` to pull an actual icon selected for each `<section>`.

Based on the conversation with @legostud, the icon's height has been modified from 32px to 35px in  _category-icon.scss.

A PR for the same change has been made in massgov/mass to match this PR for the bug fix [MASSGOV-1201](https://jira.state.ma.us/browse/MASSGOV-1201) on jira.  Its PR has the same title as this one.  Please do any necessary coordination to apply this change in massgov/mass since the change to there is unable to push as a branch through git.  I put this paragraph in the other PR as well.