### PR TITLE
DP-1367 Bring keyboard focus back to top on "Top" button click

### DIFF
--- a/styleguide/source/assets/js/modules/back2top.js
+++ b/styleguide/source/assets/js/modules/back2top.js
@@ -14,6 +14,8 @@ export default function (window,document,$,undefined) {
       catch(e) {
         $('body').scrollTop(0);
       }
+      // Bring keyboard focus back to top as well.
+      $("#main-content").focus();
       return false;
     });
 


### PR DESCRIPTION
This PR brings keyboard focus back to #main-content when the Top button is clicked.

Fixes: https://jira.state.ma.us/browse/DP-1367

To Test: 
1. pull down branch
2. move into styleguide directory: `cd styleguide`
3. build pattern lab: `gulp`
4. OPTIONAL: turn on screen reader (make sure your volume is not muted)
  - macos: https://www.apple.com/voiceover/info/guide/_1131.html
  - windows: (if you don't have a jaws license), try chrome vox: https://chrome.google.com/webstore/detail/chromevox/kgejglhpjiefppelpmljglcjbhoiplfn?hl=en
5. browse to /?p=pages-GUIDE-movng-to-ma-part1
6. tab or scroll down the page until the "Top" button appears in the lower right hand button
7. click the "Top" button
8. OPTIONAL: confirm the screen reader announces "Main" as the item that has focus
9. press `TAB` and confirm that focus then moves to the first link in the page content area: IN THIS GUIDE > Buying or Renting a Home