### PR TITLE
Change title and alt text of site logo for better pronunciation

### DIFF
--- a/styleguide/source/_patterns/01-atoms/09-media/site-logo.twig
+++ b/styleguide/source/_patterns/01-atoms/09-media/site-logo.twig
@@ -1,5 +1,5 @@
 <div class="ma__site-logo">
-  <a href="/" title="Mass Gov home page">
-    <img src="/{{ directory }}/images/stateseal.png" alt="Mass Gov" width="75" height="75" />
+  <a href="/" title="Mass.gov home page">
+    <img src="/{{ directory }}/images/stateseal.png" alt="Mass.gov" width="75" height="75" />
   </a>
 </div>


### PR DESCRIPTION
This is the Mayflower part of https://jira.state.ma.us/browse/DP-2399

See https://github.com/massgov/mass/pull/608 for the Drupal part.

Apparently "Mass Gov" is pronounced "Mass Governor" by some screen readers.   This change fixes the problem for error and interstitial pages (and for any other page template in which it may subsequently be included).

Test: 
- [ ] On home page of patternlab confirm that the site logo in the header and footer have alt text that says "Mass.gov" in place of "Mass Gov" and that the title of the related link has the same replacement.
- [ ] Using a screen reader, confirm that when you tab to each logo, its name is pronounced "mass dot gov"
