### PR TITLE
Fixes MQA-235-video-title

### DIFF
--- a/styleguide/source/_patterns/01-atoms/09-media/video.json
+++ b/styleguide/source/_patterns/01-atoms/09-media/video.json
@@ -1,5 +1,6 @@
 {
-  "video" : { 
-    "src" : "https://www.youtube.com/embed/dEkUq-Rs-Tc"
+  "video" : {
+    "src" : "https://www.youtube.com/embed/dEkUq-Rs-Tc",
+    "title" : "Using a gas grill safely"
   }
 }

--- a/styleguide/source/_patterns/01-atoms/09-media/video.twig
+++ b/styleguide/source/_patterns/01-atoms/09-media/video.twig
@@ -1,3 +1,3 @@
 <div class="ma__rich-text__embed js-ma-responsive-video">
-  <iframe width="853" height="480" src="{{video.src}}" frameborder="0" allowfullscreen></iframe>
+  <iframe width="853" height="480" src="{{video.src}}" frameborder="0" allowfullscreen title="{{video.title}}"></iframe>
 </div>


### PR DESCRIPTION
Fixes 
- https://jira.state.ma.us/browse/MQA-235

Note:  Not 100% how the js object plays with the twig file.  I see it as a placeholder for what we expect drupal to pass to the template so I wanted to makes sure that I included a new property `video.title`.  That being said, even after a new `gulp build`, I couldn't get the title to populate.  Please let me know if I got this right. 