### PR TITLE
[Do not merge] Proof-of-concept tracking utility classes.

### DIFF
--- a/styleguide/source/_patterns/01-atoms/decorative-link.twig
+++ b/styleguide/source/_patterns/01-atoms/decorative-link.twig
@@ -1,7 +1,7 @@
 <span class="ma__decorative-link">
   {% if decorativeLink.type == "external" %}
-    <a href="{{decorativeLink.href}}" class="js-clickable-link">{{decorativeLink.text}}{% if decorativeLink.info %}<span class="ma__decorative-link__info">{{ decorativeLink.info }}</span>{% endif %}&nbsp;{% include "@atoms/05-icons/svg-external-link.twig" %}</a>
+    <a href="{{decorativeLink.href}}" class="js-clickable-link trk-decorative-link">{{decorativeLink.text}}{% if decorativeLink.info %}<span class="ma__decorative-link__info">{{ decorativeLink.info }}</span>{% endif %}&nbsp;{% include "@atoms/05-icons/svg-external-link.twig" %}</a>
   {% else %}
-    <a href="{{decorativeLink.href}}" class="js-clickable-link">{{decorativeLink.text}}{% if decorativeLink.info %}<span class="ma__decorative-link__info">{{ decorativeLink.info }}</span>{% endif %}&nbsp;{% include "@atoms/05-icons/svg-arrow.twig" %}</a>
+    <a href="{{decorativeLink.href}}" class="js-clickable-link trk-decorative-link">{{decorativeLink.text}}{% if decorativeLink.info %}<span class="ma__decorative-link__info">{{ decorativeLink.info }}</span>{% endif %}&nbsp;{% include "@atoms/05-icons/svg-arrow.twig" %}</a>
   {% endif %}
 </span>

--- a/styleguide/source/_patterns/02-molecules/contact-group.twig
+++ b/styleguide/source/_patterns/02-molecules/contact-group.twig
@@ -1,4 +1,4 @@
-<div class="ma__contact-group">
+<div class="ma__contact-group trk-contact-group">
   <h6 class="ma__contact-group__name">
     {% include contactGroup.icon %}
     <span>{{contactGroup.name}}</span>
@@ -11,13 +11,13 @@
 
       {# Online wrap value in a link #}
       {% if item.type == "online" %}
-        <a href="{{item.link}}" class="ma__content-link">{{item.value}}</a>
+        <a href="{{item.link}}" class="ma__content-link trk-contact-link-online">{{item.value}}</a>
       {# Phone - add tel: to href #}
       {% elseif item.type == "phone" %}
-        <a href="tel:{{item.link}}" class="ma__content-link ma__content-link--phone">{{item.value}}</a>
+        <a href="tel:{{item.link}}" class="ma__content-link ma__content-link--phone trk-contact-link-phone">{{item.value}}</a>
       {# Email - add mailto: to href #}
       {% elseif item.type == "email" %}
-        <a href="mailto:{{item.link}}" class="ma__content-link">{{item.value}}</a>
+        <a href="mailto:{{item.link}}" class="ma__content-link trk-contact-link-email">{{item.value}}</a>
       {# Address - RTE version of value and look for directions link #}
       {% elseif item.type == "address" %}
         <div class="ma__contact-group__address">
@@ -28,7 +28,7 @@
         {% endif %}
       {# Default - just spit out the value #}
       {% else %}
-        <span class="ma__contact-group__value">{{item.value}}</span>        
+        <span class="ma__contact-group__value">{{item.value}}</span>
       {% endif %}
     </div>
     {% if item.details %}

--- a/styleguide/source/_patterns/02-molecules/related-action.twig
+++ b/styleguide/source/_patterns/02-molecules/related-action.twig
@@ -1,4 +1,4 @@
-<section class="ma__related-action">
+<section class="ma__related-action trk-related-action">
   <div class="ma__related-action__link">
     {% set decorativeLink = relatedAction.link %}
     {% include "@atoms/decorative-link.twig" with decorativeLink %}

--- a/styleguide/source/_patterns/03-organisms/by-author/quick-actions.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/quick-actions.twig
@@ -1,4 +1,4 @@
-<section class="ma__quick-actions">
+<section class="ma__quick-actions trk-quick-actions">
   {% if quickActions.coloredHeading %}
     {% set coloredHeading = quickActions.coloredHeading %}
     {% include "@atoms/04-headings/colored-heading.twig" %}

--- a/styleguide/source/_patterns/03-organisms/by-author/sidebar-widget.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/sidebar-widget.twig
@@ -1,6 +1,6 @@
 {% set coloredHeading = sidebarWidget.coloredHeading %}
 {% include "@atoms/04-headings/colored-heading.twig" %}
-<section class="ma__sidebar-widget">
+<section class="ma__sidebar-widget trk-sidebar-widget">
   <div class="ma__sidebar-widget__items">
   {% for item in sidebarWidget.items %}
       {% set data = item.data %}


### PR DESCRIPTION
Add `.trk-` classes for atoms/molecules/organisms in POC for sidebar targeting.

The goal of this is the establish a convention of `.trk-` prefixed classes to exist by default in atoms/molecules/organisms so we can traverse the DOM in a more fine-grained way to track conversions. 

For this POC I just filled out the sidebar of action pages. 
Check out an action page (http://localhost:3000/patterns/05-pages-ACTION-get-a-state-park-pass/05-pages-ACTION-get-a-state-park-pass.html) 

We have the ability to have selectors for things like the following:

| Thing to target  | Selector |
| ------------- | ------------- | 
| A quick action link  | `.trk-quick-actions .trk-decorative-link`  | 
| A related action link  | `.trk-related-action .trk-decorative-link`  | 
| Any contact link  | `.trk-contact-group a`  |
| Contact phone number  | `.trk-contact-group .trk-contact-link-phone`  |


**note** I'll set up a time to do a proper code review all together, but feel free to leave thoughts here in the meantime if you'd like. 