### PR TITLE
DP-3191 Refactored 'Go to classic Mass.gov' link positioning

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-template/header.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/header.twig
@@ -2,9 +2,7 @@
 <header class="ma__header" id="header">
   <a class="ma__header__skip-nav" href="#main-content">skip to main content</a>
   <div class="ma__header__backto">
-    <div class="ma__header__backto__container">
-      <a href="http://www.mass.gov">Go to classic Mass.gov</a>
-    </div>
+    <a href="http://www.mass.gov">Go to classic Mass.gov</a>
   </div>
   <div class="ma__header__utility-nav ma__header__utility-nav--wide">
     {% include "@organisms/by-template/utility-nav.twig" %}

--- a/styleguide/source/_patterns/03-organisms/by-template/header.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/header.twig
@@ -1,9 +1,9 @@
 <!-- Begin .header -->
 <header class="ma__header" id="header">
-  <a class="ma__header__skip-nav" href="#main-content">skip to main content</a>
   <div class="ma__header__backto">
     <a href="http://www.mass.gov">Go to classic Mass.gov</a>
   </div>
+  <a class="ma__header__skip-nav" href="#main-content">skip to main content</a>
   <div class="ma__header__utility-nav ma__header__utility-nav--wide">
     {% include "@organisms/by-template/utility-nav.twig" %}
   </div>

--- a/styleguide/source/_patterns/03-organisms/by-template/header.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/header.twig
@@ -2,7 +2,9 @@
 <header class="ma__header" id="header">
   <a class="ma__header__skip-nav" href="#main-content">skip to main content</a>
   <div class="ma__header__backto">
-    <a href="http://www.mass.gov">Go to classic Mass.gov</a>
+    <div class="ma__header__backto__container">
+      <a href="http://www.mass.gov">Go to classic Mass.gov</a>
+    </div>
   </div>
   <div class="ma__header__utility-nav ma__header__utility-nav--wide">
     {% include "@organisms/by-template/utility-nav.twig" %}

--- a/styleguide/source/assets/scss/03-organisms/_header.scss
+++ b/styleguide/source/assets/scss/03-organisms/_header.scss
@@ -355,7 +355,7 @@ body {
       }
 
       @media ($bp-header-toggle-min){
-        position: absolute;
+        position: relative;
       }
 
       @media ($bp-large-min) {

--- a/styleguide/source/assets/scss/03-organisms/_header.scss
+++ b/styleguide/source/assets/scss/03-organisms/_header.scss
@@ -30,11 +30,15 @@ body {
   }
 
   &__skip-nav {
-    @include ma-visually-hidden;
     display: block;
     margin: 0 auto;
-    width: 240px !important;
+    width: 240px;
     text-align: center;
+
+    &:not(:focus) {
+      @include ma-visually-hidden;
+      width: 240px;
+    }
   }
 
   &__container {
@@ -323,21 +327,15 @@ body {
   }
 
   &__backto {
-    position: absolute;
-    top: 0;
-    width: 100%;
+    @include ma-container;
+    display: block;
+    height: 0;
+    position: relative;
+    transition: left 0.5s ease;
+    z-index: $z-dropdown + 1;
 
-    &__container {
-      @include ma-container;
-      display: block;
-      height: 0;
-      position: relative;
-      transition: left 0.5s ease;
-      z-index: $z-dropdown + 1;
-
-      @media ($bp-header-toggle-min) {
-        z-index: $z-dropdown - 1;
-      }
+    @media ($bp-header-toggle-min) {
+      z-index: $z-dropdown - 1;
     }
 
     a {
@@ -355,7 +353,8 @@ body {
       }
 
       @media ($bp-header-toggle-min){
-        position: relative;
+        position: absolute;
+          top: -$header-mobile-controls-height - 4px;
       }
 
       @media ($bp-large-min) {

--- a/styleguide/source/assets/scss/03-organisms/_header.scss
+++ b/styleguide/source/assets/scss/03-organisms/_header.scss
@@ -31,6 +31,10 @@ body {
 
   &__skip-nav {
     @include ma-visually-hidden;
+    display: block;
+    margin: 0 auto;
+    width: 240px !important;
+    text-align: center;
   }
 
   &__container {
@@ -319,15 +323,21 @@ body {
   }
 
   &__backto {
-    @include ma-container;
-    display: block;
-    height: 0;
-    position: relative;
-    transition: left 0.5s ease;
-    z-index: $z-dropdown + 1;
+    position: absolute;
+    top: 0;
+    width: 100%;
 
-    @media ($bp-header-toggle-min) {
-      z-index: $z-dropdown - 1;
+    &__container {
+      @include ma-container;
+      display: block;
+      height: 0;
+      position: relative;
+      transition: left 0.5s ease;
+      z-index: $z-dropdown + 1;
+
+      @media ($bp-header-toggle-min) {
+        z-index: $z-dropdown - 1;
+      }
     }
 
     a {
@@ -346,7 +356,6 @@ body {
 
       @media ($bp-header-toggle-min){
         position: absolute;
-          top: -$header-mobile-controls-height - 4px;
       }
 
       @media ($bp-large-min) {


### PR DESCRIPTION
https://jira.state.ma.us/browse/DP-3191

Adjusted styling on "Skip to main content" link to:
* Avoid overlap with the 'Go back to classic Mass.gov" link. Fixes the original issue outlined in DP-3191 by centering 'Skip to main content', which looks better visually as well.
* Make it visible on focus. Removes the need to leverage Drupal classes to do this.