### PR TITLE
Align back button & chevron-icon w/ menu button & icon

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_header.scss
+++ b/styleguide/source/assets/scss/03-organisms/_header.scss
@@ -163,7 +163,7 @@ body {
     margin-left: 20px;
     padding-left: 20px;
     position: fixed;
-      top: 5px;
+      top: 3px;
       left: 100%; // hides the outline
     text-transform: uppercase;
     transition: left .5s, visibility .5s;
@@ -176,7 +176,7 @@ body {
       content: "";
       display: inline-block;
       height: .65em;
-      margin-top: 4px;
+      margin-top: 3px;
       margin-left: 3px;
       position: absolute;
         left: 0;


### PR DESCRIPTION
Back button was 2px lower than menu before
![menu_button_alignment](https://cloud.githubusercontent.com/assets/1397914/21907958/d3698b3c-d8df-11e6-9a1c-c70c048c497a.gif)
