### PR TITLE
Adjust main mobile nav container height to avoid items getting cut off.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_main-nav.scss
+++ b/styleguide/source/assets/scss/02-molecules/_main-nav.scss
@@ -156,6 +156,7 @@
 
     @media ($bp-header-toggle-max) {
       margin-top: $header-mobile-controls-height;
+      height: calc(100vh - #{$header-mobile-controls-height});
       overflow-y: auto;
       padding-left: 20px;
       right: -300px;
@@ -190,10 +191,6 @@
 
   &__container {
     @include ma-reset-list;
-
-    @media ($bp-header-toggle-max) {
-      height: 100vh;
-    }
   }
 
   &__subitem {


### PR DESCRIPTION
To see the issue in Pattern Lab you have to add more items to the mobile nav subitems or just make the 'device' height quite small. But this adjustment avoids having items cut off & the white background ending early.

**Jira:** https://jira.state.ma.us/browse/MQA-201