### PR TITLE
DP-1278 - RTE external links - correcting alignment

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_rich-text.scss
+++ b/styleguide/source/assets/scss/03-organisms/_rich-text.scss
@@ -109,6 +109,7 @@ $rich-text-spacing-mobile: 1.5rem;
 
 // end list styles
 
+// link styles
   a {
     @include ma-link-underline;
     border-bottom-width: 1px;
@@ -120,10 +121,12 @@ $rich-text-spacing-mobile: 1.5rem;
 
   .ma__decorative-link {
     display: inline;
+    vertical-align: baseline;
   }
 
+// end link styles
 
-  // TABLE styles
+// TABLE styles
   table {
     border-collapse: collapse;
     margin-bottom: $rich-text-spacing-mobile;


### PR DESCRIPTION
Alignment of links in the Rich Text was incorrect after JS converted them to decorative links (external links).

https://jira.state.ma.us/browse/DP-1278