### PR TITLE
Dp 1996 google translate

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-template/footer.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/footer.twig
@@ -34,8 +34,8 @@
       var script = document.createElement('script');
       script.src = "//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit";
       script.async = true;
-      element = document.getElementsByTagName('body')[0]; 
-      element.append(script);
+      element = document.getElementsByTagName('head')[0]; 
+      element.appendChild(script);
     })();
   </script>
 {% endif %}

--- a/styleguide/source/assets/scss/03-organisms/_header.scss
+++ b/styleguide/source/assets/scss/03-organisms/_header.scss
@@ -318,15 +318,19 @@ body {
     a {
       @include ma-chevron("left");
       border: 3px solid;
-      border-top: none;
       display: inline-block;
       padding: 6px 7px;
-      position: absolute;
-        top: -$header-mobile-controls-height;
+      position: fixed;
+        top: 0;
       white-space: nowrap;
 
       @media ($bp-x-small-max) {
         left: 0;
+      }
+
+      @media ($bp-header-toggle-min){
+        position: absolute;
+          top: -$header-mobile-controls-height - 4px;
       }
 
       @media ($bp-large-min) {


### PR DESCRIPTION
Fixed typo in footer JavaScript code preventing Google translate from working in IE.

Also fixed bug with the "Back to Classic.." header navigation button overlapping site alerts