### PR TITLE
Make post-content div background color the same as footer

### DIFF
--- a/styleguide/source/assets/scss/06-theme/04-templates/_layout.scss
+++ b/styleguide/source/assets/scss/06-theme/04-templates/_layout.scss
@@ -13,5 +13,7 @@
   }
 }
 
-
+.post-content{
+  background-color: $c-bg-section;
+}
 


### PR DESCRIPTION
Fixes https://jira.state.ma.us/browse/DP-1434

We currently cannot make the feedback module block first in the post-content div.  The issue was, the feedback form block was on a white background sandwiched between the footer and node specific content which had a grey background.  The solution implemented was, make post-content have the same background color as the footer.  We want this to be part of mayflower so any future theme changes are dynamically updated.

To test, 

- [ ] go to http://mayflower.digital.mass.gov/?p=pages-GUIDE-movng-to-ma-part2
- [ ] inspect related guides
- [ ] remove styling `background-color: #f2f2f2;`
- [ ] confirm the background is still `#f2f2f2;`