### PR TITLE
DP-1893 [a11y] add the status of alert message display with aria

### DIFF
--- a/styleguide/source/_patterns/02-molecules/button-alert.twig
+++ b/styleguide/source/_patterns/02-molecules/button-alert.twig
@@ -1,4 +1,4 @@
-<button class="ma__button-alert" aria-expanded="false">
+<button class="ma__button-alert">
   <span class="ma__button-alert__hide">{{buttonAlert.hideText}}</span>
   <span class="ma__button-alert__show">{{buttonAlert.showText}}</span> {{buttonAlert.text}}
 </button>

--- a/styleguide/source/_patterns/02-molecules/button-alert.twig
+++ b/styleguide/source/_patterns/02-molecules/button-alert.twig
@@ -1,4 +1,4 @@
-<button class="ma__button-alert">
+<button class="ma__button-alert" type="button">
   <span class="ma__button-alert__hide">{{buttonAlert.hideText}}</span>
   <span class="ma__button-alert__show">{{buttonAlert.showText}}</span> {{buttonAlert.text}}
 </button>

--- a/styleguide/source/_patterns/02-molecules/button-alert.twig
+++ b/styleguide/source/_patterns/02-molecules/button-alert.twig
@@ -1,4 +1,4 @@
-<button class="ma__button-alert">
+<button class="ma__button-alert" aria-expanded="false">
   <span class="ma__button-alert__hide">{{buttonAlert.hideText}}</span>
   <span class="ma__button-alert__show">{{buttonAlert.showText}}</span> {{buttonAlert.text}}
 </button>

--- a/styleguide/source/assets/js/modules/emergencyAlerts.js
+++ b/styleguide/source/assets/js/modules/emergencyAlerts.js
@@ -7,7 +7,8 @@ export default function (window,document,$,undefined) {
         open = true,
         id = $el.data('id'),
         cookieName = 'emergency-alerts' + id,
-        cookieValue = cookie.getCookie(cookieName);
+        cookieValue = cookie.getCookie(cookieName),
+        $buttonState = $(this).find('.ma__button-alert').attr('aria-expanded');
 
     if(typeof(cookieValue) != 'undefined' && cookieValue === 'false') {
       // cookieValue is a string so we can't use the value directly
@@ -21,9 +22,12 @@ export default function (window,document,$,undefined) {
     $el.on('click','.js-accordion-link',function(){
       // toggle the current state
       open = !open;
-      // update open/close state cookie 
+      // update open/close state cookie
       // leave off third argument to make it expire on session
       cookie.setCookie(cookieName,open);
+      // change the state of aria-expanded
+     $buttonState === 'false' ? $buttonState = 'true' : $buttonState = 'false';
+     $(this).find('.ma__button-alert').attr('aria-expanded',$buttonState);
     });
 
   });

--- a/styleguide/source/assets/js/modules/emergencyAlerts.js
+++ b/styleguide/source/assets/js/modules/emergencyAlerts.js
@@ -1,6 +1,10 @@
 import cookie   from "../helpers/cookies.js";
 
 export default function (window,document,$,undefined) {
+  // Emergency Alerts start close on page load
+  // the default behavior is to expand the alerts
+  // Emergency Alerts should stay closed if the cookie is set to false
+
   $('.js-emergency-alerts').each(function(){
     let $el = $(this),
         open = true,
@@ -8,34 +12,29 @@ export default function (window,document,$,undefined) {
         cookieName = 'emergency-alerts' + id,
         cookieValue = cookie.getCookie(cookieName),
         $button = $el.find('.js-accordion-link button'),
-        // Add an aria-expanded attribute with its default value, false. to the <button>
-        $buttonState = $button.attr('aria-expanded', !open);
+        $link = $el.find('.js-accordion-link');
 
-    if(typeof(cookieValue) != 'undefined' && cookieValue === 'false') {
-      // cookieValue is a string so we can't use the value directly
+    // if the user has closed the alerts on a previous page
+    if(typeof(cookieValue) !== 'undefined' && cookieValue === 'false') {
       open = false;
-
+      // set the state of aria-expanded
       $button.attr('aria-expanded', open);
     }
-    if(open) {
-      // expand the menu
-      $el.find('.js-accordion-link').trigger('click');
 
-      $button.trigger('click');
+    // Emergency Alerts loads closed so expand it.
+    if(open) {
+      open = false; // clicking the link swaps the value
+      $link.first().trigger('click');
     }
 
-    $button.on('click', function(e) {
-      e.preventDefault();
+    $link.on('click', function() {
       // toggle the current state
       open = !open;
       // update open/close state cookie
       // leave off third argument to make it expire on session
       cookie.setCookie(cookieName,open);
       // change the state of aria-expanded
-      $buttonState = $buttonState === open ? !open : open;
-      $(this).attr('aria-expanded', $buttonState);
+      $button.attr('aria-expanded', open);
     });
-
   });
-
 }(window,document,jQuery);

--- a/styleguide/source/assets/js/modules/emergencyAlerts.js
+++ b/styleguide/source/assets/js/modules/emergencyAlerts.js
@@ -20,26 +20,22 @@ export default function (window,document,$,undefined) {
     if(open) {
       // expand the menu
       $el.find('.js-accordion-link').trigger('click');
+
+      $button.trigger('click');
     }
 
-    $el.on('click','.js-accordion-link',function(){
+    // $button.trigger('click');
+    $button.on('click', function(e) {
+      e.preventDefault();
       // toggle the current state
       open = !open;
       // update open/close state cookie
       // leave off third argument to make it expire on session
       cookie.setCookie(cookieName,open);
-    });
-
-    $button.trigger('click');
-    $button.on('click', function(e) {
-      e.preventDefault();
-
-      open = !open;
       // change the state of aria-expanded
       $buttonState = $buttonState === open ? !open : open;
       $(this).attr('aria-expanded', $buttonState);
     });
-
 
   });
 

--- a/styleguide/source/assets/js/modules/emergencyAlerts.js
+++ b/styleguide/source/assets/js/modules/emergencyAlerts.js
@@ -1,18 +1,21 @@
 import cookie   from "../helpers/cookies.js";
 
 export default function (window,document,$,undefined) {
-
   $('.js-emergency-alerts').each(function(){
     let $el = $(this),
         open = true,
         id = $el.data('id'),
         cookieName = 'emergency-alerts' + id,
         cookieValue = cookie.getCookie(cookieName),
-        $buttonState = $(this).find('.ma__button-alert').attr('aria-expanded');
+        $button = $el.find('.js-accordion-link button'),
+        // Add an aria-expanded attribute with its default value, false. to the <button>
+        $buttonState = $button.attr('aria-expanded', !open);
 
     if(typeof(cookieValue) != 'undefined' && cookieValue === 'false') {
       // cookieValue is a string so we can't use the value directly
       open = false;
+
+      $button.attr('aria-expanded', open);
     }
     if(open) {
       // expand the menu
@@ -25,10 +28,18 @@ export default function (window,document,$,undefined) {
       // update open/close state cookie
       // leave off third argument to make it expire on session
       cookie.setCookie(cookieName,open);
-      // change the state of aria-expanded
-     $buttonState === 'false' ? $buttonState = 'true' : $buttonState = 'false';
-     $(this).find('.ma__button-alert').attr('aria-expanded',$buttonState);
     });
+
+    $button.trigger('click');
+    $button.on('click', function(e) {
+      e.preventDefault();
+
+      open = !open;
+      // change the state of aria-expanded
+      $buttonState = $buttonState === open ? !open : open;
+      $(this).attr('aria-expanded', $buttonState);
+    });
+
 
   });
 

--- a/styleguide/source/assets/js/modules/emergencyAlerts.js
+++ b/styleguide/source/assets/js/modules/emergencyAlerts.js
@@ -24,7 +24,6 @@ export default function (window,document,$,undefined) {
       $button.trigger('click');
     }
 
-    // $button.trigger('click');
     $button.on('click', function(e) {
       e.preventDefault();
       // toggle the current state

--- a/styleguide/source/assets/js/modules/emergencyAlerts.js
+++ b/styleguide/source/assets/js/modules/emergencyAlerts.js
@@ -11,8 +11,17 @@ export default function (window,document,$,undefined) {
         id = $el.data('id'),
         cookieName = 'emergency-alerts' + id,
         cookieValue = cookie.getCookie(cookieName),
-        $button = $el.find('.js-accordion-link button'),
-        $link = $el.find('.js-accordion-link');
+        $button = $el.find('.js-accordion-link button');
+
+    $button.on('click', function() {
+      // toggle the current state
+      open = !open;
+      // update open/close state cookie
+      // leave off third argument to make it expire on session
+      cookie.setCookie(cookieName,open);
+      // change the state of aria-expanded
+      $button.attr('aria-expanded', open);
+    });
 
     // if the user has closed the alerts on a previous page
     if(typeof(cookieValue) !== 'undefined' && cookieValue === 'false') {
@@ -24,17 +33,8 @@ export default function (window,document,$,undefined) {
     // Emergency Alerts loads closed so expand it.
     if(open) {
       open = false; // clicking the link swaps the value
-      $link.first().trigger('click');
+      $button.first().trigger('click');
     }
 
-    $link.on('click', function() {
-      // toggle the current state
-      open = !open;
-      // update open/close state cookie
-      // leave off third argument to make it expire on session
-      cookie.setCookie(cookieName,open);
-      // change the state of aria-expanded
-      $button.attr('aria-expanded', open);
-    });
   });
 }(window,document,jQuery);


### PR DESCRIPTION
No visual change.

Add `aria-expanded` to the alert `<button>` to tell the current status of the display of the alert messages. Its value gets changed between `true` and `false` with JavaScript as the button is clicked.

## Testing
- [ ] The `aria-expanded` value is `false` when the alert messages are hidden.
<img width="751" alt="button_close" src="https://cloud.githubusercontent.com/assets/9633303/23672879/2a289372-033e-11e7-9675-5fa2120e16c9.png">
- [ ] The `aria-expanded` value is `true` when the alert messages are shown.
<img width="748" alt="button_open" src="https://cloud.githubusercontent.com/assets/9633303/23672885/2efb3e2c-033e-11e7-9640-b76d523419d7.png">
- [ ] The status gets updated as the `<button>` is clicked accordingly. 