### PR TITLE
Fixes DP-1521 Make callout links card a link

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -2,7 +2,7 @@
 
 ## 3.2.0 (Sprint 11)
 
-### DS-5 
+### DS-5
 * DP-1103 - Implement default file/download icon in Patternlab
 * DP-691 - Implement Google Translate in Pattern Lab
 
@@ -12,10 +12,11 @@
 ### DS-41
 * DP-787 - Create Park Icons for Park Types, Activities, Users
 
-### Bugs 
+### Bugs
 * DP-1278 - [Action] Link & text alignment issue in action steps
 * DP-1312 - Activities Paragraph shows link icon when there is no link
 * DP-1279 - Spacing issue between numbered steps & rich text field
+* DP-1521 - External links under jclickable containers were not firing the interstitial js
 
 ## 3.1.0 (Sprint 10)
 ### Org Page
@@ -144,8 +145,8 @@
 ### Action Detail page modifications
 * MGVDU-120 - FE Dev: Modifications to Action page: Image / diagram
 * MGVDU-118 - FE Dev: Modifications to Action page: Sequential Lists
-* MGVDU-119 - FE Dev: Modifications to Action page: Map 
-* MGVDU-137 - FE Dev: Modifications to Action page: OR Lists 
+* MGVDU-119 - FE Dev: Modifications to Action page: Map
+* MGVDU-137 - FE Dev: Modifications to Action page: OR Lists
 * MGVDU-139 - FE Dev: Action Page Header
 
 ### Location Page

--- a/styleguide/source/_patterns/02-molecules/callout-link.json
+++ b/styleguide/source/_patterns/02-molecules/callout-link.json
@@ -2,6 +2,7 @@
   "calloutLink": {
     "text": "Order a MassParks Pass online through Reserve America",
     "type": "",
-    "href": "#"
+    "href": "#",
+    "info": ""
   }
 }

--- a/styleguide/source/_patterns/02-molecules/callout-link.md
+++ b/styleguide/source/_patterns/02-molecules/callout-link.md
@@ -2,19 +2,24 @@
 title: Callout link
 ---
 Description: An decorative link `<a>` element which wraps a styled container.
+
 ## Status: BETA
+
 ### Used in:
 - [@organisms/by-author/action-finder](/?p=organisms-action-finder)
 - [@organisms/by-author/key-actions](/?p=organisms-key-actions)
 - [@organisms/by-author/top-actions](/?p=organisms-top-actions)
+
 ### Required Variables
 ~~~
 calloutLink: {
   href:
-    string
+    type: string/required
   text:
-    string
+    type: string/required
   type:
-    NULL or "External"
+    type: string/optional ("external")
+  info:
+    type: string/optional
 }
 ~~~

--- a/styleguide/source/_patterns/02-molecules/callout-link.md
+++ b/styleguide/source/_patterns/02-molecules/callout-link.md
@@ -1,7 +1,7 @@
 ---
 title: Callout link
 ---
-Description: A decorative link `<a>` element which is wrapped in a styled container.
+Description: An decorative link `<a>` element which wraps a styled container.
 ## Status: BETA
 ### Used in:
 - [@organisms/by-author/action-finder](/?p=organisms-action-finder)

--- a/styleguide/source/_patterns/02-molecules/callout-link.twig
+++ b/styleguide/source/_patterns/02-molecules/callout-link.twig
@@ -1,14 +1,13 @@
-{% set decorativeLink = calloutLink %}
-{% if decorativeLink.type == "external" %}
+{% if calloutLink.type == "external" %}
   {% set atom_svg_path = "@atoms/05-icons/svg-external-link.twig" %}
 {% else %}
   {% set atom_svg_path = "@atoms/05-icons/svg-arrow.twig" %}
 {% endif %}
 
-<a href="{{decorativeLink.href}}">
-  <div class="ma__callout-link">
-    <span class="ma__decorative-link">
-      {{decorativeLink.text}}{% if decorativeLink.info %}<span class="ma__decorative-link__info">{{ decorativeLink.info }}</span>{% endif %}&nbsp;{% include(atom_svg_path) %}
+<a class="ma__callout-link" href="{{ calloutLink.href }}">
+  <span class="ma__callout-link__container">
+    <span class="ma__callout-link__text">
+      {{ calloutLink.text }}{% if calloutLink.info %}<span class="ma__callout-link__info">{{ calloutLink.info }}</span>{% endif %}&nbsp;{% include(atom_svg_path) %}
     </span>
-  </div>
+  </span>
 </a>

--- a/styleguide/source/_patterns/02-molecules/callout-link.twig
+++ b/styleguide/source/_patterns/02-molecules/callout-link.twig
@@ -1,4 +1,14 @@
-<div class="ma__callout-link js-clickable">
-  {% set decorativeLink = calloutLink %}
-  {% include "@atoms/decorative-link.twig" %}
-</div>
+{% set decorativeLink = calloutLink %}
+{% if decorativeLink.type == "external" %}
+  {% set atom_svg_path = "@atoms/05-icons/svg-external-link.twig" %}
+{% else %}
+  {% set atom_svg_path = "@atoms/05-icons/svg-arrow.twig" %}
+{% endif %}
+
+<a href="{{decorativeLink.href}}">
+  <div class="ma__callout-link">
+    <span class="ma__decorative-link">
+      {{decorativeLink.text}}{% if decorativeLink.info %}<span class="ma__decorative-link__info">{{ decorativeLink.info }}</span>{% endif %}&nbsp;{% include(atom_svg_path) %}
+    </span>
+  </div>
+</a>

--- a/styleguide/source/assets/scss/02-molecules/_callout-link.scss
+++ b/styleguide/source/assets/scss/02-molecules/_callout-link.scss
@@ -22,4 +22,28 @@
     font-size: 1.625rem;
     line-height: 1.3;
   }
+
+  &__container {
+    display: inline-block;
+    padding-right: 18px;
+    vertical-align: middle;
+  }
+
+  &__info {
+    @include ma-visually-hidden;
+  }
+
+  &__text {
+    @include ma-link-underline;
+    font-size: 1.625rem;
+    display: inline;
+    line-height: 1.3;
+
+    svg {
+      display: inline-block;
+      height: .6em;
+      margin-right: -18px;
+      width: .6em;
+    }
+  }
 }

--- a/styleguide/source/assets/scss/03-organisms/_action-finder.scss
+++ b/styleguide/source/assets/scss/03-organisms/_action-finder.scss
@@ -56,7 +56,6 @@ $action-finder-bp: 900px;
 
   &__items {
     @include ma-reset-list;
-    cursor: pointer;
     display: flex;
       flex-wrap: wrap;
   }

--- a/styleguide/source/assets/scss/06-theme/02-molecules/_callout-link.scss
+++ b/styleguide/source/assets/scss/06-theme/02-molecules/_callout-link.scss
@@ -2,4 +2,14 @@
   background-color: tint($c-font-link,90%);
   border-color: tint($c-font-link,50%);
   box-shadow: 0 0.25rem 0.5rem rgba(#000, 0.25);
+
+  &:hover &__text {
+    border-bottom-color: rgba($c-font-link,.5);
+  }
+
+  &__text {
+    svg {
+      fill: rgba($c-font-link,.5);
+    }
+  }
 }

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_action-finder.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_action-finder.scss
@@ -28,10 +28,6 @@ $action-finder-border-color: tint($c-theme-blue,50%);
     }
   }
 
-  &__item:hover a {
-    border-color: rgba($c-font-link, .5);
-  }
-
   &__items--all {
     
     .ma__callout-link {


### PR DESCRIPTION
Issue:  Jsclickable js will always fire while interstitial js will not. This is only for links nested under jsclickable parents.  In html5, we can have block links - meaning divs, h1, p can
be children of the 'a' element. This removes the need for JS and will unblock this clash of JS for this element.

jira ticket: https://jira.state.ma.us/browse/DP-1521

Notes: html 5 resource, https://davidwalsh.name/html5-elements-links