### PR TITLE
Force pageBanner.titleSubText to uppercase and put in ( )'s

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-template/page-banner.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/page-banner.twig
@@ -27,7 +27,7 @@
       <h1 class="ma__page-banner__title">
         {{ pageBanner.title }}
         {% if pageBanner.titleSubText %}
-          <span> {{ pageBanner.titleSubText }}</span>
+          <span> ({{ pageBanner.titleSubText|upper }})</span>
         {% endif %}
       </h1>
     </div>

--- a/styleguide/source/_patterns/05-pages/ORG-Health-Services.json
+++ b/styleguide/source/_patterns/05-pages/ORG-Health-Services.json
@@ -16,7 +16,7 @@
     "size": "large",
     "icon": null,
     "title": "Executive Office of Health and Human Services",
-    "titleSubText": "(EOHHS)"
+    "titleSubText": "eohhs"
   },
 
   "actionHeader": {


### PR DESCRIPTION
This PR adds some formatting to the pageBanner.titleSubText property.  Namely, it forces the string to uppercase, and surrounds it with ().  I'm certainly open to making this behavior conditional and based on a boolean flag (e.g. pageBanner.titleSubText.isAcronym), but since the .json data sent for this page template was (EOHHS) I figured the design decision was already made.  Let me know if that's not the case.

Related to JIRA ticket: https://jira.state.ma.us/browse/DP-2008

To test:

- [ ] Pull the branch down and build locally
- [ ] Browse to the org page: http://localhost:3000/?p=pages-ORG-Health-Services
- [ ] Confirm that the subtitle text still renders in all capital letters and in parens.
- [ ] Optionally, alter the pageBanner.subTitleText value in mayflower patterns pages > ORG-Health-Services.json