### PR TITLE
DP-3239 - Location General - add location banne

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-author/location-banner.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/location-banner.json
@@ -3,6 +3,7 @@
     "bgTitle":"Mt Greylock State Park",
     "bgWide":"/assets/images/placeholder/1600x400.png",
     "bgNarrow":"/assets/images/placeholder/800x400.png",
+    "id": "GUID24872901570",
     "actionMap": {
       "map": {
         "center": {

--- a/styleguide/source/_patterns/03-organisms/by-author/location-banner.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/location-banner.twig
@@ -1,26 +1,25 @@
+{% set locationBannerId = locationBanner.id ? locationBanner.id : 'banner-id' %}
+
 <section class="ma__location-banner">
   <style>
-    #GUID24872901570 {
-      background-image: url('{{locationBanner.bgNarrow}}');
+    #{{ locationBannerId }} {
+      background-image: url('{{ locationBanner.bgNarrow }}');
     }
     
     @media (min-width: 801px) {
-      #GUID24872901570 {
-        background-image: url('{{locationBanner.bgWide}}');
+      #{{ locationBannerId }} {
+        background-image: url('{{ locationBanner.bgWide }}');
       }
     }
   </style>
   <div class="ma__location-banner__map">
-    {% set googleMap = locationBanner.actionMap %}
+    {% set googleMap = locationBanner.actionMap ? locationBanner.actionMap : locationBanner.googleMap %}
     {% include "@molecules/google-map.twig" %}
   </div>
   <div 
     class="ma__location-banner__image" 
-    id="GUID24872901570"
+    id="{{ locationBannerId }}"
     role="image"
-    title="{{locationBanner.bgTitle}}">
+    title="{{ locationBanner.bgTitle }}">
   </div>
-{% if schemaPageType %}
-  <meta property="image" src="{{locationBanner.bgNarrow}}" alt="{{locationBanner.bgTitle}}" />
-{% endif %}
 </section>

--- a/styleguide/source/_patterns/05-pages/location-general-content.json
+++ b/styleguide/source/_patterns/05-pages/location-general-content.json
@@ -67,25 +67,36 @@
     }]
   },
 
-  "bannerCarousel": {
-    "slides":[{
-      "image":"/assets/images/placeholder/800x400.png",
-      "imageLarge":"/assets/images/placeholder/1600x400.png",
-      "alt":"view from the lodge"
-    },{
-      "image":"/assets/images/placeholder/800x400.png",
-      "imageLarge":"/assets/images/placeholder/1600x400.png",
-      "alt":"view from the lodge"
-    },{
-      "image":"/assets/images/placeholder/800x400.png",
-      "imageLarge":"/assets/images/placeholder/1600x400.png",
-      "alt":"view from the lodge"
-    },{
-      "image":"/assets/images/placeholder/800x400.png",
-      "imageLarge":"/assets/images/placeholder/1600x400.png",
-      "alt":"view from the lodge"
-    }]
+  "locationBanner": {
+    "bgTitle":"Mt Greylock State Park",
+    "bgWide":"/assets/images/placeholder/1600x400.png",
+    "bgNarrow":"/assets/images/placeholder/800x400.png",
+    "id": "GUID24872901570",
+    "googleMap": {
+      "map": {
+        "center": {
+          "lat": 42.077474,
+          "lng": -72.0352727
+        },
+        "zoom": 12
+      },
+      "markers": [{
+        "position": {
+          "lat": 42.077474,
+          "lng": -72.0352727
+        },
+        "label": "",
+        "infoWindow": {
+          "name": "Southbridge RMV",
+          "phone": "14134994262",
+          "fax": "",
+          "email": "",
+          "address": "6 Larochelle Way\nSouthbridge, MA 01550"
+        }
+      }]
+    }
   },
+
 
   "COMMENT":"****PAGE CONTENT COMPONENTS****",
 

--- a/styleguide/source/_patterns/05-pages/location-general-content.twig
+++ b/styleguide/source/_patterns/05-pages/location-general-content.twig
@@ -6,7 +6,7 @@
   {% endfor %}
   {% include "@organisms/by-template/breadcrumbs.twig" %}
   {% include "@organisms/by-template/page-header.twig" %}
-  {% include "@organisms/by-author/banner-carousel.twig" %}
+  {% include "@organisms/by-author/location-banner.twig" %}
 {% endblock %}
 {% block pageContent %}
   {% set quickActions = sidebar.quickActions %}

--- a/styleguide/source/_patterns/05-pages/location-park-content.json
+++ b/styleguide/source/_patterns/05-pages/location-park-content.json
@@ -296,9 +296,9 @@
         }
       }
     },{
-      "title":"Activities",
+      "title":"Recommended Activities",
       "intro": "",
-      "id":"activities",
+      "id":"recommended-activities",
       "path": "@organisms/by-author/image-promos.twig",
       "data": {
         "imagePromos": {
@@ -324,11 +324,7 @@
                 }]
               }
             },
-            "link": {
-              "text": "Details & Maps",
-              "type": "chevron",
-              "href": "#"
-            }
+            "link": null
           },{
             "title": {
               "text": "Camping",
@@ -351,11 +347,7 @@
                 }]
               }
             },
-            "link": {
-              "text": "More",
-              "type": "chevron",
-              "href": "#"
-            }
+            "link": null
           },{
             "title": {
               "text": "Winter Sports",
@@ -378,64 +370,42 @@
                 }]
               }
             },
-            "link": {
-              "text": "More",
-              "type": "chevron",
-              "href": "#"
-            }
-          },{
-            "title": {
-              "text": "Hunting",
-              "href": "#"
-            },
-            "image": {
-              "src": "/assets/images/placeholder/190x107.png",
-              "alt": "hunting image",
-              "href": "#"
-            },
-            "description": {
-              "richText":{
-                "rteElements": [{
-                  "path": "@atoms/11-text/paragraph.twig",
-                  "data": {
-                    "paragraph" : {
-                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi eu tellus sit amet turpis convallis finibus at id nulla."
-                    }
-                  }
-                }]
-              }
-            },
-            "link": {
-              "text": "",
-              "type": "",
-              "href": ""
-            }
-          },{
-            "title": {
-              "text": "Bird Watching",
-              "href": "#"
-            },
-            "image": {
-              "src": "/assets/images/placeholder/190x107.png",
-              "alt": "bird image",
-              "href": "#"
-            },
-            "description": {
-              "richText":{
-                "rteElements": [{
-                  "path": "@atoms/11-text/paragraph.twig",
-                  "data": {
-                    "paragraph" : {
-                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi eu tellus sit amet turpis convallis finibus at id nulla."
-                    }
-                  }
-                }]
-              }
-            },
-            "link": {
-              "text": "More",
-              "type": "chevron",
-              "href": "#"
+            "link": null
+          }]
+        }
+      }
+    },{
+      "title":"All Activities",
+      "intro": "",
+      "id":"all-activities",
+      "path": "organisms-rich-text",
+      "data": {
+        "richText": {
+          "property": "",
+          "rteElements": [{
+            "path": "atoms-unordered-list",
+            "data": {
+              "unorderedList": [{
+                "text": "Hiking"
+              },{
+                "text": "Bird Watching"
+              },{
+                "text": "Swimming"
+              },{
+                "text": "Bug Collecting"
+              },{
+                "text": "Whale Riding"
+              },{
+                "text": "Mountain Biking"
+              },{
+                "text": "Camping"
+              },{
+                "text": "More Taxonomy"
+              },{
+                "text": "More Taxonomy"
+              },{
+                "text": "More Taxonomy"
+              }]
             }
           }]
         }

--- a/styleguide/source/_patterns/05-pages/location-park-content.json
+++ b/styleguide/source/_patterns/05-pages/location-park-content.json
@@ -98,7 +98,8 @@
     "bgTitle":"Mt Greylock State Park",
     "bgWide":"/assets/images/placeholder/1600x400.png",
     "bgNarrow":"/assets/images/placeholder/800x400.png",
-    "actionMap": {
+    "id": "GUID24872901570",
+    "googleMap": {
       "map": {
         "center": {
           "lat": 42.594129,


### PR DESCRIPTION
https://jira.state.ma.us/browse/DP-3239

1. Updated the General Location page to use the Location Banner instead of the Banner Carousel
2, Updated the Location Banner to use googleMap data object (backward compatible with actionMap)
3. Added a new "id" data value to override the static one setting the background image location