### PR TITLE
Fix top-level link JS in main navigation

### DIFF
--- a/styleguide/source/assets/js/modules/mainNav.js
+++ b/styleguide/source/assets/js/modules/mainNav.js
@@ -158,7 +158,6 @@ export default function (window,document,$,undefined) {
     });
     $mainNavToggle.children('a').on('click', function(e) {
       if(windowWidth <= breakpoint) {
-        e.preventDefault();
         let $content = $(this).parent().find('.js-main-nav-content');
         // add open class to this item
         $(this).parent().addClass(openClass);


### PR DESCRIPTION
Remove `preventDefault` that was stopping the link-following behavior of top-level links.

**Jira:** https://jira.state.ma.us/browse/MQA-195