### PR TITLE
DP-3190 Adjusting the tab order in the header

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-template/header.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/header.twig
@@ -4,6 +4,9 @@
   <div class="ma__header__backto">
     <a href="http://www.mass.gov">Go to classic Mass.gov</a>
   </div>
+  <div class="ma__header__utility-nav">
+        {% include "@organisms/by-template/utility-nav.twig" %}
+      </div>
   <div class="ma__header__container">
     <div class="ma__header__logo">
       {% include "@atoms/09-media/site-logo.twig" %}
@@ -31,9 +34,6 @@
       {% endif %}
       <div class="ma__header__main-nav">
         {% include "@molecules/main-nav.twig" %}
-      </div>
-      <div class="ma__header__utility-nav">
-        {% include "@organisms/by-template/utility-nav.twig" %}
       </div>
     </div>
   </nav>


### PR DESCRIPTION
Description:
To adjust the order in which tab works in the header. Currently the tab will focus on skip to main content >Go to classic>logo>search bar>main nav>(than back to utility nav). With this fix it will go skip to main content >go to classic>utility nav>logo>search bar> main nav. 

Jira:
https://jira.state.ma.us/browse/DP-3190

To Test:
- [ ] http://localhost:3000/?p=organisms-header
- [ ] Start to tab it should show in this order Skip to main content > Go to Classic > State Organizations > Log in to > Log > Search Bar > Main Nav (below in the screenshot shows the new tab order in the header

Old tab order in the header:
![current order of tab in the header](https://cloud.githubusercontent.com/assets/19477691/25912836/a67fd33e-3586-11e7-8b51-ca62d216ca43.jpg)

New tab order in the header:
![new tab order in the header](https://cloud.githubusercontent.com/assets/19477691/25912850/b3aa75be-3586-11e7-8534-45ccd398f2a3.jpg)
