### PR TITLE
DP-2078 - Use h1 for messaging on transition page since it's more expected for screenreaders

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-template/transition-page.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/transition-page.twig
@@ -2,7 +2,7 @@
   <div class="ma__transition-page__icon">
     {% include transitionPage.icon %}
   </div>
-  <p class="ma__transition-page__message">{{ transitionPage.message }}</p>
+  <h1 class="ma__transition-page__message">{{ transitionPage.message }}</h1>
   <form class="ma__form ma__transition-page__form" action="{{ transitionPage.href}}">
     <div class="ma__transition-page__checkbox">
       {% set inputCheckbox = transitionPage.inputCheckbox %}


### PR DESCRIPTION
This just changes a `<p>` tag to an `<h1>`. This is a desired change so Assistive tech users have an h1 as they expect. 

**Jira:** https://jira.state.ma.us/browse/DP-2078