### PR TITLE
DP-2853 [dev] Contact section appears even when there is no additional contact added.

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-author/sidebar-contact.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/sidebar-contact.twig
@@ -1,5 +1,7 @@
-{% set coloredHeading = sidebarContact.coloredHeading %}
-{% include "@atoms/04-headings/colored-heading.twig" %}
+{% if sidebarContact.coloredHeading %}
+  {% set coloredHeading = sidebarContact.coloredHeading %}
+  {% include "@atoms/04-headings/colored-heading.twig" %}
+{% endif %}
 {% for item in sidebarContact.items %}
   {% set contactUs = item.contactUs %}
   {% include "@molecules/contact-us.twig" %}


### PR DESCRIPTION
This PR ensures that when there is not contact information included in a `sidebarContact` data structure, no contact header or other component markup renders in the sidebar.

### JIRA ticket: 
https://jira.state.ma.us/browse/DP-2853

### To Test:

- Pull down branch
- Build and serve pattern lab locally
- In your code editor, open @pages/LOC-Mt-Greylock-State-Park.json
- Remove the object assigned to the `sidebarContact` property at line 535 (through 691), replace it with an empty string
- Browse to http://localhost:3000/?p=pages-LOC-Mt-Greylock-State-Park and verify that there is no contact header visible in the sidebar.

### Screenshots:

#### Bug screenshot: note empty sidebar contact pattern
![image](https://cloud.githubusercontent.com/assets/3279883/24962473/08c04426-1f6a-11e7-8877-60b3597e3447.png)

#### Fixed: note removal of empty sidebar contact pattern
![image](https://cloud.githubusercontent.com/assets/3279883/24962522/2482e466-1f6a-11e7-8e2c-518655b2b88c.png)

### Notes:
This PR is a dependency for https://github.com/massgov/mass/pull/637 -- once this PR is merged, we need a pre-release tag cut.

