### PR TITLE
DP-2400 [a11y] Add more context to the linked text "Log in to..."

### DIFF
--- a/styleguide/source/_data/utilityNav.json
+++ b/styleguide/source/_data/utilityNav.json
@@ -21,6 +21,7 @@
 
     "items": [{
       "text": "State Organizations",
+      "ariaLabelText": "",
       "icon": "@atoms/05-icons/svg-building.twig",
       "closeText": "Close",
       "panel": {
@@ -38,6 +39,7 @@
       }
     },{
       "text": "Log in to...",
+      "ariaLabelText": "Log in to the most requested services",
       "icon": "@atoms/05-icons/svg-login.twig",
       "closeText": "Close",
       "panel": {

--- a/styleguide/source/_patterns/03-organisms/by-template/utility-nav.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/utility-nav.twig
@@ -16,7 +16,6 @@
           href="#"
           aria-label="{% if item.ariaLabelText %}{{ item.ariaLabelText }}{% else %}{{ item.text }}{% endif %}">
           {% include item.icon %}
-
           <span>
             {{ item.text }}
           </span>

--- a/styleguide/source/_patterns/03-organisms/by-template/utility-nav.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/utility-nav.twig
@@ -12,10 +12,11 @@
     {% endif %}
     {% for item in utilityNav.items %}
       <li class="ma__utility-nav__item js-util-nav-toggle">
-        <a class="ma__utility-nav__link" 
-          href="#" 
-          title="{{ item.text }}">
+        <a class="ma__utility-nav__link"
+          href="#"
+          aria-label="{% if item.ariaLabelText %}{{ item.ariaLabelText }}{% else %}{{ item.text }}{% endif %}">
           {% include item.icon %}
+
           <span>
             {{ item.text }}
           </span>


### PR DESCRIPTION
## Challenges

- One of the utility link text, "Log in to…", doesn't provide enough context to AT users.  

- With AT, the link's title attribute value is announced after the link text is read. This could be confusing AT users since they hear the link text twice or two different data, one from the link text and another from the title attribute.

Just adding a feature to set different data for the title attribute value to add necessary context is not enough because of the second challenge above.

## Approach
Stream line the link label replacing the title attribute with aria-label and give it its specific value targeting AT users with necessary context.
The aria-label value can have its own unique data different from its associated linked text.  If that's not necessary, the same data used for the link text is set for the value.

1. Replace the title attribute with aria-label in `<a>`.
2. Define a new variable, ariaLabelText, for the aria-label value.
3. Set a condition to put the ariaLabelText value if available, otherwise use text for the aria-label value.

## Outcome
AT ignores the link text and only announces the aria-label value. 