### PR TITLE
Change aria presentation of + symbol on close button in utility nav

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-template/utility-nav.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/utility-nav.twig
@@ -23,7 +23,7 @@
         <div aria-hidden="true" class="ma__utility-nav__content js-util-nav-content is-closed">
           <div class="ma__utility-nav__container">
             <div class="ma__utility-nav__content-title">
-              <button class="ma__utility-nav__close js-close-util-nav"><span>{{ item.closeText }}</span><span role="presentation">+</span></button>
+              <button class="ma__utility-nav__close js-close-util-nav"><span>{{ item.closeText }}</span><span aria-hidden="true">+</span></button>
               {% include item.icon %}
               <span>{{ item.text }}</span>
             </div>


### PR DESCRIPTION
Makes the + sign inaudible to screen readers.

Completes https://jira.state.ma.us/browse/DP-2401

To test:
- [ ] navigate to /?p=organisms-utility-nav.  Using screen reader, enter the utility nav.  Tab around until you are on the close button, note that reader just says "Close", not "Close Plus"