### PR TITLE
DP-1995 - Add nl2br filter to contact us address to allow new line instead of <br>

### DIFF
--- a/styleguide/source/_patterns/02-molecules/action-map.json
+++ b/styleguide/source/_patterns/02-molecules/action-map.json
@@ -30,7 +30,7 @@
         "phone": "16176261250",
         "fax": "16176261351",
         "email": "mass.parks@state.ma.us",
-        "address": "251 Causeway Street, Suite 900<br />Boston, MA 02114-2104"
+        "address": "251 Causeway Street, Suite 900\nBoston, MA 02114-2104"
       }
     },{
       "position": {
@@ -43,7 +43,7 @@
         "phone": "16176261250",
         "fax": "",
         "email": "mass.parks@state.ma.us",
-        "address": "24 Beacon St<br />Boston, MA 02133"
+        "address": "24 Beacon St\nBoston, MA 02133"
       }
     }]
   }

--- a/styleguide/source/_patterns/02-molecules/contact-group.twig
+++ b/styleguide/source/_patterns/02-molecules/contact-group.twig
@@ -26,7 +26,7 @@
       {# Address - RTE version of value and look for directions link #}
       {% elseif item.type == "address" %}
         <div class="ma__contact-group__address"{% if item.property %} property="{{item.property}}" typeof="PostalAddress"{% endif %}>
-          {{item.value | raw}}
+          {{item.value | nl2br | raw}}
         </div>
         {% if item.link %}
           <div class="ma__contact-group__directions"{% if item.property %} property="hasMap" typeof="Map"{% endif %}>

--- a/styleguide/source/_patterns/02-molecules/contact-us.json
+++ b/styleguide/source/_patterns/02-molecules/contact-us.json
@@ -78,7 +78,7 @@
         "type": "address",
         "property": "",
         "label": "",
-        "value": "555 Park Drive<br/>Boston, MA 02231",
+        "value": "555 Park Drive\nBoston, MA 02231",
         "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215",
         "details": ""
       }]

--- a/styleguide/source/_patterns/02-molecules/contact-us~linked-title.json
+++ b/styleguide/source/_patterns/02-molecules/contact-us~linked-title.json
@@ -68,7 +68,7 @@
       "items": [{
         "type": "address",
         "label": "",
-        "value": "555 Park Drive<br/>Boston, MA 02231",
+        "value": "555 Park Drive\nBoston, MA 02231",
         "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215",
         "details": ""
       }]

--- a/styleguide/source/_patterns/02-molecules/google-map.json
+++ b/styleguide/source/_patterns/02-molecules/google-map.json
@@ -18,7 +18,7 @@
         "phone": "16176261250",
         "fax": "16176261351",
         "email": "mass.parks@state.ma.us",
-        "address": "251 Causeway Street, Suite 900<br />Boston, MA 02114-2104"
+        "address": "251 Causeway Street, Suite 900\nBoston, MA 02114-2104"
       }
     },{
       "position": {
@@ -31,7 +31,7 @@
         "phone": "16176261250",
         "fax": "",
         "email": "mass.parks@state.ma.us",
-        "address": "24 Beacon St<br />Boston, MA 02133"
+        "address": "24 Beacon St\nBoston, MA 02133"
       }
     }]
   }

--- a/styleguide/source/_patterns/02-molecules/google-map.twig
+++ b/styleguide/source/_patterns/02-molecules/google-map.twig
@@ -22,15 +22,15 @@
             lat: {{marker.position.lat}},
             lng: {{marker.position.lng}} 
           },
-          label: "{{marker.label}}", // single character only
+          label: "{{ marker.label }}", // single character only
           infoWindow: {
-            name: "{{marker.infoWindow.name | raw}}", // raw was needed to prevent rendering ascii characters
-            phone: "{{marker.infoWindow.phone}}",
-            fax: "{{marker.infoWindow.fax}}",
-            email: "{{marker.infoWindow.email}}",
-            address: "{{marker.infoWindow.address | raw}}"
+            name: "{{ marker.infoWindow.name|raw }}", // raw was needed to prevent rendering ascii characters
+            phone: "{{ marker.infoWindow.phone }}",
+            fax: "{{ marker.infoWindow.fax }}",
+            email: "{{ marker.infoWindow.email }}",
+            address: "{{ marker.infoWindow.address|replace({'\n': '<br>'})|raw }}"
           }
-        }{{loop.last ? '' : ','}}
+        }{{ loop.last ? '' : ',' }}
       {% endfor %}
       ]
     });

--- a/styleguide/source/_patterns/03-organisms/by-author/location-banner.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/location-banner.json
@@ -22,7 +22,7 @@
           "phone": "14134994262",
           "fax": "",
           "email": "mass.parks@state.ma.us",
-          "address": "30 Rockwell Road<br />Lanesborough, MA 01237"
+          "address": "30 Rockwell Road\nLanesborough, MA 01237"
         }
       },{
         "position": {
@@ -35,7 +35,7 @@
           "phone": "14137431591",
           "fax": "",
           "email": "mail@bascomlodge.net",
-          "address": "30 Rockwell Road<br />Lanesborough, MA 01237"
+          "address": "30 Rockwell Road\nLanesborough, MA 01237"
         }
       }]
     }

--- a/styleguide/source/_patterns/03-organisms/by-author/location-listing.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/location-listing.json
@@ -39,7 +39,7 @@
           "phone": "16176261250",
           "fax": "16176261351",
           "email": "mass.parks@state.ma.us",
-          "address": "251 Causeway Street, Suite 900<br />Boston, MA 02114-2104"
+          "address": "251 Causeway Street, Suite 900\nBoston, MA 02114-2104"
         }
       },{
         "position": {
@@ -52,7 +52,7 @@
           "phone": "16176261250",
           "fax": "",
           "email": "mass.parks@state.ma.us",
-          "address": "24 Beacon St<br />Boston, MA 02133"
+          "address": "24 Beacon St\nBoston, MA 02133"
         }
       }]
     },

--- a/styleguide/source/_patterns/03-organisms/by-author/mapped-locations.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/mapped-locations.json
@@ -31,7 +31,7 @@
           "phone": "16176261250",
           "fax": "16176261351",
           "email": "mass.parks@state.ma.us",
-          "address": "251 Causeway Street, Suite 900<br />Boston, MA 02114-2104"
+          "address": "251 Causeway Street, Suite 900\nBoston, MA 02114-2104"
         }
       },{
         "position": {
@@ -44,7 +44,7 @@
           "phone": "16176261250",
           "fax": "",
           "email": "mass.parks@state.ma.us",
-          "address": "24 Beacon St<br />Boston, MA 02133"
+          "address": "24 Beacon St\nBoston, MA 02133"
         }
       }]
     }

--- a/styleguide/source/_patterns/03-organisms/by-author/sidebar-contact.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/sidebar-contact.json
@@ -50,7 +50,7 @@
             "type": "address",
             "property": "",
             "label":"",
-            "value": "555 Park Drive<br/>Boston, MA 02231",
+            "value": "555 Park Drive\nBoston, MA 02231",
             "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215",
             "details": ""
           }]
@@ -107,7 +107,7 @@
             "type": "address",
             "property": "",
             "label": "",
-            "value": "555 Park Drive<br/>North Hampton, MA 02231",
+            "value": "555 Park Drive\nNorth Hampton, MA 02231",
             "link": "",
             "details": ""
           }]

--- a/styleguide/source/_patterns/03-organisms/by-author/stacked-row-section.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/stacked-row-section.json
@@ -94,7 +94,7 @@
             "items": [{
               "type": "address",
               "label":"",
-              "value": "555 Park Drive<br/>Boston, MA 02231",
+              "value": "555 Park Drive\nBoston, MA 02231",
               "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215"
             }]
           }]

--- a/styleguide/source/_patterns/05-pages/ACTION-get-a-state-park-pass.json
+++ b/styleguide/source/_patterns/05-pages/ACTION-get-a-state-park-pass.json
@@ -476,7 +476,7 @@
               "phone": "16176261250",
               "fax": "16176261351",
               "email": "mass.parks@state.ma.us",
-              "address": "251 Causeway Street, Suite 900<br />Boston, MA 02114-2104"
+              "address": "251 Causeway Street, Suite 900\nBoston, MA 02114-2104"
             }
           },{
             "position": {
@@ -489,7 +489,7 @@
               "phone": "16176261250",
               "fax": "",
               "email": "mass.parks@state.ma.us",
-              "address": "24 Beacon St<br />Boston, MA 02133"
+              "address": "24 Beacon St\nBoston, MA 02133"
             }
           }]
 
@@ -604,7 +604,7 @@
           "items": [{
             "type": "address",
             "label":"",
-            "value":"251 Causeway Street<br/>Suite 900<br/>Boston, MA 02114-2104",
+            "value":"251 Causeway Street\nSuite 900\nBoston, MA 02114-2104",
             "link": "",
             "details":""
           }]
@@ -653,7 +653,7 @@
           "items": [{
             "type": "address",
             "label":"",
-            "value":"251 Causeway Street<br/>Suite 900<br/>Boston, MA 02114-2104",
+            "value":"251 Causeway Street\nSuite 900\nBoston, MA 02114-2104",
             "link": "",
             "details":""
           }]

--- a/styleguide/source/_patterns/05-pages/GUIDE-movng-to-ma-part1.json
+++ b/styleguide/source/_patterns/05-pages/GUIDE-movng-to-ma-part1.json
@@ -175,7 +175,7 @@
             "items": [{
               "type": "address",
               "label": "",
-              "value": "555 Park Drive<br/>Boston, MA 02231",
+              "value": "555 Park Drive\nBoston, MA 02231",
               "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215",
               "details": ""
             }]
@@ -263,7 +263,7 @@
             "items": [{
               "type": "address",
               "label": "",
-              "value": "555 Park Drive<br/>Boston, MA 02231",
+              "value": "555 Park Drive\nBoston, MA 02231",
               "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215",
               "details": ""
             }]
@@ -435,7 +435,7 @@
             "items": [{
               "type": "address",
               "label": "",
-              "value": "555 Park Drive<br/>Boston, MA 02231",
+              "value": "555 Park Drive\nBoston, MA 02231",
               "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215",
               "details": ""
             }]
@@ -491,7 +491,7 @@
             "items": [{
               "type": "address",
               "label": "",
-              "value": "555 Park Drive<br/>Boston, MA 02231",
+              "value": "555 Park Drive\nBoston, MA 02231",
               "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215",
               "details": ""
             }]
@@ -645,7 +645,7 @@
             "items": [{
               "type": "address",
               "label": "",
-              "value": "555 Park Drive<br/>Boston, MA 02231",
+              "value": "555 Park Drive\nBoston, MA 02231",
               "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215",
               "details": ""
             }]
@@ -701,7 +701,7 @@
             "items": [{
               "type": "address",
               "label": "",
-              "value": "555 Park Drive<br/>Boston, MA 02231",
+              "value": "555 Park Drive\nBoston, MA 02231",
               "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215",
               "details": ""
             }]
@@ -812,7 +812,7 @@
             "items": [{
               "type": "address",
               "label": "",
-              "value": "555 Park Drive<br/>Boston, MA 02231",
+              "value": "555 Park Drive\nBoston, MA 02231",
               "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215",
               "details": ""
             }]

--- a/styleguide/source/_patterns/05-pages/GUIDE-movng-to-ma-part2.json
+++ b/styleguide/source/_patterns/05-pages/GUIDE-movng-to-ma-part2.json
@@ -240,7 +240,7 @@
             "items": [{
               "type": "address",
               "label": "",
-              "value": "555 Park Drive<br/>Boston, MA 02231",
+              "value": "555 Park Drive\nBoston, MA 02231",
               "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215",
               "details": ""
             }]
@@ -372,7 +372,7 @@
             "items": [{
               "type": "address",
               "label": "",
-              "value": "555 Park Drive<br/>Boston, MA 02231",
+              "value": "555 Park Drive\nBoston, MA 02231",
               "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215",
               "details": ""
             }]
@@ -478,7 +478,7 @@
             "items": [{
               "type": "address",
               "label": "",
-              "value": "555 Park Drive<br/>Boston, MA 02231",
+              "value": "555 Park Drive\nBoston, MA 02231",
               "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215",
               "details": ""
             }]
@@ -559,7 +559,7 @@
             "items": [{
               "type": "address",
               "label": "",
-              "value": "555 Park Drive<br/>Boston, MA 02231",
+              "value": "555 Park Drive\nBoston, MA 02231",
               "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215",
               "details": ""
             }]

--- a/styleguide/source/_patterns/05-pages/GUIDE-movng-to-ma-part3.json
+++ b/styleguide/source/_patterns/05-pages/GUIDE-movng-to-ma-part3.json
@@ -204,7 +204,7 @@
             "items": [{
               "type": "address",
               "label": "",
-              "value": "555 Park Drive<br/>Boston, MA 02231",
+              "value": "555 Park Drive\nBoston, MA 02231",
               "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215",
               "details": ""
             }]
@@ -300,7 +300,7 @@
             "items": [{
               "type": "address",
               "label": "",
-              "value": "555 Park Drive<br/>Boston, MA 02231",
+              "value": "555 Park Drive\nBoston, MA 02231",
               "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215",
               "details": ""
             }]
@@ -415,7 +415,7 @@
             "items": [{
               "type": "address",
               "label": "",
-              "value": "555 Park Drive<br/>Boston, MA 02231",
+              "value": "555 Park Drive\nBoston, MA 02231",
               "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215",
               "details": ""
             }]
@@ -523,7 +523,7 @@
             "items": [{
               "type": "address",
               "label": "",
-              "value": "555 Park Drive<br/>Boston, MA 02231",
+              "value": "555 Park Drive\nBoston, MA 02231",
               "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215",
               "details": ""
             }]
@@ -618,7 +618,7 @@
             "items": [{
               "type": "address",
               "label": "",
-              "value": "555 Park Drive<br/>Boston, MA 02231",
+              "value": "555 Park Drive\nBoston, MA 02231",
               "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215",
               "details": ""
             }]
@@ -720,7 +720,7 @@
             "items": [{
               "type": "address",
               "label": "",
-              "value": "555 Park Drive<br/>Boston, MA 02231",
+              "value": "555 Park Drive\nBoston, MA 02231",
               "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215",
               "details": ""
             }]
@@ -849,7 +849,7 @@
             "items": [{
               "type": "address",
               "label": "",
-              "value": "555 Park Drive<br/>Boston, MA 02231",
+              "value": "555 Park Drive\nBoston, MA 02231",
               "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215",
               "details": ""
             }]

--- a/styleguide/source/_patterns/05-pages/LOC-Mt-Greylock-State-Park.json
+++ b/styleguide/source/_patterns/05-pages/LOC-Mt-Greylock-State-Park.json
@@ -109,7 +109,7 @@
           "phone": "14134994262",
           "fax": "",
           "email": "mass.parks@state.ma.us",
-          "address": "30 Rockwell Road<br />Lanesborough, MA 01237"
+          "address": "30 Rockwell Road\nLanesborough, MA 01237"
         }
       },{
         "position": {
@@ -122,7 +122,7 @@
           "phone": "14137431591",
           "fax": "",
           "email": "mail@bascomlodge.net",
-          "address": "30 Rockwell Road<br />Lanesborough, MA 01237"
+          "address": "30 Rockwell Road\nLanesborough, MA 01237"
         }
       }]
     }
@@ -269,7 +269,7 @@
               "phone": "14134994262",
               "fax": "",
               "email": "mass.parks@state.ma.us",
-              "address": "30 Rockwell Road<br />Lanesborough, MA 01237"
+              "address": "30 Rockwell Road\n Lanesborough, MA 01237"
             }
           },{
             "position": {
@@ -282,7 +282,7 @@
               "phone": "14137431591",
               "fax": "",
               "email": "mail@bascomlodge.net",
-              "address": "30 Rockwell Road<br />Lanesborough, MA 01237"
+              "address": "30 Rockwell Road\n Lanesborough, MA 01237"
             }
           }]
         }
@@ -593,7 +593,7 @@
             "type": "address",
             "property": "address",
             "label":"",
-            "value":"555 Park Drive<br />Boston, MA 02231",
+            "value":"555 Park Drive\nBoston, MA 02231",
             "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215",
             "details":""
           }]
@@ -654,7 +654,7 @@
             "type": "address",
             "property": "address",
             "label":"",
-            "value":"555 Park Drive<br />North Hampton, MA 02231",
+            "value":"555 Park Drive\nNorth Hampton, MA 02231",
             "link": "",
             "details":""
           }]

--- a/styleguide/source/_patterns/05-pages/LOC-Southbridge-RMV.json
+++ b/styleguide/source/_patterns/05-pages/LOC-Southbridge-RMV.json
@@ -227,7 +227,7 @@
               "phone": "14134994262",
               "fax": "",
               "email": "mass.parks@state.ma.us",
-              "address": "30 Rockwell Road<br />Lanesborough, MA 01237"
+              "address": "30 Rockwell Road\nLanesborough, MA 01237"
             }
           },{
             "position": {
@@ -240,7 +240,7 @@
               "phone": "14137431591",
               "fax": "",
               "email": "mail@bascomlodge.net",
-              "address": "30 Rockwell Road<br />Lanesborough, MA 01237"
+              "address": "30 Rockwell Road\nLanesborough, MA 01237"
             }
           }]
         }
@@ -438,7 +438,7 @@
             "type": "address",
             "property": "address",
             "label": "",
-            "value":"555 Park Drive<br />Boston, MA 02231",
+            "value":"555 Park Drive\nBoston, MA 02231",
             "link": "https://www.google.com/maps/place/555+Park+Dr,+Boston,+MA+02215",
             "details": ""
           }]
@@ -499,7 +499,7 @@
             "type": "address",
             "property": "address",
             "label":"",
-            "value":"555 Park Drive<br />North Hampton, MA 02231",
+            "value":"555 Park Drive\nNorth Hampton, MA 02231",
             "link": "",
             "details":""
           }]

--- a/styleguide/source/_patterns/05-pages/Map-listing-human-services.json
+++ b/styleguide/source/_patterns/05-pages/Map-listing-human-services.json
@@ -82,7 +82,7 @@
                 "phone": "16176261250",
                 "fax": "16176261351",
                 "email": "mass.parks@state.ma.us",
-                "address": "251 Causeway Street, Suite 900<br>Boston, MA 02114-2104"
+                "address": "251 Causeway Street, Suite 900\nBoston, MA 02114-2104"
               }
             },{
               "position": {
@@ -95,7 +95,7 @@
                 "phone": "16176261250",
                 "fax": "",
                 "email": "mass.parks@state.ma.us",
-                "address": "24 Beacon St<br>Boston, MA 02133"
+                "address": "24 Beacon St\nBoston, MA 02133"
               }
             }]
           },

--- a/styleguide/source/_patterns/05-pages/ORG-Health-Services.json
+++ b/styleguide/source/_patterns/05-pages/ORG-Health-Services.json
@@ -240,7 +240,7 @@
                 "phone": "16176261250",
                 "fax": "16176261351",
                 "email": "mass.parks@state.ma.us",
-                "address": "251 Causeway Street, Suite 900<br />Boston, MA 02114-2104"
+                "address": "251 Causeway Street, Suite 900\nBoston, MA 02114-2104"
               }
             },{
               "position": {
@@ -253,7 +253,7 @@
                 "phone": "16176261250",
                 "fax": "",
                 "email": "mass.parks@state.ma.us",
-                "address": "24 Beacon St<br />Boston, MA 02133"
+                "address": "24 Beacon St\nBoston, MA 02133"
               }
             }]
           }


### PR DESCRIPTION
Ticket: https://jira.state.ma.us/browse/DP-1995

Uses http://twig.sensiolabs.org/doc/2.x/filters/nl2br.html on the address in the contact group to allow the use of /n for a line break.

To test:
* Confirm that an address that is supposed to have a multi line break uses \n instead and that it renders properly.