### PR TITLE
Dp 1374 convey menu state to screen reader

### DIFF
--- a/styleguide/source/_patterns/02-molecules/main-nav.twig
+++ b/styleguide/source/_patterns/02-molecules/main-nav.twig
@@ -1,8 +1,8 @@
 <section class="ma__main-nav">
   <ul class="ma__main-nav__items js-main-nav">
     {% for nav in mainNav %}
-      {% set buttonId =  nav.text|lower ~ '-button-' ~ loop.index %}
-      {% set menuId =  nav.text|lower ~ '-' ~ loop.index %}
+      {% set buttonId =  'button' ~ loop.index %}
+      {% set menuId =  'menu' ~ loop.index %}
       <li class="ma__main-nav__item {{ nav.active ? 'is-active' : '' }} {{ nav.subNav ? 'has-subnav js-main-nav-toggle' : 'js-main-nav-top-link' }}">
         {% if nav.subNav %}
           <button id="{{ buttonId }}" class="ma__main-nav__top-link" aria-haspopup="true" aria-expanded="false" aria-controls="{{ menuId }}">{{ nav.text }}</button>

--- a/styleguide/source/_patterns/02-molecules/main-nav.twig
+++ b/styleguide/source/_patterns/02-molecules/main-nav.twig
@@ -1,16 +1,18 @@
 <section class="ma__main-nav">
   <ul class="ma__main-nav__items js-main-nav">
     {% for nav in mainNav %}
+      {% set buttonId =  nav.text|lower ~ '-button-' ~ loop.index %}
+      {% set menuId =  nav.text|lower ~ '-' ~ loop.index %}
       <li class="ma__main-nav__item {{ nav.active ? 'is-active' : '' }} {{ nav.subNav ? 'has-subnav js-main-nav-toggle' : 'js-main-nav-top-link' }}">
-        <button class="ma__main-nav__top-link">{{ nav.text }}</button>
         {% if nav.subNav %}
+          <button id="{{ buttonId }}" class="ma__main-nav__top-link" aria-haspopup="true" aria-expanded="false" aria-controls="{{ menuId }}">{{ nav.text }}</button>
           <div class="ma__main-nav__subitems js-main-nav-content is-closed">
-            <ul class="ma__main-nav__container">
-              <li class="ma__main-nav__subitem"><a href="{{ nav.href }}" class="ma__main-nav__link">{{ nav.text }}</a></li>
+            <ul id="{{ menuId }}" role="menu" aria-labelledby="{{ buttonId }}" class="ma__main-nav__container">
+              <li role="menuitem" class="ma__main-nav__subitem"><a href="{{ nav.href }}" class="ma__main-nav__link">{{ nav.text }}</a></li>
               {% for subNav in nav.subNav %}
-                <li class="ma__main-nav__subitem"><a href="{{ subNav.href }}" class="ma__main-nav__link">{{ subNav.text }}</a></li>
+                <li role="menuitem" class="ma__main-nav__subitem"><a href="{{ subNav.href }}" class="ma__main-nav__link">{{ subNav.text }}</a></li>
               {% endfor %}
-              <li class="ma__main-nav__subitem">
+              <li role="menuitem" class="ma__main-nav__subitem">
                 <a href="{{ nav.href }}" class="ma__main-nav__link">
                   {% include "@atoms/05-icons/svg-arrow-bent.twig" %}
                   <span>{{ nav.text }}</span>
@@ -18,6 +20,8 @@
               </li>
             </ul>
           </div>
+        {% else %}
+          <button id="{{ buttonId }}" class="ma__main-nav__top-link">{{ nav.text }}</button>
         {% endif %}
       </li>
     {% endfor %}

--- a/styleguide/source/assets/js/modules/mainNav.js
+++ b/styleguide/source/assets/js/modules/mainNav.js
@@ -34,7 +34,6 @@ export default function (window,document,$,undefined) {
           $dropdownLinks = $link.find('.ma__main-nav__subitem .ma__main-nav__link'),
           focusIndexInDropdown = $dropdownLinks.index($focusedElement),
           isShift = !!e.shiftKey; // typecast to boolean
-          console.log(isShift);
 
       // down arrow or tab key
       if((e.keyCode === 40) || (e.keyCode === 9 && !isShift)) {

--- a/styleguide/source/assets/js/modules/mainNav.js
+++ b/styleguide/source/assets/js/modules/mainNav.js
@@ -57,6 +57,7 @@ export default function (window,document,$,undefined) {
           }
         } else {
           show($topLevelItem.find('.js-main-nav-content'));
+          $topLevelLink.attr('aria-expanded', 'true');
           $link.addClass(openClass);
           if($dropdownLinks[1]) {
             $dropdownLinks[1].focus();
@@ -65,7 +66,8 @@ export default function (window,document,$,undefined) {
         }
       }
 
-       if(e.keyCode === 38) {  // up arrow
+       // up arrow
+       if(e.keyCode === 38) {
         // hide content
         // If menubar focus
         //  - Open pull down menu and select first menu item
@@ -76,7 +78,7 @@ export default function (window,document,$,undefined) {
         if(open) {
           if(focusIndexInDropdown <= 1 ) { // not 0 bc of hidden first link
             hide($openContent);
-            $topLevelLink.focus();
+            $topLevelLink.focus().attr('aria-expanded', 'false');
             return;
           } else {
             $dropdownLinks[focusIndexInDropdown-1].focus();
@@ -84,6 +86,7 @@ export default function (window,document,$,undefined) {
           }
         } else {
           show($topLevelItem.find('.js-main-nav-content'));
+          $topLevelLink.focus().attr('aria-expanded', 'true');
           $link.addClass(openClass);
           return;
         }
@@ -95,7 +98,7 @@ export default function (window,document,$,undefined) {
         e.preventDefault();
         hide($openContent);
         $link.removeClass(openClass);
-        $topLevelLink.focus();
+        $topLevelLink.focus().attr('aria-expanded','false');
         return;
       }
 
@@ -109,6 +112,7 @@ export default function (window,document,$,undefined) {
         // If dropdown focus
         //  - Open previous pull down menu and select first item
         hide($openContent);
+        $topLevelLink.attr('aria-expanded','false');
         let index = $topLevelLinks.index($topLevelLink)-1;
         if($topLevelLinks[index]) {
           $topLevelLinks[index].focus();
@@ -126,6 +130,7 @@ export default function (window,document,$,undefined) {
         // If dropdown focus
         //  - Open next pull menu and select first item
         hide($openContent);
+        $topLevelLink.attr('aria-expanded','false');
         let index = $topLevelLinks.index($topLevelLink)+1;
         if($topLevelLinks[index]) {
           $topLevelLinks[index].focus();

--- a/styleguide/source/assets/js/modules/mainNav.js
+++ b/styleguide/source/assets/js/modules/mainNav.js
@@ -36,7 +36,7 @@ export default function (window,document,$,undefined) {
           isShift = !!e.shiftKey; // typecast to boolean
           console.log(isShift);
 
-      // down arrow key
+      // down arrow or tab key
       if((e.keyCode === 40) || (e.keyCode === 9 && !isShift)) {
         // hide content
         // If menubar focus
@@ -67,7 +67,7 @@ export default function (window,document,$,undefined) {
         }
       }
 
-       // up arrow
+       // up arrow or shift+tab keys
        if((e.keyCode === 38) || (e.keyCode === 9 && isShift)) {
         // hide content
         // If menubar focus

--- a/styleguide/source/assets/js/modules/mainNav.js
+++ b/styleguide/source/assets/js/modules/mainNav.js
@@ -144,12 +144,6 @@ export default function (window,document,$,undefined) {
         return;
       }
 
-      // hide content
-      // hide($openContent);
-      // add open class to this item
-      // $(this).addClass(openClass);
-      // add open class to the correct content based on index
-      // show($link.find('.js-main-nav-content'));
     });
     $mainNavItems.on('mouseenter', function(e) {
       $(this).children('button').attr("aria-expanded","true");

--- a/styleguide/source/assets/js/modules/mainNav.js
+++ b/styleguide/source/assets/js/modules/mainNav.js
@@ -146,12 +146,16 @@ export default function (window,document,$,undefined) {
       show($link.find('.js-main-nav-content'));
     });
     $mainNavItems.on('mouseenter', function(e) {
+      $(this).children('button').attr("aria-expanded","true");
+
       if(windowWidth > breakpoint) {
         let $openContent = $(this).find('.js-main-nav-content');
         show($openContent);
       }
     });
     $mainNavItems.on('mouseleave', function(e) {
+      $(this).children('button').attr("aria-expanded","false");
+
       if(windowWidth > breakpoint) {
         let $openContent = $(this).find('.js-main-nav-content');
         hide($openContent);
@@ -170,11 +174,14 @@ export default function (window,document,$,undefined) {
         // add open class to this item
         $elParent.addClass(openClass);
         show($content);
+        $el.attr('aria-expanded', 'true');
       } else {
         hide($openContent);
+        $el.attr('aria-expanded', 'false');
 
         if(!isOpen) {
           show($content);
+          $el.attr('aria-expanded', 'true');
         }
       }
     });
@@ -201,7 +208,6 @@ export default function (window,document,$,undefined) {
       let $openContent = $parent.find('.js-main-nav-content.' + openClass);
       hide($openContent);
     });
-
 
     function hide($content) {
       $('body').removeClass(submenuClass);

--- a/styleguide/source/assets/js/modules/mainNav.js
+++ b/styleguide/source/assets/js/modules/mainNav.js
@@ -32,11 +32,12 @@ export default function (window,document,$,undefined) {
           $topLevelItem = $focusedElement.parents('.ma__main-nav__item'),
           $topLevelLink = $topLevelItem.find('.ma__main-nav__top-link'),
           $dropdownLinks = $link.find('.ma__main-nav__subitem .ma__main-nav__link'),
-          focusIndexInDropdown = $dropdownLinks.index($focusedElement);
-
+          focusIndexInDropdown = $dropdownLinks.index($focusedElement),
+          isShift = !!e.shiftKey; // typecast to boolean
+          console.log(isShift);
 
       // down arrow key
-      if(e.keyCode === 40) {
+      if((e.keyCode === 40) || (e.keyCode === 9 && !isShift)) {
         // hide content
         // If menubar focus
         //  - Open pull down menu and select first menu item
@@ -67,7 +68,7 @@ export default function (window,document,$,undefined) {
       }
 
        // up arrow
-       if(e.keyCode === 38) {
+       if((e.keyCode === 38) || (e.keyCode === 9 && isShift)) {
         // hide content
         // If menubar focus
         //  - Open pull down menu and select first menu item
@@ -144,11 +145,11 @@ export default function (window,document,$,undefined) {
       }
 
       // hide content
-      hide($openContent);
+      // hide($openContent);
       // add open class to this item
-      $(this).addClass(openClass);
+      // $(this).addClass(openClass);
       // add open class to the correct content based on index
-      show($link.find('.js-main-nav-content'));
+      // show($link.find('.js-main-nav-content'));
     });
     $mainNavItems.on('mouseenter', function(e) {
       $(this).children('button').attr("aria-expanded","true");


### PR DESCRIPTION
## Overview
This PR enables the the main nav to convey menu state to screen readers.

## Testing
- Go to http://localhost:3000/?p=molecules-main-nav
- Enable screen reader
- Click inside the browser window to bring it to focus
- Hit tab
- Screen reader will announce menu items as collapsed (see screenshot).
<img width="714" alt="screen_shot_2017-02-07_at_1_46_00_pm" src="https://cloud.githubusercontent.com/assets/1906849/22706119/138660a8-ed3c-11e6-9327-9f69f72ec13a.png">
