### PR TITLE
DP-3167 announcement page design review updates

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_press-status.scss
+++ b/styleguide/source/assets/scss/02-molecules/_press-status.scss
@@ -1,5 +1,5 @@
 .ma__press-status {
-  margin-bottom: 50px;
+  @include ma-component-spacing;
   padding: 30px;
   position: relative;
 

--- a/styleguide/source/assets/scss/02-molecules/_press-status.scss
+++ b/styleguide/source/assets/scss/02-molecules/_press-status.scss
@@ -1,5 +1,5 @@
 .ma__press-status {
-  margin-bottom: 30px;
+  margin-bottom: 50px;
   padding: 30px;
   position: relative;
 

--- a/styleguide/source/assets/scss/02-molecules/_press-status.scss
+++ b/styleguide/source/assets/scss/02-molecules/_press-status.scss
@@ -38,7 +38,7 @@
   }
 
   &__date {
-    font-size: 1.25rem;
+    margin-bottom: 5px;
 
     @media ($bp-small-min) {
       @include span-columns(3 of 8);

--- a/styleguide/source/assets/scss/03-organisms/_link-list.scss
+++ b/styleguide/source/assets/scss/03-organisms/_link-list.scss
@@ -55,6 +55,7 @@
   }
 
   &__eyebrow {
+    margin-bottom: 5px;
 
     span {
       font-size: 0.813rem;

--- a/styleguide/source/assets/scss/03-organisms/_personal-message.scss
+++ b/styleguide/source/assets/scss/03-organisms/_personal-message.scss
@@ -34,4 +34,8 @@
   .ma__image-promo {
     padding: 0;
   }
+
+  .ma__image-promo__description {
+    font-size: 1.375rem;
+  }
 }

--- a/styleguide/source/assets/scss/06-theme/02-molecules/_header-tags.scss
+++ b/styleguide/source/assets/scss/06-theme/02-molecules/_header-tags.scss
@@ -1,5 +1,5 @@
 .ma__header-tags {
-  font-weight: 800;
+  font-weight: 600;
 
   &__terms {
 

--- a/styleguide/source/assets/scss/06-theme/02-molecules/_social-links.scss
+++ b/styleguide/source/assets/scss/06-theme/02-molecules/_social-links.scss
@@ -1,6 +1,6 @@
 .ma__social-links {
 
   &__label {
-    font-weight: 800;
+    font-weight: 600;
   }
 }


### PR DESCRIPTION
This PR makes small updates based on the design review for [DP-3167](https://jira.state.ma.us/browse/DP-3167):

### Make announcement page > header tag + social link labels lighter weight

**BEFORE:**

![image](https://cloud.githubusercontent.com/assets/3279883/25744650/0f25a412-3169-11e7-8c8a-893479bf169b.png)

**AFTER:**

Header Tag label:
![image](https://cloud.githubusercontent.com/assets/3279883/25744753/7a5d2386-3169-11e7-88ab-1a54923adef9.png)

Social links label:
![image](https://cloud.githubusercontent.com/assets/3279883/25744767/91af4000-3169-11e7-8bd7-f026106ba946.png)

	
### Increase space between announcement page > press status + main content

**BEFORE:**

![image](https://cloud.githubusercontent.com/assets/3279883/25744856/f647cbae-3169-11e7-8baf-e976dc2eed36.png)


**AFTER:**

![image](https://cloud.githubusercontent.com/assets/3279883/25744848/f167eeac-3169-11e7-9b18-f46f36685d23.png)


### Increase space between sidebar link list eyebrows and link text

**BEFORE:**

![image](https://cloud.githubusercontent.com/assets/3279883/25744921/69149478-316a-11e7-9c49-f767c2edfec3.png)


**AFTER:**

![image](https://cloud.githubusercontent.com/assets/3279883/25745069/384af052-316b-11e7-8da6-a8046b60b6bc.png)



### Increase announcement page > press status date font size, bottom margin

**BEFORE:**

![image](https://cloud.githubusercontent.com/assets/3279883/25744911/4d9d807e-316a-11e7-9fbf-e9ed4bc355a4.png)

**AFTER:**

![image](https://cloud.githubusercontent.com/assets/3279883/25745008/e6665ac4-316a-11e7-964f-5186e906bf09.png)


### Increase image promo description font size when child of personal msg

**BEFORE:**

![image](https://cloud.githubusercontent.com/assets/3279883/25744932/7d1640de-316a-11e7-881b-3f03444d6abe.png)


**AFTER:**

![image](https://cloud.githubusercontent.com/assets/3279883/25745025/feeb20ca-316a-11e7-8c29-4e0f2bae2938.png)
