### PR TITLE
Set Mayflower default pattern to greeting / readme page

### DIFF
--- a/styleguide/config/config.yml
+++ b/styleguide/config/config.yml
@@ -18,7 +18,7 @@ cacheBusterOn: 'true'
 exportDir: export
 publicDir: public
 sourceDir: source
-defaultPattern: all
+defaultPattern: pages-Readme
 defaultShowPatternInfo: true
 lineageMatch: '{%([ ]+)?include( |\()[&quot;\&#039;]([A-Za-z0-9-_]+)[&quot;\&#039;](\))?(.*)%}'
 lineageMatchKey: 3

--- a/styleguide/source/_patterns/05-pages/Readme.json
+++ b/styleguide/source/_patterns/05-pages/Readme.json
@@ -1,4 +1,9 @@
 {
+  "narrowTemplate": {
+    "side": "left",
+    "color": "blue"
+  },
+
   "errorPage": {
     "type": "v2.2.1 (01/09/2016)",
     "title": "Welcome to Mayflower, the Commonwealth's Design System",

--- a/styleguide/source/_patterns/05-pages/Readme.json
+++ b/styleguide/source/_patterns/05-pages/Readme.json
@@ -1,7 +1,7 @@
 {
   "narrowTemplate": {
     "side": "left",
-    "color": "blue"
+    "color": "green"
   },
 
   "errorPage": {

--- a/styleguide/source/_patterns/05-pages/Readme.json
+++ b/styleguide/source/_patterns/05-pages/Readme.json
@@ -1,0 +1,7 @@
+{
+  "errorPage": {
+    "type": "v2.2.1 (01/09/2016)",
+    "title": "Welcome to Mayflower, the Commonwealth's Design System",
+    "message": "Use the navigation menu above to browse our patterns."
+  }
+}

--- a/styleguide/source/_patterns/05-pages/Readme.twig
+++ b/styleguide/source/_patterns/05-pages/Readme.twig
@@ -1,0 +1,5 @@
+{% extends '@templates/narrow-template.twig' %}
+
+{% block narrowContent %}
+  {% include "@organisms/by-template/error-page.twig" %}
+{% endblock %}


### PR DESCRIPTION
This PR creates a (sparse) homepage or Mayflower, which currently displays the version, date, and a greeting.

This page should be more of a readme than a greeting, but this is a start. (Please feel free to add more information, suggest better patterns, plan for the future, etc.)

Would love to add to the deploy process a step where the version gets bumped and the contents of this page are updated.

### Screenshot of current page content
![image](https://cloud.githubusercontent.com/assets/3279883/21848201/b5032cf6-d7cd-11e6-81c7-181e04270931.png)
