### PR TITLE
Replace h4 with a div for action item link title

### DIFF
--- a/styleguide/source/_patterns/02-molecules/illustrated-link.twig
+++ b/styleguide/source/_patterns/02-molecules/illustrated-link.twig
@@ -1,10 +1,10 @@
 <div class="ma__illustrated-link">
   <div class="ma__illustrated-link__content">
-    <h4 class="ma__illustrated-link__title">
+    <div class="ma__illustrated-link__title">
       <span class="ma__illustrated-link__label">Guide:</span>
       {% set decorativeLink = illustratedLink %}
       {% include "@atoms/decorative-link.twig" %}
-    </h4>
+    </div>
   </div>
   <div class="ma__illustrated-link__image" style="background-image: url('{{illustratedLink.image}}')"></div>
 </div>

--- a/styleguide/source/assets/scss/02-molecules/_illustrated-link.scss
+++ b/styleguide/source/assets/scss/02-molecules/_illustrated-link.scss
@@ -35,6 +35,7 @@ $illustrated-link-image-width: 130px;
 
   &__label {
     font-size: 1rem;
+    font-weight: bold;
     letter-spacing: .1em;
     line-height: 1.71;
     text-transform: uppercase;


### PR DESCRIPTION
Since this has no associated content with it, it makes a little more sense to be just a div rather than a semantic headline. Adjusted CSS to account for the font change due to the markup tweak. 