### PR TITLE
DP-1555 subnav keyboard focus

### DIFF
--- a/styleguide/source/_patterns/01-atoms/04-headings/comp-heading.twig
+++ b/styleguide/source/_patterns/01-atoms/04-headings/comp-heading.twig
@@ -7,7 +7,7 @@
 {% endif %}
 
 {% if compHeading.sub %}
-  <h3 class="ma__comp-heading {{ colored }} {{ centered }}" {% if compHeading.id %}id="{{compHeading.id}}"{% endif %}>
+  <h3 class="ma__comp-heading {{ colored }} {{ centered }}" {% if compHeading.id %}id="{{compHeading.id}}"{% endif %} tabindex="-1">
     {{ compHeading.title }}
   </h3>
 {% else %}

--- a/styleguide/source/assets/js/modules/scrollAnchors.js
+++ b/styleguide/source/assets/js/modules/scrollAnchors.js
@@ -27,6 +27,8 @@ export default function (window,document,$,undefined) {
 
     $el.find('a').on('click',function(e) {
       e.preventDefault();
+      // Get the link hash target so we can bring focus to it
+      let hash = this.hash;
 
       // is the menu closed on mobile
       if(!$el.hasClass('is-open') && isMobile) {     
@@ -49,6 +51,8 @@ export default function (window,document,$,undefined) {
 
       $("html,body").stop(true,true).animate({scrollTop:position}, '750', function(){
         linkScrolling = false;
+        // bring focus to the item we just scrolled to
+        $(hash).focus();
       });
       
     });


### PR DESCRIPTION
This PR adds functionality to move focus to the subnav link target once that subnav link is clicked.

Ticket: https://jira.state.ma.us/browse/DP-1555

## To Test:
1. Pull branch down
2. move into styleguide cd styleguide
3. build mayflower gulp
4. browse to action page: http://localhost:3000/?p=pages-ACTION-get-a-state-park-pass
5. Scroll down into the "Details" section
6. Click "Forms"
7. Verify that you are still scrolled down to the forms section (we didn't touch this functionality so it should still work!)
8. Verify that the "Forms" sub heading now has focus (see screenshot below for what this focus looks like on my browser)
9. Verify that when you press `TAB` key you are brought to the first form link

## Screenshot

### Forms Sub Heading has Focus
![image](https://cloud.githubusercontent.com/assets/3279883/22652578/f69c4bc0-ec54-11e6-8e39-036789467ec2.png)


## Resources:
Keyboard navigable js widgets: https://developer.mozilla.org/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets
