### PR TITLE
MASSGOV-1202_section-links-title-link

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_section-links.scss
+++ b/styleguide/source/assets/scss/02-molecules/_section-links.scss
@@ -13,7 +13,7 @@
   }
 
   // controls for when to activate accordion
-  &.js-section-accordion:before {
+  &.js-accordion:before {
     content: "true";
     display: none;
 


### PR DESCRIPTION
The css selector fix to fix the non working link issue on `<h3 class="ma__section-links__title js-accordion-link" id="section_titles_GUIDasjdhf1"><span class="ma__decorative-link">
<a href="#" class="js-clickable-link">`. The incorrect selector was identified and the correct one was confirmed by @legostud.