### PR TITLE
MQA-203 add webkit algorithm flag for column count

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_link-list.scss
+++ b/styleguide/source/assets/scss/03-organisms/_link-list.scss
@@ -20,6 +20,7 @@
   }
 
   &__item {
+    -webkit-column-break-inside: avoid; // avoids partial-overflow bug on webkit
     padding: 5px 0 5px 1.4em;
     text-indent: -1.4em;
   }


### PR DESCRIPTION
This avoids part of an element that is laid out via column-count from partially overflowing (i.e part of the border or padding from the last element in column one is at the top of column two).

**Jira:** https://jira.state.ma.us/browse/MQA-203
