### PR TITLE
DP-2693 fix action activities empty "more link"

### DIFF
--- a/styleguide/source/_patterns/02-molecules/image-promo.twig
+++ b/styleguide/source/_patterns/02-molecules/image-promo.twig
@@ -35,7 +35,7 @@
       {% set richText = imagePromo.description %}
       {% include "@organisms/by-author/rich-text.twig" %}
     </div>
-    {% if imagePromo.link %}
+    {% if imagePromo.link.text %}
       <div class="ma__image-promo__link">
         {% set decorativeLink = imagePromo.link %}
         {% include "@atoms/decorative-link.twig" %}

--- a/styleguide/source/_patterns/05-pages/LOC-Mt-Greylock-State-Park.json
+++ b/styleguide/source/_patterns/05-pages/LOC-Mt-Greylock-State-Park.json
@@ -327,8 +327,8 @@
           "alt": "hunting image",
           "title": "Hunting",
           "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi eu tellus sit amet turpis convallis finibus at id nulla.",
-          "linkTitle": "More",
-          "href": "#"
+          "linkTitle": "",
+          "href": ""
         },{
           "image": "/assets/images/placeholder/190x107.png",
           "alt": "bird image",


### PR DESCRIPTION
This PR fixes the bug where empty more links render in the action activities / image promo component.  (see screenshot below).

The fix updates the conditional logic to check for the presence of a populated link object (since the link property exists even if empty) in the image promo molecule in order to prevent empty "more" links from bring printed in the action activities organism (used on location pages).

Ticket: https://jira.state.ma.us/secure/RapidBoard.jspa?rapidView=1603&view=detail&selectedIssue=DP-2693

To Test:
- Pull the branch down
- Build pattern lab
- Inspect the @pages/LOC-Mt-Greylock-State-Park.json file actionDetails > sections > [3] > data > actionActivities and confirm that one of those child objects has no value for linkTitle and href
- Browse to http://localhost:3000/?p=pages-LOC-Mt-Greylock-State-Park and verify that no decorative link markup is rendered

Screenshot of issue:
![dp-2693-action-activities-more-link](https://cloud.githubusercontent.com/assets/3279883/24917744/227a6856-1eac-11e7-9e6a-2df4dee52e1a.png)

Screenshot of fix:
![image](https://cloud.githubusercontent.com/assets/3279883/24917779/361482b6-1eac-11e7-9a5e-3019ee079d26.png)
