### PR TITLE
DP 1347 rmv wait time component update

### DIFF
--- a/styleguide/source/_patterns/02-molecules/wait-time.json
+++ b/styleguide/source/_patterns/02-molecules/wait-time.json
@@ -2,12 +2,10 @@
   "waitTime": {
     "items":[{
       "label": "Licensing",
-      "time": "2:00",
-      "units": "hrs"
+      "time": "2 hours, 15 minutes"
     },{
       "label": "Registration",
-      "time": "24",
-      "units": "mins"
     }]
+      "time": "24 minutes, 11 seconds"
   }
 }

--- a/styleguide/source/_patterns/02-molecules/wait-time.json
+++ b/styleguide/source/_patterns/02-molecules/wait-time.json
@@ -5,7 +5,8 @@
       "time": "2 hours, 15 minutes"
     },{
       "label": "Registration",
-    }]
       "time": "24 minutes, 11 seconds"
+    }],
+    "refreshed": "4:48pm"
   }
 }

--- a/styleguide/source/_patterns/02-molecules/wait-time.twig
+++ b/styleguide/source/_patterns/02-molecules/wait-time.twig
@@ -6,9 +6,11 @@
   <ul class="ma__wait-time__items">
     {% for item in waitTime.items %}
       <li class="ma__wait-time__item">
-        <div class="ma__wait-time__label">{{item.label}}</div>
+        <div class="ma__wait-time__label">{{item.label}}:</div>
         <div class="ma__wait-time__value">
-          <span class="ma__wait-time__time">{{item.time}}</span>&nbsp;<span class="ma__wait-time__units">{{item.units}}</span>
+          <span class="ma__wait-time__time">
+            {{ item.time }}
+          </span>
         </div>
       </li>
     {% endfor %}

--- a/styleguide/source/_patterns/02-molecules/wait-time.twig
+++ b/styleguide/source/_patterns/02-molecules/wait-time.twig
@@ -15,5 +15,5 @@
       </li>
     {% endfor %}
   </ul>
-  <span class="ma__wait-time__refreshed">Wait time refreshed at {{ waitTime.refreshed }}</span>
+  <span class="ma__wait-time__refreshed">Updated at {{ waitTime.refreshed }}</span>
 </section>

--- a/styleguide/source/_patterns/02-molecules/wait-time.twig
+++ b/styleguide/source/_patterns/02-molecules/wait-time.twig
@@ -15,4 +15,5 @@
       </li>
     {% endfor %}
   </ul>
+  <span class="ma__wait-time__refreshed">Wait time refreshed at {{ waitTime.refreshed }}</span>
 </section>

--- a/styleguide/source/_patterns/05-pages/LOC-Southbridge-RMV.json
+++ b/styleguide/source/_patterns/05-pages/LOC-Southbridge-RMV.json
@@ -54,13 +54,12 @@
         "waitTime": {
           "items":[{
             "label": "Licensing",
-            "time": "2:00",
-            "units": "hrs"
+            "time": "1 hour, 15 minutes"
           },{
             "label": "Registration",
-            "time": "24",
-            "units": "mins"
-          }]
+            "time": "24 minutes"
+          }],
+          "refreshed": "4:48 PM"
         }
       }
     }]

--- a/styleguide/source/assets/scss/02-molecules/_wait-time.scss
+++ b/styleguide/source/assets/scss/02-molecules/_wait-time.scss
@@ -58,11 +58,10 @@
     text-transform: uppercase;
   }
 
-  &__time {
+  &__time
+  {
     font-size: 2.125rem;
   }
 
-  &__units {
-    font-size: 1.5rem;
   }
 }

--- a/styleguide/source/assets/scss/02-molecules/_wait-time.scss
+++ b/styleguide/source/assets/scss/02-molecules/_wait-time.scss
@@ -33,17 +33,7 @@
 
   &__items {
     @include ma-reset-list;
-    display: flex;
-      flex-wrap: wrap;
-      align-items: stretch;
     margin-bottom: 1rem;
-  }
-
-  &__item {
-    flex-basis: auto;
-    flex-grow: 0;
-    flex-shrink: 0;
-    width: 100%;
   }
 
   &__item ~ &__item {
@@ -58,14 +48,11 @@
     text-transform: uppercase;
   }
 
-  &__time
-  {
+  &__time {
     font-size: 2.125rem;
   }
 
-  &__refreshed
-  {
+  &__refreshed {
     font-size: 1.125rem;
-    font-style: italic;
   }
 }

--- a/styleguide/source/assets/scss/02-molecules/_wait-time.scss
+++ b/styleguide/source/assets/scss/02-molecules/_wait-time.scss
@@ -36,23 +36,18 @@
     display: flex;
       flex-wrap: wrap;
       align-items: stretch;
+    margin-bottom: 1rem;
   }
 
   &__item {
     flex-basis: auto;
     flex-grow: 0;
     flex-shrink: 0;
-    margin-bottom: 20px;
-    width: 50%;
+    width: 100%;
+  }
 
-    &:nth-child(even) {
-      border-left: 1px solid;
-      padding-left: 38px;
-    }
-
-    &:nth-child(odd) {
-      padding-right: 38px;
-    }
+  &__item ~ &__item {
+    margin-top: 20px;
   }
 
   &__label {

--- a/styleguide/source/assets/scss/02-molecules/_wait-time.scss
+++ b/styleguide/source/assets/scss/02-molecules/_wait-time.scss
@@ -63,5 +63,9 @@
     font-size: 2.125rem;
   }
 
+  &__refreshed
+  {
+    font-size: 1.125rem;
+    font-style: italic;
   }
 }

--- a/styleguide/source/assets/scss/06-theme/02-molecules/_wait-time.scss
+++ b/styleguide/source/assets/scss/06-theme/02-molecules/_wait-time.scss
@@ -25,4 +25,8 @@
     color: $c-font-dark;
     font-weight: 900;
   }
+
+  &__refreshed {
+    font-style: italic;
+  }
 }

--- a/styleguide/source/assets/scss/06-theme/02-molecules/_wait-time.scss
+++ b/styleguide/source/assets/scss/06-theme/02-molecules/_wait-time.scss
@@ -25,9 +25,4 @@
     color: $c-font-dark;
     font-weight: 900;
   }
-
-  &__units {
-    color: $c-font-dark;
-    font-weight: 500;
-  }
 }


### PR DESCRIPTION
This PR alters the markup, presentation, and variable structure for the wait time component, based on the screenshot from visual design work done in [DP-822](https://jira.state.ma.us/browse/DP-822).

User Story: https://jira.state.ma.us/browse/DP-1347

Looking Design and Front End UAT.

## To Test

Either use screenshots below or:

1. Pull down branch and build styleguide
2. See molecule isolated at: /?p=molecules-wait-time
3. See component on rmv location page at: /?p=pages-LOC-Southbridge-RMV

## Screenshots

### From DP-822
![1-17_velir_mass_gov_waittimecomponent_psd___100___icon_copy_2__rgb_8__](https://cloud.githubusercontent.com/assets/3279883/22081541/f8f562e8-dd91-11e6-80c1-e68e61d18a5d.png)


### From work done (on org page)

#### Small
![image](https://cloud.githubusercontent.com/assets/3279883/22081662/6cdf00a6-dd92-11e6-91cd-7e38834a99b3.png)

#### Full
![image](https://cloud.githubusercontent.com/assets/3279883/22081686/86fc1604-dd92-11e6-9515-d78379ca7b1b.png)


### From work done (No wait time)
![image](https://cloud.githubusercontent.com/assets/3279883/22081750/d4b605d0-dd92-11e6-96e2-3770251d6005.png)


### From work done (closed)
![image](https://cloud.githubusercontent.com/assets/3279883/22081715/a186d0e0-dd92-11e6-884a-c78e01291c6a.png)


### From work Done (with error state)
![image](https://cloud.githubusercontent.com/assets/3279883/22081779/f92766fc-dd92-11e6-9838-b90d425ddd98.png)


