### PR TITLE
DP-1881 Focus is more visuallly clear for the top nav dropdown

### DIFF
--- a/styleguide/source/assets/scss/06-theme/02-molecules/_main-nav.scss
+++ b/styleguide/source/assets/scss/06-theme/02-molecules/_main-nav.scss
@@ -63,11 +63,7 @@
     font-weight: 500;
     color: $c-font-base;
 
-    &:hover {
-      background-color: $c-bg-subtle;
-      color: $c-font-link-subtle;
-    }
-
+    &:hover, 
     &:focus {
       background-color: $c-bg-subtle;
       color: $c-font-link-subtle;

--- a/styleguide/source/assets/scss/06-theme/02-molecules/_main-nav.scss
+++ b/styleguide/source/assets/scss/06-theme/02-molecules/_main-nav.scss
@@ -67,6 +67,11 @@
       background-color: $c-bg-subtle;
       color: $c-font-link-subtle;
     }
+
+    &:focus {
+      background-color: $c-bg-subtle;
+      color: $c-font-link-subtle;
+    }
   }
 
   &__subitem:first-child &__link {


### PR DESCRIPTION
Accessibility fix for making the focus more clear visually for the top nav dropdown. Per request from @WheresHJ to have :focus use the same treatment as the :hover for the top nav dropdown. 

JIRA ticket: https://jira.state.ma.us/browse/DP-1881

## To Test
- [ ] Type in this URL http://localhost:3000/?p=molecules-main-nav
- [ ] Tab to the Living than tab each subitem in the dropdown
- [ ] Each tab should give a background color #f2f2f2

Original focus for the top nav dropdown
![screen shot 2017-03-08 at 11 56 21 am](https://cloud.githubusercontent.com/assets/19477691/23714862/be20d980-03f8-11e7-81a0-07c2345fc9dc.jpg)

Updated focus for the top nav dropdown
![screen shot 2017-03-08 at 12 09 49 pm](https://cloud.githubusercontent.com/assets/19477691/23714868/c3d7113c-03f8-11e7-8f63-6eb7aeeff1ea.jpg)
