### PR TITLE
Fixes DP-1312-act-paragraphs

### DIFF
--- a/styleguide/source/_patterns/02-molecules/action-activities.md
+++ b/styleguide/source/_patterns/02-molecules/action-activities.md
@@ -21,9 +21,15 @@ actionActivities: [{
     type: string/required
   description:
     type: string/required
+}]
+~~~
+
+### Required Variables
+~~~
+actionActivities: [{
   linkTitle:
-    type: string/required
+    type: string/optional
   href:
-    type: string/url/required
+    type: string/url/optional
 }]
 ~~~

--- a/styleguide/source/_patterns/02-molecules/action-activities.twig
+++ b/styleguide/source/_patterns/02-molecules/action-activities.twig
@@ -5,7 +5,9 @@
       <div class="ma__action-activities__details">
         <h5 class="ma__action-activities__title">{{ activity.title }}</h5>
         <div class="ma__action-activities__description">{{ activity.description }}</div>
-        <a class="ma__action-activities__link" href="{{ activity.href }}">{{ activity.linkTitle }}<span class="visually-hidden"> about {{ activity.title }}</span></a>
+        {% if activity.href %}
+          <a class="ma__action-activities__link" href="{{ activity.href }}">{{ activity.linkTitle }}<span class="visually-hidden"> about {{ activity.title }}</span></a>
+        {% endif %}
       </div>
     </div>
   {% endfor %}


### PR DESCRIPTION
In drupal, the link is not required but in the twig it was always show.  If an author didn't add a link the icon would show.  We add conditional logic to determine if the link has been populated, if so, display it.

To test:
 - go here `http://mass.local/bash-bish-falls-state-park`, confirm the the link icon isn't displayed (`>`)
- edit the page and add a link, confirm they are displayed correctly

Screenshots
![screen shot 2017-01-19 at 3 16 07 pm](https://cloud.githubusercontent.com/assets/3721535/22124231/ef5d0ac6-de5c-11e6-868f-65cec8159117.png)
![screen shot 2017-01-19 at 3 18 03 pm](https://cloud.githubusercontent.com/assets/3721535/22124230/ef5cf612-de5c-11e6-92fc-85702f82df57.png)
