### PR TITLE
MQA-64 contact accordion implementation refactor

### DIFF
--- a/styleguide/source/_patterns/02-molecules/contact-group.md
+++ b/styleguide/source/_patterns/02-molecules/contact-group.md
@@ -1,0 +1,40 @@
+---
+title: Contact Group
+---
+Description: A list of a specific type of contact information for an entity wrapped in a container, described by a title and optional icon.
+
+## State: ALPHA
+### Notes:
+Multiple contact groups are often aggregated into an array, used by Contact Us molecule.
+
+### Used In:
+[@molecules/contact-us](?p=molecules-contact-us)
+
+### Contains
+
+
+### Variables:
+~~~
+group: { // aggregated in array contactUs.contactGroups
+    icon:
+        type: string (include path to icon twig template) / optional
+    name:
+        type: string ("Phone" || "Online" || "Address" || "Fax") / optional
+    items: [
+      ...,
+        {
+            type: 
+                type: string ("phone" || "online" || "address" || "fax" ) / required,
+            label:
+                type: string / optional
+            value:
+                type: string (html allowed) / required
+            link:
+                type: string / optional
+            details: 
+                type: string / optional
+        },
+      ...
+    ] / required
+}
+~~~

--- a/styleguide/source/_patterns/02-molecules/contact-us.json
+++ b/styleguide/source/_patterns/02-molecules/contact-us.json
@@ -8,7 +8,6 @@
     "groups": [{
       "icon": "@atoms/05-icons/svg-phone.twig",
       "name": "Phone",
-      "hidden": "",
       "items": [{
         "type": "phone",
         "label":"Main:",
@@ -54,7 +53,6 @@
     },{
       "icon": "@atoms/05-icons/svg-fax-icon.twig",
       "name": "Fax",
-      "hidden": "true",
       "items": [{
         "type": "fax",
         "label":"Main:",
@@ -65,7 +63,6 @@
     },{
       "icon": "@atoms/05-icons/svg-marker.twig",
       "name": "Address",
-      "hidden": "true",
       "items": [{
         "type": "address",
         "label": "",

--- a/styleguide/source/_patterns/02-molecules/contact-us.md
+++ b/styleguide/source/_patterns/02-molecules/contact-us.md
@@ -1,34 +1,35 @@
 ---
-Title: Contact Us
+title: Contact Us
 ---
+Description: `<section>` element which contains an `<h4>` title heading (an entity title) and several groups (or types IE phone, fax, email, address) of contact information.
 
-##Fields:
-* Title (optional) - object
-  * href (optional) - string/url
-  * target (optional) -  string "_blank" or ""
-  * text - string
-  * chevron - string/boolean - "false"
-* Hide (optional) - string "Fax", "Address", or "" - States where the accordion should start.  If blank, the accordion isn't shown.
-* Phone (optional) - Object
-  * contains a Contact Group partial
-* Online (optional) - Object
-  * contains a Contact Group partial
-* Fax (optional) - Object
-  * contains a Contact Group partial
-* Address (optional) - Object
-  * Address 1 - string
-  * Address 2 - string
-  * City - string
-  * State - string
-  * zip - number
-  * directions:
-    * href - string/url - google map URL with street address
-    * target (optional) -  string "_blank" or ""
-    * text - string "directions"
-    * chevron - string/boolean - "true"
+## State: ALPHA
 
-##Partials:
-* Contact Group
+### Notes:
+The first two contact groups should always be visible on page load.  Additional contact groups should be hidden within the accordion.
 
-##Notes:
-* first two contact groups should always be visible on page load.  Additional contact groups should be hidden within the accordion.
+### Used In:
+
+### Contains
+[@molecules/contact-group](?p=molecules-contact-group)
+
+### Variables:
+~~~
+contactUs: {
+    title: {
+        href:
+            type: string (url) / optional
+        target:
+            type: string (_blank || "") / optional
+        text:
+            type: string / required
+        chevron:
+            type: string (boolean, "false") / required
+    } / required
+    groups: [
+      ...
+        contactGroup object instances, see @molecules/contact-group
+      ...
+    ] / required
+}
+~~~

--- a/styleguide/source/_patterns/02-molecules/contact-us.twig
+++ b/styleguide/source/_patterns/02-molecules/contact-us.twig
@@ -1,4 +1,3 @@
-{% set accordion = false %}
 <section class="ma__contact-us js-accordion">
   {% if contactUs.title %}
     <h4 class="ma__column-heading">
@@ -11,18 +10,17 @@
     </h4>
   {% endif %}
 
-  {# If more than 2 contact groups, they should load inside of accordion.#}
-  {% for contactGroup in contactUs.groups %}
-    {% if loop.length > 2 %}
-      {% set accordion = true %}
-    {% endif %}
-    {% if loop.index == 3 %}
-      <div class="ma__contact-us__extra js-accordion-content">
-    {% endif %}
+  {# Show first 2 contact groups outside of accordion #}
+  {% for contactGroup in contactUs.groups[:2] %}
     {% include "@molecules/contact-group.twig" %}
   {% endfor %}
 
-  {% if accordion %}
+  {# Show 3rd+ contact groups inside of accordion (if they exist) #}
+  {% if contactUs.groups|length > 2 %}
+    <div class="ma__contact-us__extra js-accordion-content">
+    {% for contactGroup in contactUs.groups[2:last] %}
+      {% include "@molecules/contact-group.twig" %}
+    {% endfor %}
     </div> {# end ma__contact-us__extra #}
     <div class="ma__contact-us__expand">
       <button class="js-accordion-link">

--- a/styleguide/source/_patterns/02-molecules/contact-us.twig
+++ b/styleguide/source/_patterns/02-molecules/contact-us.twig
@@ -11,9 +11,12 @@
     </h4>
   {% endif %}
 
+  {# If more than 2 contact groups, they should load inside of accordion.#}
   {% for contactGroup in contactUs.groups %}
-    {% if contactGroup.hidden and not accordion %}
+    {% if loop.length > 2 %}
       {% set accordion = true %}
+    {% endif %}
+    {% if loop.index == 3 %}
       <div class="ma__contact-us__extra js-accordion-content">
     {% endif %}
     {% include "@molecules/contact-group.twig" %}

--- a/styleguide/source/_patterns/05-pages/ACTION-get-a-state-park-pass.json
+++ b/styleguide/source/_patterns/05-pages/ACTION-get-a-state-park-pass.json
@@ -577,7 +577,6 @@
         "groups": [{
           "icon": "@atoms/05-icons/svg-phone.twig",
           "name": "Phone",
-          "hidden": "",
           "items": [{
             "type": "phone",
             "label":"Main:",
@@ -588,7 +587,6 @@
         },{
           "icon": "@atoms/05-icons/svg-laptop.twig",
           "name": "Online",
-          "hidden": "",
           "items": [{
             "type": "email",
             "label":"Email:",
@@ -599,7 +597,6 @@
         },{
           "icon": "@atoms/05-icons/svg-fax-icon.twig",
           "name": "Fax",
-          "hidden": "true",
           "items": [{
             "type": "fax",
             "label":"",
@@ -610,7 +607,6 @@
         },{
           "icon": "@atoms/05-icons/svg-marker.twig",
           "name": "Address",
-          "hidden": "true",
           "items": [{
             "type": "address",
             "label":"",
@@ -630,7 +626,6 @@
         "groups": [{
           "icon": "@atoms/05-icons/svg-phone.twig",
           "name": "Phone",
-          "hidden": "",
           "items": [{
             "type": "phone",
             "label":"Main:",
@@ -641,7 +636,6 @@
         },{
           "icon": "@atoms/05-icons/svg-laptop.twig",
           "name": "Online",
-          "hidden": "",
           "items": [{
             "type": "email",
             "label":"Email:",
@@ -652,7 +646,6 @@
         },{
           "icon": "@atoms/05-icons/svg-fax-icon.twig",
           "name": "Fax",
-          "hidden": "true",
           "items": [{
             "type": "fax",
             "label":"",
@@ -663,7 +656,6 @@
         },{
           "icon": "@atoms/05-icons/svg-marker.twig",
           "name": "Address",
-          "hidden": "true",
           "items": [{
             "type": "address",
             "label":"",


### PR DESCRIPTION
WIP PR to refactor contact us accordion implementation, making it so that the first two groups of contact information for an entity always appear and any subsequent group is hidden in a drop down accordion.

### Ticket
Address mayflower code aspects of: https://jira.state.ma.us/browse/MQA-64

### Notes
Prior implementation has the contact us molecule pattern looking for a "hidden" attribute passed as a variable to the template and associated with each contact group.  This would imply that there needs to be input from a content author as an implementation detail (see conversation here: https://github.com/massgov/mayflower/pull/189/files#diff-80ce4390df2666783f866d9b5c81ef06R15 )

This PR eliminates the "hidden" attribute, since the need for the accordion can be determined and applied automatically based on the length of the contact groups array.

### Implementation / Integration
There will still need to be some implementation changes in massgov/mass.  I'm happy to continue that work, but would like some insight from @nstriedinger as I believe he has done existing sidebar / contact work (which is why I've asked him to review this PR)

