### PR TITLE
Update google-map.twig to add escape(js) filters

### DIFF
--- a/styleguide/source/_patterns/02-molecules/google-map.twig
+++ b/styleguide/source/_patterns/02-molecules/google-map.twig
@@ -24,11 +24,11 @@
           },
           label: "{{ marker.label }}", // single character only
           infoWindow: {
-            name: "{{ marker.infoWindow.name|raw }}", // raw was needed to prevent rendering ascii characters
-            phone: "{{ marker.infoWindow.phone }}",
-            fax: "{{ marker.infoWindow.fax }}",
-            email: "{{ marker.infoWindow.email }}",
-            address: "{{ marker.infoWindow.address|replace({'\n': '<br>'})|raw }}"
+            name: "{{ marker.infoWindow.name|raw|e('js') }}", // raw was needed to prevent rendering ascii characters
+            phone: "{{ marker.infoWindow.phone|e('js') }}",
+            fax: "{{ marker.infoWindow.fax|e('js') }}",
+            email: "{{ marker.infoWindow.email|e('js') }}",
+            address: "{{ marker.infoWindow.address|replace({'\n': '<br>'})|raw|e('js') }}"
           }
         }{{ loop.last ? '' : ',' }}
       {% endfor %}


### PR DESCRIPTION
As entered in Drupal, address strings can contain characters that break the json passed to the google maps js.  This adds escaping to the address, and in an excess of caution, to the other textual output as well.

test:
[ ] No change to the marker output of http://localhost:3000/?p=pages-Service-Unemployment-Benefits
[ ] Add some crap to google-map.json infoWindow:address  (add some special characters, an apostrophe, what have you), confirm that marker output is not changed.