### PR TITLE
Dockerize Mayflower

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM php:7.1
+
+# Add the current version of the code (this will vanish if you -v map)
+ADD ./styleguide /usr/local/src
+
+# Move into source code working directory
+WORKDIR /usr/local/src
+
+# Update Apt Get
+RUN apt-get update
+
+# Install NPM
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - && apt-get install -y nodejs build-essential
+
+# Install NPM dependencies
+RUN npm install -g gulp gulp-util
+
+# Globally install all the npm dependencies
+RUN npm install
+RUN npm install -g
+
+# Build PHP/Twig templates
+RUN php core/console --generate
+
+# Run the application
+## Does the generation again, just in case there is a -v mapping with changes
+CMD php core/console --generate && gulp

--- a/README.md
+++ b/README.md
@@ -1,35 +1,55 @@
-#Style Guide
-This living styleguide is built using PatternLab.
+# Style Guide
 
-##Machine set up
-1. Install PHP
-2. Install NodeJS version 6.9.4 (https://nodejs.org/en/download/)
-3. Install GulpJS, via command line `npm install -g gulp`
+This living style guide is built using [PatternLab](http://patternlab.io).
 
-##Set up instructions
-1. Clone Repo
-2. Move into the styleguide directory `cd mayflower/styleguide`
-3. Generate pattern lab default files `php core/console --generate`
-4. Install npm dependencies `npm install`
+## Developer Setup (Local Machine)
 
-##Generate a styleguide
-### For local development
-1. run `gulp`
-2. launch browser at http://localhost:3000/ or port shown in gulp output
-3. Browser will automatically refresh as you make changes
+### Dependencies
 
-### For a dev environment
-1. run 'gulp build'
+- [Docker Community Edition](https://store.docker.com/search?offering=community&type=edition)
 
-### For a production environment
-1. run 'gulp prod'
+### First Developer Time Setup
 
-#Working with PatternLab
-##All work is done in the source folder.
-* Mark-up is in the source/_patterns directory.
-* Front end assets can be found in the source/assets directory
+Do this the first time you're setting up the project, or when `Dockerfile` changes.
+
+1. Open a terminal/command prompt into the directory this project is cloned from
+1. `docker build -t massgov/mayflower .`
+
+_Note: This step can go away if we start deploying to Docker Hub whenever we update Mayflower via CircleCI_
+
+### Run Local Server
+
+1. Open a terminal/command prompt into the root directory of the project
+1. `docker run -i -v $PWD/styleguide:/usr/local/src -p 3000:3000 massgov/mayflower`
+  - This does the following:
+    - Generates the PHP/Twig templates
+    - Runs `gulp`
+    - Maps the directory from your local machine into the Linux Docker container
+    - Maps your local port 3000 to the Docker container's port 3000
+  - To run a different command, just add your command to the end (example: `bash` or `gulp prod` or `npm install`)
+
+## Running Standalone
+
+_Note: This does not work as-is right now, as we haven't deployed our image to Docker Hub yet._
+
+1. Have Docker running locally or on the server you're deploying to
+1. `docker run -d -p <port exposed>:3000 massgov/mayflower`
+
+## Updating the Docker Image on Docker Hub
+
+1. Open a terminal/command prompt into the directory this project is cloned from
+1. Login to your Docker Hub account that has access to the `massgov` Docker org
+1. `docker build -t massgov/mayflower:<version> .`
+1. `docker push massgov/mayflower:<version>`
+
+## Working with PatternLab
+
+* All work is done in the source folder.
+* Mark-up is in the `source/_patterns` directory.
+* Front end assets can be found in the `source/assets` directory
 * Gulp will handle the conversion of files from source to public
-* Pattern Lab specific files are in the /public/styleguide directory (the styleguide.html file is automatically generated when twig templates are updated)
+* Pattern Lab specific files are in the `/public/styleguide` directory (the `styleguide.html` file is automatically generated when twig templates are updated)
 
 # Release Deployment
+
 Tagged releases are automatically (via CircleCI) deployed to the [Mayflower Artifacts](https://github.com/palantirnet/mayflower-artifacts) repo for consumption by the Palantir team. Tags should follow [semantic versioning](https://github.com/sindresorhus/semver-regex) conventions.

--- a/docs/Local Setup.md
+++ b/docs/Local Setup.md
@@ -1,0 +1,32 @@
+# Local Setup
+
+Instructions if you prefer to not use a Docker container.
+
+## Machine set up
+
+1. Install PHP
+1. Install NodeJS version 6.9.4 (https://nodejs.org/en/download/)
+1. Install GulpJS, via command line `npm install -g gulp`
+
+## Set up instructions
+
+1. Clone Repo
+1. Move into the styleguide directory `cd mayflower/styleguide`
+1. Generate pattern lab default files `php core/console --generate`
+1. Install npm dependencies `npm install`
+
+## Generate a styleguide
+
+### For local development
+
+1. run `gulp`
+1. launch browser at http://localhost:3000/ or port shown in gulp output
+1. Browser will automatically refresh as you make changes
+
+### For a dev environment
+
+1. run `gulp build`
+
+### For a production environment
+
+1. run `gulp prod`

--- a/styleguide/.gitignore
+++ b/styleguide/.gitignore
@@ -6,5 +6,6 @@ public/*
 public/styleguide/html/styleguide.html
 public/styleguide/data/patternlab-data.js
 !public/index.html
+npm-debug.log
 
 /deploy


### PR DESCRIPTION
This PR enables creation of Docker-housed Mayflower development.

Benefits (in order of importance):

- Moves Mayflower local development into an environment that is clean and consistent across anyone's machine
- Streamlines setup steps (can be streamlined more if we have CircleCI produce Docker images deployed to Docker Hub)
- Might make it easier to setup free Heroku spot instances (i.e. generate an environment for PRs) -- this assumes we'd want Mayflower running via Gulp on Heroku (versus just static deployments built/deployed by CircleCI)

To Test:

- Run the setup steps in `/README.md`