### PR TITLE
DP-3209 Park icons

### DIFF
--- a/styleguide/source/_patterns/02-molecules/location-icons.twig
+++ b/styleguide/source/_patterns/02-molecules/location-icons.twig
@@ -1,6 +1,6 @@
 <section class="ma__location-icons">
   <h2 class="visually-hidden">Location Features</h2>
-  <div>
+  <div class="ma__location-icons__items">
     {% for icon in locationIcons.icons %}
       <div class="ma__location-icons__item"{% if schemaPageType %} property="amenityFeature" typeof="LocationFeatureSpecification"{% endif %}>
         <div class="ma__location-icons__icon">

--- a/styleguide/source/assets/scss/02-molecules/_location-icons.scss
+++ b/styleguide/source/assets/scss/02-molecules/_location-icons.scss
@@ -29,9 +29,10 @@
 
   &__name {
     font-size: 13px;
-    margin-bottom: 0;
+    margin: 0 auto;
     letter-spacing: .1em;
     line-height: 1.3;
+    max-width: 150px;
     text-transform: uppercase;
   }
 }

--- a/styleguide/source/assets/scss/02-molecules/_location-icons.scss
+++ b/styleguide/source/assets/scss/02-molecules/_location-icons.scss
@@ -1,20 +1,19 @@
 .ma__location-icons {
-  @include clearfix;
   margin-bottom: -30px;
+
+  &__items {
+    display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+  }
 
   &__item {
     text-align: center;
     margin-bottom: 30px;
-
-    @media ($bp-x-small-max) {
-      @include span-columns(2 of 6);
-      @include omega(3n);
-    }
-
-    @media print, ($bp-x-small-min) {
-      @include span-columns(1 of 4);
-      @include omega(4n);
-    }
+    flex-grow: 1;
+    flex-shrink: 0;
+    flex-basis: 80px;
+    min-width: 80px;
   }
 
   &__icon {


### PR DESCRIPTION
Adjusting the park icons on location pages to use flex box to give each icon a fluid width.