### PR TITLE
DP-3825 policy advisory content type

### DIFF
--- a/styleguide/source/_patterns/01-atoms/11-text/publish-state.json
+++ b/styleguide/source/_patterns/01-atoms/11-text/publish-state.json
@@ -1,0 +1,5 @@
+{
+  "publishState": {
+    "text": "Published State"
+  }
+}

--- a/styleguide/source/_patterns/01-atoms/11-text/publish-state.md
+++ b/styleguide/source/_patterns/01-atoms/11-text/publish-state.md
@@ -1,0 +1,16 @@
+---
+title: Publish State
+---
+Description: Displays the large text depicting the state of content. 
+
+## State: Alpha
+
+### Used In:
+
+### Required Variables:
+~~~
+publishState {
+  text:
+    type: string
+}
+~~~

--- a/styleguide/source/_patterns/01-atoms/11-text/publish-state.twig
+++ b/styleguide/source/_patterns/01-atoms/11-text/publish-state.twig
@@ -1,0 +1,2 @@
+{# content and html need to be on a single line to remove whitespace #}
+<div class="ma__publish-state">{{ publishState.text }}</div>

--- a/styleguide/source/_patterns/02-molecules/footnote.json
+++ b/styleguide/source/_patterns/02-molecules/footnote.json
@@ -2,6 +2,7 @@
   "footnote": {
     "number": 1,
     "target": "#",
+    "id": "footnotemsg1",
     "richText": {
       "property": "",
       "rteElements": [{

--- a/styleguide/source/_patterns/02-molecules/footnote.json
+++ b/styleguide/source/_patterns/02-molecules/footnote.json
@@ -1,0 +1,24 @@
+{
+  "footnote": {
+    "number": 1,
+    "target": "#",
+    "richText": {
+      "property": "",
+      "rteElements": [{
+        "path": "@atoms/11-text/paragraph.twig",
+        "data": {
+          "paragraph" : {
+            "text": "<b><i>Optional Description of this policy</i></b>"
+          }
+        }
+      },{
+        "path": "@atoms/11-text/paragraph.twig",
+        "data": {
+          "paragraph" : {
+            "text": "Explicabo itaque possimus dignissimos? Repudiandae tempore, fugit illum? Iure error omnis eveniet eius iste molestias. Veritatis provident hic voluptate voluptatibus ullam accusantium, obcaecati tempora soluta praesentium accusamus sed dicta sapiente."
+          }
+        }
+      }]
+    }
+  }
+}

--- a/styleguide/source/_patterns/02-molecules/footnote.md
+++ b/styleguide/source/_patterns/02-molecules/footnote.md
@@ -1,7 +1,7 @@
 ---
 title: Footnote
 ---
-Description: A Footnote containing Rich Text and links back to content in a previous Rich Text.
+Description: A Footnote containing Rich Text that is linked to from a Rich Text footnote.
 
 ## Status: ALPHA
 
@@ -15,7 +15,11 @@ Description: A Footnote containing Rich Text and links back to content in a prev
 ~~~
 footnote: {
   number: 
-    type: number/required,
+    type: number/required
+  target:
+    type: string/required
+  id:
+    type: string/required
   richText: 
     type: richText/required 
 }

--- a/styleguide/source/_patterns/02-molecules/footnote.md
+++ b/styleguide/source/_patterns/02-molecules/footnote.md
@@ -1,0 +1,22 @@
+---
+title: Footnote
+---
+Description: A Footnote containing Rich Text and links back to content in a previous Rich Text.
+
+## Status: ALPHA
+
+### Used in:
+
+### Contains:
+- [@organisms/by-author/rich-text](?p=organisms-rich-text)
+
+
+### Required Variables
+~~~
+footnote: {
+  number: 
+    type: number/required,
+  richText: 
+    type: richText/required 
+}
+~~~

--- a/styleguide/source/_patterns/02-molecules/footnote.twig
+++ b/styleguide/source/_patterns/02-molecules/footnote.twig
@@ -1,4 +1,4 @@
-<div class="ma__footnote js-footnote" id="ma-footnote-message{{ footnote.number }}">
+<div class="ma__footnote js-footnote" id="{{ footnote.id }}" tabindex="-1">
   <a class="ma__footnote__link js-footnote-link" href="{{ footnote.target }}">{{ footnote.number }}</a>
   <div class="ma__footnote__rich-text js-footnote-message">
     {% set richText = footnote.richText %}

--- a/styleguide/source/_patterns/02-molecules/footnote.twig
+++ b/styleguide/source/_patterns/02-molecules/footnote.twig
@@ -1,0 +1,7 @@
+<div class="ma__footnote js-footnote" id="ma-footnote-message{{ footnote.number }}">
+  <a class="ma__footnote__link js-footnote-link" href="{{ footnote.target }}">{{ footnote.number }}</a>
+  <div class="ma__footnote__rich-text js-footnote-message">
+    {% set richText = footnote.richText %}
+    {% include "@organisms/by-author/rich-text.twig" %}
+  </div>
+</div>

--- a/styleguide/source/_patterns/02-molecules/listing-table.twig
+++ b/styleguide/source/_patterns/02-molecules/listing-table.twig
@@ -4,7 +4,7 @@
       {% for row in listingTable.rows %}
         <tr>
           <th scope="row">{{ row.label }}</th>
-          <td>{{ row.text }}</td>
+          <td class="ma__rich-text">{{ row.text|raw }}</td>
         </tr>
       {% endfor %}
     </table>

--- a/styleguide/source/_patterns/03-organisms/by-author/footnote-list.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/footnote-list.json
@@ -3,6 +3,7 @@
     "items": [{
       "number": 1,
       "target": "#",
+      "id": "footnotemsg1",
       "richText": {
         "property": "",
         "rteElements": [{
@@ -24,6 +25,7 @@
     },{
       "number": 2,
       "target": "#",
+      "id": "footnotemsg1",
       "richText": {
         "property": "",
         "rteElements": [{

--- a/styleguide/source/_patterns/03-organisms/by-author/footnote-list.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/footnote-list.json
@@ -1,0 +1,47 @@
+{
+  "footnoteList": {
+    "items": [{
+      "number": 1,
+      "target": "#",
+      "richText": {
+        "property": "",
+        "rteElements": [{
+          "path": "@atoms/11-text/paragraph.twig",
+          "data": {
+            "paragraph" : {
+              "text": "<b><i>Optional Description of this policy</i></b>"
+            }
+          }
+        },{
+          "path": "@atoms/11-text/paragraph.twig",
+          "data": {
+            "paragraph" : {
+              "text": "Explicabo itaque possimus dignissimos? Repudiandae tempore, fugit illum? Iure error omnis eveniet eius iste molestias. Veritatis provident hic voluptate voluptatibus ullam accusantium, obcaecati tempora soluta praesentium accusamus sed dicta sapiente."
+            }
+          }
+        }]
+      }
+    },{
+      "number": 2,
+      "target": "#",
+      "richText": {
+        "property": "",
+        "rteElements": [{
+          "path": "@atoms/11-text/paragraph.twig",
+          "data": {
+            "paragraph" : {
+              "text": "<b><i>Optional Description of this policy</i></b>"
+            }
+          }
+        },{
+          "path": "@atoms/11-text/paragraph.twig",
+          "data": {
+            "paragraph" : {
+              "text": "Explicabo itaque possimus dignissimos? Repudiandae tempore, fugit illum? Iure error omnis eveniet eius iste molestias. Veritatis provident hic voluptate voluptatibus ullam accusantium, obcaecati tempora soluta praesentium accusamus sed dicta sapiente."
+            }
+          }
+        }]
+      }
+    }]
+  }
+}

--- a/styleguide/source/_patterns/03-organisms/by-author/footnote-list.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/footnote-list.twig
@@ -1,0 +1,7 @@
+<section class="ma__footnote-list">
+  <div class="ma__footnote-list__container">
+    {% for footnote in footnoteList.items %}
+      {% include "@molecules/footnote.twig" %}
+    {% endfor %}
+  </div>
+</section>

--- a/styleguide/source/_patterns/03-organisms/by-template/page-header.md
+++ b/styleguide/source/_patterns/03-organisms/by-template/page-header.md
@@ -16,6 +16,7 @@ Description: Page Header with multiple spots (see optional content + widgets pro
 ### Contains:
 - [@molecules/header-tags.twig](/?p=molecules-header-tags)
 - [@molecules/header-contact.twig](/?p=molecules-header-contact)
+- [@atoms/11-text/publish-state.twig](/?p=atoms-publish-state)
 
 
 ### Required Variables
@@ -31,6 +32,10 @@ pageHeader:
     type: string
   headerTags:
     type: see @molecules/header-tags
+  publishState:
+    type: object / optional
+      text: 
+        type: string/required   
   optionalContents:
     type: array / optional (used to populate header main column under subTitle)
     path:

--- a/styleguide/source/_patterns/03-organisms/by-template/page-header.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/page-header.twig
@@ -18,6 +18,12 @@
   <div 
     class="ma__page-header__content"
     {% if schemaPageType %} property="mainEntityOfPage"{% endif %}>
+      {% if pageHeader.publishState %}
+        <div class="ma__page-header__publish-state">
+          {% set publishState = pageHeader.publishState %}
+          {% include "@atoms/11-text/publish-state.twig" %}
+        </div>
+      {% endif %}
       {% if pageHeader.category %}
         <div class="ma__page-header__category">
           {{ pageHeader.category }}

--- a/styleguide/source/_patterns/03-organisms/by-template/page-header~with-everything.json
+++ b/styleguide/source/_patterns/03-organisms/by-template/page-header~with-everything.json
@@ -39,24 +39,8 @@
         "linkType": "linkedin"
       }]
     },
-    "socialLinks": {
-      "label": "Share:",
-      "items": [{
-        "altText": "Follow us on Facebook",
-        "href": "#",
-        "icon": "@atoms/05-icons/svg-facebook.twig",
-        "linkType": "facebook"
-      },{
-        "altText": "Follow us on Twitter",
-        "href": "#",
-        "icon": "@atoms/05-icons/svg-twitter.twig",
-        "linkType": "twitter"
-      },{
-        "altText": "Follow us on LinkedIn",
-        "href": "#",
-        "icon": "@atoms/05-icons/svg-linkedin.twig",
-        "linkType": "linkedin"
-      }]
+    "publishState": {
+      "text": "Draft"
     },
     "optionalContents": [{
       "path": "@organisms/by-author/rich-text.twig",

--- a/styleguide/source/_patterns/04-templates/01-content-types/policy-advisory.json
+++ b/styleguide/source/_patterns/04-templates/01-content-types/policy-advisory.json
@@ -1,0 +1,305 @@
+{
+  "pageHeader": {
+    "category": "required category",
+    "divider": false,
+    "title": "Title",
+    "subTitle": "",
+    "headerTags": {
+      "label": "Related to:",
+      "taxonomyTerms": [{
+        "href": "#",
+        "text": "Parent Page"
+      },{
+        "href": "#",
+        "text": "Another Parent Page"
+      }]
+    },
+    "socialLinks": null,
+    "optionalContents": [{
+      "path": "@molecules/listing-table.twig",
+      "data": {
+        "listingTable": {
+          "rows": [{
+            "label": "Date:",
+            "text": "3/2/2017"
+          },{
+            "label": "Issuer:",
+            "text": "Mark E. Nunnelly, Commissioner of Revenue"
+          },{
+            "label": "Referenced Legistration:",
+            "text": "<a href=\"#\">M.G.L. c.51, S47C</a><br/><a href=\"#\">G.L. c.64H, S6</a>"
+          }]
+        }
+      }
+    },{
+      "path": "@organisms/by-author/rich-text.twig",
+      "data": {
+        "richText": {
+          "property": "",
+          "rteElements": [{
+            "path": "@atoms/11-text/paragraph.twig",
+            "data": {
+              "paragraph" : {
+                "text": "<b><i>Optional Description of this policy</i></b>"
+              }
+            }
+          },{
+            "path": "@atoms/11-text/paragraph.twig",
+            "data": {
+              "paragraph" : {
+                "text": "Explicabo itaque possimus dignissimos? Repudiandae tempore, fugit illum? Iure error omnis eveniet eius iste molestias. Veritatis provident hic voluptate voluptatibus ullam accusantium, obcaecati tempora soluta praesentium accusamus sed dicta sapiente."
+              }
+            }
+          }]
+        }
+      }
+    }],
+    "widgets": null
+  },
+
+  "jumpLinks": {
+    "title": "In this Section",
+    "links": [{
+      "text": "Rich Text",
+      "href": "rich-text"
+    },{
+      "text": "Downloads",
+      "href": "downloads"
+    },{
+      "text": "Contact",
+      "href": "contact"
+    }]
+  },
+
+  "mainContent": {
+    "contents": [{
+      "compHeading": {
+        "title": "Rich text",
+        "sub": false,
+        "color": "",
+        "id": "rich-text",
+        "centered": ""
+      },
+      "rteElements": [{
+        "path": "@atoms/11-text/paragraph.twig",
+        "data": {
+          "paragraph" : {
+            "text": "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Officiis sunt deleniti fuga consequuntur laudantium qui repellendus eveniet, culpa ipsum ullam libero quibusdam dolore, sit. Quasi alias sed atque saepe, tempora dolore dolor quod amet. Quaerat omnis illo, totam eligendi at."
+          }
+        }
+      },{
+        "path": "@atoms/11-text/paragraph.twig",
+        "data": {
+          "paragraph" : {
+            "text": "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tenetur consectetur eligendi recusandae, blanditiis nisi quibusdam, dolor voluptas dolore unde eius, eos esse doloremque enim? Culpa delectus excepturi beatae eos quod distinctio, ipsam ratione ad architecto doloremque modi eius consectetur at facere. Nobis, laboriosam, officia. Itaque maiores porro voluptates, sint sed dolore! Omnis, iusto sed est!"
+          }
+        }
+      }]
+    }],
+
+    "formDownloads": {
+      "compHeading": {
+        "title": "Downloads",
+        "sub": false,
+        "color": "",
+        "id": "downloads",
+        "centered": ""
+      },
+      "downloadLinks": [{
+        "downloadLink": {
+          "iconSize": "",
+          "icon": "@atoms/05-icons/svg-doc-pdf.twig",
+          "decorativeLink": {
+            "text": "PDF download item",
+            "href": "#",
+            "info": "",
+            "property": ""
+          },
+          "size": "30kb",
+          "format": "PDF"
+        }
+      },{
+        "downloadLink": {
+          "iconSize": "",
+          "icon": "@atoms/05-icons/svg-doc-docx.twig",
+          "decorativeLink": {
+            "text": "Word download item",
+            "href": "#",
+            "info": "",
+            "property": ""
+          },
+          "size": "40kb",
+          "format": "DOCX"
+        }
+      },{
+        "downloadLink": {
+          "iconSize": "",
+          "icon": "@atoms/05-icons/svg-laptop.twig",
+          "decorativeLink": {
+            "text": "Online form or information page",
+            "href": "#",
+            "info": "",
+            "property": ""
+          },
+          "size": "",
+          "format": "form"
+        }
+      }]
+    },
+
+    "contactList": {
+      "viewSpecific": false,
+      "compHeading":{
+        "title": "Contact",
+        "sub": false,
+        "color": "",
+        "id": "contact",
+        "centered": ""
+      },
+      "contacts":[{
+        "accordion": true,
+        "isExpanded": false,
+        "subTitle": {
+          "href":"",
+          "text": "Person to Contact"
+        },
+        "groups": [{
+          "icon": "@atoms/05-icons/svg-phone.twig",
+          "name": "Phone",
+          "items": [{
+            "type": "phone",
+            "property": "",
+            "label":"Main:",
+            "link": {
+              "href": "+17817401605",
+              "text": "(781) 740-1605",
+              "info": "",
+              "property": ""
+            },
+            "details":""
+          }]
+        },{
+          "icon": "@atoms/05-icons/svg-laptop.twig",
+          "name": "Online",
+          "hidden": "",
+          "items": [{
+            "type": "online",
+            "property": "",
+            "label":"Email:",
+            "link": {
+              "href":"#",
+              "text": "person@email.com",
+              "info": "",
+              "property": ""
+            },
+            "details":""
+          }]
+        }]
+      }]
+    },
+
+    "references": {
+      "label": "Referenced Legislation:",
+      "taxonomyTerms": [{
+        "href": "#",
+        "text": "Reference 1"
+      },{
+        "href": "#",
+        "text": "Reference 2"
+      }]
+    }
+  },
+
+  "sideContent": {
+    "contactList": {
+      "viewSpecific": false,
+      "sidebarHeading":{
+        "title": "Contact"
+      },
+      "contacts":[{
+        "subTitle": {
+          "href":"",
+          "text": "Person to Contact"
+        },
+        "groups": [{
+          "icon": "@atoms/05-icons/svg-laptop.twig",
+          "name": "Online",
+          "hidden": "",
+          "items": [{
+            "type": "online",
+            "property": "",
+            "label":"Email:",
+            "link": {
+              "href":"#",
+              "text": "person@email.com",
+              "info": "",
+              "property": ""
+            },
+            "details":""
+          }]
+        }]
+      }]
+    },
+
+    "pressListing": {
+      "sidebarHeading": {
+        "title": "Related"
+      },
+      "items": [{
+        "eyebrow": "Letter Ruling",
+        "title" : {
+          "url":"#",
+          "text":"Link to Ruling",
+          "info": "",
+          "property": ""
+        },
+        "date": "4/3/2017",
+        "org": "",
+        "description": null
+      },{
+        "eyebrow": "Regulation",
+        "title" : {
+          "url":"#",
+          "text":"Link to Regulation",
+          "info": "",
+          "property": ""
+        },
+        "date": "4/3/2017",
+        "org": "",
+        "description": null
+      },{
+        "eyebrow": "Regulation",
+        "title" : {
+          "url":"#",
+          "text":"Link to Regulation",
+          "info": "",
+          "property": ""
+        },
+        "date": "",
+        "org": "",
+        "description": null
+      }]
+    },
+
+    "eventListing": {
+      "sidebarHeading":{
+        "title": "Upcoming Events"
+      },
+      "events":[{
+        "title": {
+          "href": "#",
+          "text": "Name of Event",
+          "info": "",
+          "property": ""
+        },
+        "location": "location",
+        "date": {
+          "summary": "Date" 
+        },
+        "time": "Time",
+        "description":"This is a description of the event that will happen at a future date"
+      }],
+      "more": null
+    }
+  }
+}

--- a/styleguide/source/_patterns/04-templates/01-content-types/policy-advisory.json
+++ b/styleguide/source/_patterns/04-templates/01-content-types/policy-advisory.json
@@ -94,6 +94,20 @@
         "path": "@atoms/11-text/paragraph.twig",
         "data": {
           "paragraph" : {
+            "text": "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tenetur consectetur eligendi recusandae<a class=\"ma__rich-text__footnote js-rich-text-footnote\" id=\"footnoteref1\" title=\"source for this information\" href=\"#footnotemsg1\">1</a>, blanditiis nisi quibusdam, dolor voluptas dolore unde eius, eos esse doloremque enim? Culpa delectus excepturi beatae eos quod distinctio, ipsam ratione ad architecto doloremque modi eius consectetur at facere. Nobis, laboriosam, officia. Itaque maiores porro voluptates, sint sed dolore! Omnis, iusto sed est!"
+          }
+        }
+      },{
+        "path": "@atoms/11-text/paragraph.twig",
+        "data": {
+          "paragraph" : {
+            "text": "Lorem ipsum dolor sit amet, consectetur<a class=\"ma__rich-text__footnote js-rich-text-footnote\" id=\"footnoteref2\" title=\"source for this information\" href=\"#footnotemsg2\">2</a> adipisicing elit. Tenetur consectetur eligendi recusandae, blanditiis nisi quibusdam, dolor voluptas dolore unde eius, eos esse doloremque enim? Culpa delectus excepturi beatae eos quod distinctio, ipsam ratione ad architecto doloremque modi eius consectetur at facere. Nobis, laboriosam, officia. Itaque maiores porro voluptates, sint sed dolore! Omnis, iusto sed est!"
+          }
+        }
+      },{
+        "path": "@atoms/11-text/paragraph.twig",
+        "data": {
+          "paragraph" : {
             "text": "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tenetur consectetur eligendi recusandae, blanditiis nisi quibusdam, dolor voluptas dolore unde eius, eos esse doloremque enim? Culpa delectus excepturi beatae eos quod distinctio, ipsam ratione ad architecto doloremque modi eius consectetur at facere. Nobis, laboriosam, officia. Itaque maiores porro voluptates, sint sed dolore! Omnis, iusto sed est!"
           }
         }
@@ -198,6 +212,54 @@
             "details":""
           }]
         }]
+      }]
+    },
+
+    "footnoteList": {
+      "items": [{
+        "number": 1,
+        "target": "#footnoteref1",
+        "id": "footnotemsg1",
+        "richText": {
+          "property": "",
+          "rteElements": [{
+            "path": "@atoms/11-text/paragraph.twig",
+            "data": {
+              "paragraph" : {
+                "text": "<b><i>Optional Description of this policy</i></b>"
+              }
+            }
+          },{
+            "path": "@atoms/11-text/paragraph.twig",
+            "data": {
+              "paragraph" : {
+                "text": "Explicabo itaque possimus dignissimos? Repudiandae tempore, fugit illum? Iure error omnis eveniet eius iste molestias. Veritatis provident hic voluptate voluptatibus ullam accusantium, obcaecati tempora soluta praesentium accusamus sed dicta sapiente."
+              }
+            }
+          }]
+        }
+      },{
+        "number": 2,
+        "target": "#footnoteref2",
+        "id": "footnotemsg2",
+        "richText": {
+          "property": "",
+          "rteElements": [{
+            "path": "@atoms/11-text/paragraph.twig",
+            "data": {
+              "paragraph" : {
+                "text": "<b><i>Optional Description of this policy</i></b>"
+              }
+            }
+          },{
+            "path": "@atoms/11-text/paragraph.twig",
+            "data": {
+              "paragraph" : {
+                "text": "Explicabo itaque possimus dignissimos? Repudiandae tempore, fugit illum? Iure error omnis eveniet eius iste molestias. Veritatis provident hic voluptate voluptatibus ullam accusantium, obcaecati tempora soluta praesentium accusamus sed dicta sapiente."
+              }
+            }
+          }]
+        }
       }]
     },
 

--- a/styleguide/source/_patterns/04-templates/01-content-types/policy-advisory.json
+++ b/styleguide/source/_patterns/04-templates/01-content-types/policy-advisory.json
@@ -15,6 +15,9 @@
       }]
     },
     "socialLinks": null,
+    "publishState": {
+      "text": "Draft"
+    },
     "optionalContents": [{
       "path": "@molecules/listing-table.twig",
       "data": {
@@ -212,7 +215,7 @@
 
   "sideContent": {
     "contactList": {
-      "viewSpecific": false,
+      "viewSpecific": true,
       "sidebarHeading":{
         "title": "Contact"
       },

--- a/styleguide/source/_patterns/04-templates/01-content-types/policy-advisory.twig
+++ b/styleguide/source/_patterns/04-templates/01-content-types/policy-advisory.twig
@@ -1,0 +1,75 @@
+
+{# site header #}
+{% block header %}{% endblock %}
+
+<main id="main-content" tabindex="-1">
+  <div class="pre-content">
+    {% block preContent %}
+
+      {% include "@organisms/by-template/page-header.twig" %}
+    {% endblock %}
+  </div>
+  {% if jumpLinks %}
+    {% include "@organisms/by-template/jump-links.twig" %}
+  {% endif %}
+  <div class="main-content main-content--two">
+    <div class="page-content">
+      {% for richText in mainContent.contents %}
+        {% include "@organisms/by-author/rich-text.twig" %}
+        <div>...</div>
+      {% endfor %}
+
+      {% block pageContent %}
+        {% include "@base/placeholder.twig" with {'placeholder':{'text':'Page Content'}} %}
+      {% endblock %}
+
+      {% if mainContent.formDownloads %}
+        {% set formDownloads = mainContent.formDownloads %}
+        {% include "@organisms/by-author/form-downloads.twig" %}
+      {% endif %}
+
+      {% if mainContent.contactList %}
+        {% set contactList = mainContent.contactList %}
+        {% include "@organisms/by-author/contact-list.twig" %}
+      {% endif %}
+
+      {% for footnote in mainContent.footnotes %}
+
+      {% endfor %}
+
+      {% if mainContent.references %}
+        {% set headerTags = mainContent.references %}
+        {% include "@molecules/header-tags.twig" %}
+      {% endif %}
+    </div>
+    <aside class="sidebar {{ sidebar.coloredHeadings ? 'sidebar--colored' : '' }}">
+      {% if sideContent.contactList %}
+        {% set contactList = sideContent.contactList %}
+        {% include "@organisms/by-author/contact-list.twig" %}
+      {% endif %}
+      
+      {% if sideContent.pressListing %}
+        {% set pressListing = sideContent.pressListing %}
+        {% include "@organisms/by-author/press-listing.twig" %}
+      {% endif %}
+
+      {% if sideContent.eventListing %}
+        {% set eventListing = sideContent.eventListing %}
+        {% include "@organisms/by-author/event-listing.twig" %}
+      {% endif %}
+
+      {% block sidebar %}
+        {% include "@base/placeholder.twig" with {'placeholder':{'text':'sidebar'}} %}
+      {% endblock %}
+    </aside>
+  </div>
+  <div class="post-content">
+    {% block postContent %}
+      {% include "@base/placeholder.twig" with {'placeholder':{'text':'Post Content'}} %}
+    {% endblock %}
+  </div>
+  {% block schemaContent %}{% endblock %}
+</main>
+
+{# site footer #}
+{% block footer %}{% endblock %}

--- a/styleguide/source/_patterns/04-templates/01-content-types/policy-advisory.twig
+++ b/styleguide/source/_patterns/04-templates/01-content-types/policy-advisory.twig
@@ -32,9 +32,10 @@
         {% include "@organisms/by-author/contact-list.twig" %}
       {% endif %}
 
-      {% for footnote in mainContent.footnotes %}
-
-      {% endfor %}
+      {% if mainContent.footnoteList %}
+        {% set footnoteList = mainContent.footnoteList %}
+        {% include "@organisms/by-author/footnote-list.twig" %}
+      {% endif %}
 
       {% if mainContent.references %}
         {% set headerTags = mainContent.references %}

--- a/styleguide/source/_patterns/04-templates/01-content-types/policy-advisory.twig
+++ b/styleguide/source/_patterns/04-templates/01-content-types/policy-advisory.twig
@@ -2,10 +2,9 @@
 {# site header #}
 {% block header %}{% endblock %}
 
-<main id="main-content" tabindex="-1">
+<main id="main-content ma__policy-advisory" tabindex="-1">
   <div class="pre-content">
     {% block preContent %}
-
       {% include "@organisms/by-template/page-header.twig" %}
     {% endblock %}
   </div>

--- a/styleguide/source/_patterns/04-templates/01-content-types/press.json
+++ b/styleguide/source/_patterns/04-templates/01-content-types/press.json
@@ -369,32 +369,43 @@
       }]
     },
 
-    "linkList" : {
+    "pressListing": {
       "sidebarHeading": {
         "title": "Related"
       },
-      "stacked": true,
-      "links" : [{
-        "url":"#",
-        "text":"Admin Releases Unprecendented Report on Opiod Epidemic",
-        "info": "",
-        "property": "",
+      "items": [{
         "eyebrow": "Press Release",
-        "date": "4/3/2017"
+        "title" : {
+          "url":"#",
+          "text":"Admin Releases Unprecendented Report on Opiod Epidemic",
+          "info": "",
+          "property": ""
+        },
+        "date": "4/3/2017",
+        "org": "",
+        "description": null
       },{
-        "url":"#",
-        "text":"Dispensing procedures for pharmacists (105 CMR 722)",
-        "info": "",
-        "property": "",
         "eyebrow": "Regulation",
-        "date": ""
+        "title" : {
+          "url":"#",
+          "text":"Dispensing procedures for pharmacists (105 CMR 722)",
+          "info": "",
+          "property": ""
+        },
+        "date": "",
+        "org": "",
+        "description": null
       },{
-        "url":"#",
-        "text":"Related Non News, Annoucement, Reg, or Law Here",
-        "info": "",
-        "property": "",
-        "eyebrow": "",
-        "date": ""
+        "eyebrow": "Regulation",
+        "title" : {
+          "url":"#",
+          "text":"Related Non News, Annoucement, Reg, or Law Here",
+          "info": "",
+          "property": ""
+        },
+        "date": "",
+        "org": "",
+        "description": null
       }]
     }
   }

--- a/styleguide/source/_patterns/05-pages/directive.json
+++ b/styleguide/source/_patterns/05-pages/directive.json
@@ -242,12 +242,12 @@
           "name": "Online",
           "hidden": "",
           "items": [{
-            "type": "online",
+            "type": "email",
             "property": "",
             "label":"Email:",
             "link": {
-              "href":"#",
-              "text": "person@email.com",
+              "href":"Rulesandregulations@DOR.State.MA.US",
+              "text": "Rulesandregulations@DOR.State.MA.US",
               "info": "",
               "property": ""
             },
@@ -304,11 +304,11 @@
           "name": "Online",
           "hidden": "",
           "items": [{
-            "type": "online",
+            "type": "email",
             "property": "",
             "label":"Email:",
             "link": {
-              "href":"#",
+              "href":"Rulesandregulations@DOR.State.MA.US",
               "text": "Rulesandregulations@DOR.State.MA.US",
               "info": "",
               "property": ""

--- a/styleguide/source/_patterns/05-pages/directive.json
+++ b/styleguide/source/_patterns/05-pages/directive.json
@@ -1,0 +1,384 @@
+{
+  "pageHeader": {
+    "category": "Directive",
+    "divider": false,
+    "title": "Directive 13-XX: Criteria for Determining Whether a Transaction is a Taxable Sale of Pre-written Software or a Non-taxable Service",
+    "subTitle": "",
+    "headerTags": {
+      "label": "Related to:",
+      "taxonomyTerms": [{
+        "href": "#",
+        "text": "Department of Revenue"
+      },{
+        "href": "#",
+        "text": "Rules & Regulations Bureau"
+      }]
+    },
+    "socialLinks": null,
+    "publishState": {
+      "text": "Draft"
+    },
+    "optionalContents": [{
+      "path": "@molecules/listing-table.twig",
+      "data": {
+        "listingTable": {
+          "rows": [{
+            "label": "Date:",
+            "text": "3/2/2017"
+          },{
+            "label": "Issuer:",
+            "text": "Mark E. Nunnelly, Commissioner of Revenue"
+          },{
+            "label": "Referenced Legistration:",
+            "text": "<a href=\"#\">M. G.L. c. 51, § 47C</a><br/><a href=\"#\">G.L. c. 64H, § 6</a>"
+          }]
+        }
+      }
+    },{
+      "path": "@organisms/by-author/rich-text.twig",
+      "data": {
+        "richText": {
+          "property": "",
+          "rteElements": [{
+            "path": "@atoms/11-text/paragraph.twig",
+            "data": {
+              "paragraph" : {
+                "text": "<b><i>This is a working draft for practitioner comment. Please contact the Rules and Regulations Bureau for feedback.</i></b>"
+              }
+            }
+          },{
+            "path": "@atoms/11-text/paragraph.twig",
+            "data": {
+              "paragraph" : {
+                "text": "Attached for public comment is a draft Directive that addresses the application of the Massachusetts sales and use tax to sales of software and computer related services. This Directive has been drafted in response to the large number of recent ruling requests pertaining to the Computer Industry Services and Products regulation,830 CMR 64H.1.3, particularly involving sales of \"Software as a Service,\" \"Cloud Computing,\" and so-called \"Business Solutions,\" all of which involve software, sometimes bundled with other non-taxable services.  Long established rules provide that software sales involving a tangible medium transferred to the customer are taxable; the focus of this Directive is on the taxation of software sales that involve remote access to software following the statutory change announced in TIR 05-15.  Given that the Department does not have the resources to individually rule on every product involving software, the Directive lists factors that DOR will use in determining if a sale is a taxable sale of software or a non-taxable sale of services. The factors will be considered cumulatively; no one factor is determinative of taxability."
+              }
+            }
+          }]
+        }
+      }
+    }],
+    "widgets": null
+  },
+   
+  "jumpLinks": {
+    "title": "In this Section",
+    "links": [{
+      "text": "Working Draft for Practitioner Comment",
+      "href": "working-draft"
+    },{
+      "text": "Another Section",
+      "href": "another-section"
+    },{
+      "text": "Downloads",
+      "href": "downloads"
+    },{
+      "text": "Contact",
+      "href": "contact"
+    }]
+  },
+
+  "mainContent": {
+    "contents": [{
+      "compHeading": {
+        "title": "Working Draft for Practitioner Comment",
+        "sub": false,
+        "color": "",
+        "id": "working-draft",
+        "centered": false
+      },
+      "rteElements": [{
+        "path": "@atoms/11-text/paragraph.twig",
+        "data": {
+          "paragraph" : {
+            "text": "<b>Sales & Use Tax - Directive 13-XX</b>"
+          }
+        }
+      },{
+        "path": "@atoms/11-text/paragraph.twig",
+        "data": {
+          "paragraph" : {
+            "text": "<b>Criteria for Determining Whether a Transaction is a Taxable Sale of Pre-written Software or a Non-taxable Service</b>"
+          }
+        }
+      },{
+        "path": "@atoms/11-text/paragraph.twig",
+        "data": {
+          "paragraph" : {
+            "text": "<b>Introduction:</b> This Directive is being issued in response to the large number of recent requests for guidance received by the Department of Revenue pertaining to the Computer Industry Services and Products regulation at 830 CMR 64H.1.3. That regulation explains the application of the Massachusetts sales and use taxes, G.L. c. 64H and G.L. c. 64I, to computer products and software and provides that taxable transfers of prewritten software include sales effected in any of the following ways regardless of the method of delivery (including electronic delivery or load and leave):  licenses, leases, transfers of rights to use software installed on a remote server, upgrades, and license upgrades. A taxable sale may involve a one-time payment or periodic payments, as in the case of transactions structured as a \"subscription.\""
+          }
+        }
+      },{
+        "path": "@atoms/11-text/paragraph.twig",
+        "data": {
+          "paragraph" : {
+            "text": "Long-established rules provide that software sales involving a tangible medium transferred to the customer are taxable.  In 2005, the Massachusetts sales/use tax definition of taxable tangible property was expanded to include software sales that do not involve transfers of or in a tangible medium. St. 2005, c. 163 §§ 27, 29, 34, 59, 61; see TIR 05-15.  The focus of this Directive is on the taxation of software sales that involve remote access to software following that statutory change, which became effective on April 1, 2006."
+          }
+        }
+      },{
+        "path": "@atoms/11-text/paragraph.twig",
+        "data": {
+          "paragraph" : {
+            "text": "Software-related products and the terminology used to describe and market them are evolving at a rapid rate.  As technology develops, purchasers increasingly have access to sophisticated software which is hosted on sellers’ or third party servers and marketed in various ways and with terminology that may be suggestive of the provision of services, e.g., as Software-as-a-Service, Cloud Computing, or \"business solutions\". Several recent Letter Rulings have addressed whether sales of various “business solutions” and products were taxable as sales of prewritten software or instead were non-taxable services.<a class=\"ma__rich-text__footnote js-rich-text-footnote\" id=\"footnoteref1\" title=\"source for this information\" href=\"#footnotemsg1\">1</a>"
+          }
+        }
+      },{
+        "path": "@atoms/11-text/paragraph.twig",
+        "data": {
+          "paragraph" : {
+            "text": "This Directive is meant to be a general guide for taxpayers, providing criteria the Commissioner considers when determining whether a transaction a taxable sale or other transfer of the right to use pre-written software or, instead, involves a product that is a non-taxable personal or professional service. The factors mentioned below will be considered cumulatively; no one factor is determinative of taxability. In those instances where both services and the right to use software may be integrated or bundled in one transaction, the Commissioner applies an “object of the transaction” test.  Where the object of the transaction is the purchase or use of the software, the transaction will be taxable.  Where the object of the transaction is determined to be a non-taxable service, and any use or access to pre-written software is incidental, the transaction will be non-taxable."
+          }
+        }
+      },{
+        "path": "@atoms/11-text/paragraph.twig",
+        "data": {
+          "paragraph" : {
+            "text": "<b>Issue 1:</b> What criteria indicate to the Commissioner that a transaction is a taxable transfer of pre-written software?"
+          }
+        }
+      },{
+        "path": "@atoms/11-text/paragraph.twig",
+        "data": {
+          "paragraph" : {
+            "text": "<b>Directive 1:</b> Factors that indicate that a transaction should be characterized as a taxable transfer of pre-written software include the following:"
+          }
+        }
+      },{
+        "path": "@atoms/08-lists/unordered-list.twig",
+        "data": {
+          "unorderedList": [{ 
+            "text": "A contract or written agreement provides for a transfer by license, sale, subscription, lease, or other means, of prewritten software for consideration."
+          },{ 
+            "text": "A customer can access a seller’s prewritten software on its own or the seller’s or a third party server, and can enter its own information, manipulate that information, and/or run reports.  (Mere search queries in a seller’s database are not considered \"entering information.\")"
+          },{ 
+            "text": "The seller provides the customer with the use of software that functions with little or no personal intervention by the seller or seller’s employees other than “help desk” assistance for customers having difficulty using the software."
+          },{
+            "text": "The seller refers to itself as an Application Service Provider (ASP) or its product as Software as a Service (SaaS) or in a similar manner, although the seller’s characterization of a product is not ultimately determinative of its treatment for tax purposes."
+          },{ 
+            "text": "The seller provides access to software, including operating system software or application software, even if no software is transferred to the customer; this may be referred to as \"cloud computing.\""
+          },{
+            "text": "The software provides an organizational tool or function that is used by customer, e.g., screen sharing."
+          },{ 
+            "text": "Pre-written software is bundled with a non-taxable service and sold for a single price, but only where the software constitutes the predominant value of the sale."
+          },{
+            "text": "The seller provides an application that is downloaded to any device, including but not limited to a Smart-phone, PC or Tablet, and there is a charge for the application."
+          }]
+        }
+      }]
+    },{
+      "compHeading": {
+        "title": "Another section",
+        "sub": false,
+        "color": "",
+        "id": "working-draft",
+        "centered": false
+      },
+      "rteElements": [{
+        "path": "@atoms/11-text/paragraph.twig",
+        "data": {
+          "paragraph" : {
+            "text": "Donec gravida posuere arcu. Nulla facilisi. Phasellus imperdiet. Vestibulum at metus. Integer euismod. Nullam placerat rhoncus sapien. Ut euismod. Praesent libero. Morbi pellentesque libero sit amet ante. Maecenas tellus. Maecenas erat. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas."
+          }
+        }
+      }]
+    }],
+
+    "formDownloads": {
+      "compHeading": {
+        "title": "Downloads",
+        "sub": false,
+        "color": "",
+        "id": "downloads",
+        "centered": ""
+      },
+      "downloadLinks": [{
+        "downloadLink": {
+          "iconSize": "",
+          "icon": "@atoms/05-icons/svg-doc-pdf.twig",
+          "decorativeLink": {
+            "text": "Signed, official copy of this document",
+            "href": "#",
+            "info": "",
+            "property": ""
+          },
+          "size": "1MB",
+          "format": "PDF"
+        }
+      }]
+    },
+
+    "contactList": {
+      "viewSpecific": false,
+      "compHeading":{
+        "title": "Contact",
+        "sub": false,
+        "color": "",
+        "id": "contact",
+        "centered": ""
+      },
+      "contacts":[{
+        "accordion": true,
+        "isExpanded": false,
+        "subTitle": {
+          "href":"",
+          "text": "Rules & Regulations Bureau"
+        },
+        "groups": [{
+          "icon": "@atoms/05-icons/svg-phone.twig",
+          "name": "Phone",
+          "items": [{
+            "type": "phone",
+            "property": "",
+            "label":"Main:",
+            "link": {
+              "href": "+17817401605",
+              "text": "(781) 740-1605",
+              "info": "",
+              "property": ""
+            },
+            "details":""
+          }]
+        },{
+          "icon": "@atoms/05-icons/svg-laptop.twig",
+          "name": "Online",
+          "hidden": "",
+          "items": [{
+            "type": "online",
+            "property": "",
+            "label":"Email:",
+            "link": {
+              "href":"#",
+              "text": "person@email.com",
+              "info": "",
+              "property": ""
+            },
+            "details":""
+          }]
+        }]
+      }]
+    },
+
+    "footnoteList": {
+      "items": [{
+        "number": 1,
+        "target": "#footnoteref1",
+        "id": "footnotemsg1",
+        "richText": {
+          "property": "",
+          "rteElements": [{
+            "path": "@atoms/11-text/paragraph.twig",
+            "data": {
+              "paragraph" : {
+                "text": "The Department has issued a number of recent Letter Rulings applying the rules in the Computer Industry Services and Products Regulation to specific factual situations, including: LR 12-13, Internet-Based Marketing and Customer-Communications Solutions, LR 12-11, Data Back-up and Restoration, LR 12-10, Screen-sharing Software and the Massachusetts Sales/Use Tax, LR 12-8, Cloud Computing, LR 12-6, Sales/Use Tax on Publishing Software, LR 12-5, MA Sales/Use Tax on Business Offerings to Physician Practice Customers, LR 12-4, Massachusetts Sales/Use Tax on “Call Tracking Service,”  LR 12-1, Teleconferencing Services, LR 11-4, MA Sales/Use Tax: On-line Services for Prospective Employees, LR 11-2, MA Sales/Use Tax: Sales of On-line Services, LR 10-1, Litigation Support Services."
+              }
+            }
+          }]
+        }
+      }]
+    },
+
+    "references": {
+      "label": "Referenced Legislation:",
+      "taxonomyTerms": [{
+        "href": "#",
+        "text": "M. G.L. c. 51, § 47C"
+      },{
+        "href": "#",
+        "text": "G.L. c. 64H, § 6"
+      }]
+    }
+  },
+
+  "sideContent": {
+    "contactList": {
+      "viewSpecific": true,
+      "sidebarHeading":{
+        "title": "Contact"
+      },
+      "contacts":[{
+        "subTitle": {
+          "href":"",
+          "text": "Rules & Regulations Bureau"
+        },
+        "groups": [{
+          "icon": "@atoms/05-icons/svg-laptop.twig",
+          "name": "Online",
+          "hidden": "",
+          "items": [{
+            "type": "online",
+            "property": "",
+            "label":"Email:",
+            "link": {
+              "href":"#",
+              "text": "Rulesandregulations@DOR.State.MA.US",
+              "info": "",
+              "property": ""
+            },
+            "details":""
+          }]
+        }]
+      }]
+    },
+
+    "pressListing": {
+      "sidebarHeading": {
+        "title": "Related"
+      },
+      "items": [{
+        "eyebrow": "Letter Ruling",
+        "title" : {
+          "url":"#",
+          "text":"LR 12-3: Internet-Based Marketing and Customer-Communications Solutions",
+          "info": "",
+          "property": ""
+        },
+        "date": "3/12/2016",
+        "org": "",
+        "description": null
+      },{
+        "eyebrow": "Regulation",
+        "title" : {
+          "url":"#",
+          "text":"830 CMR 64H.1.3",
+          "info": "",
+          "property": ""
+        },
+        "date": "4/17/2016",
+        "org": "",
+        "description": null
+      },{
+        "eyebrow": "",
+        "title" : {
+          "url":"#",
+          "text":"Related Non News, Announcements, Reg, or Law Here",
+          "info": "",
+          "property": ""
+        },
+        "date": "",
+        "org": "",
+        "description": null
+      }]
+    },
+
+    "eventListing": {
+      "sidebarHeading":{
+        "title": "Upcoming Events"
+      },
+      "events":[{
+        "title": {
+          "href": "#",
+          "text": "Public Hearing",
+          "info": "",
+          "property": ""
+        },
+        "location": "Boston, MA",
+        "date": {
+          "summary": "May 20, 2017" 
+        },
+        "time": "12 p.m. - 2 p.m.",
+        "description": "Event description. Ut nulla. Vivamus bibendum, nulla ut congue fringilla, lorem ipsum ultricies risus, ut rutrum velit tortor vel purus."
+      }],
+      "more": null
+    }
+  }
+}
+

--- a/styleguide/source/_patterns/05-pages/directive.twig
+++ b/styleguide/source/_patterns/05-pages/directive.twig
@@ -1,0 +1,18 @@
+{% extends '@templates/01-content-types/policy-advisory.twig' %}
+
+{% block header %}
+  {% include "@organisms/by-template/header.twig" %}
+{% endblock %}
+
+{% block pageContent %}{% endblock %}
+
+{% block sidebar %}{% endblock %}
+
+{% block postContent %}{% endblock %}
+
+
+{% block footer %}
+  {% include "@organisms/by-template/footer.twig" %}
+{% endblock %}
+
+

--- a/styleguide/source/assets/js/index.js
+++ b/styleguide/source/assets/js/index.js
@@ -5,6 +5,7 @@ import bannerCarousel   from "./modules/bannerCarousel.js";
 import clickable        from "./modules/clickable.js";
 import dropdown         from "./modules/dropdown.js";
 import emergencyAlerts  from "./modules/emergencyAlerts.js";
+import footnote         from "./modules/footnote.js";
 import formValidation   from "./modules/formValidation.js";
 import hideAlert        from "./modules/hideAlert.js";
 import keywordSearch    from "./modules/keywordSearch.js";

--- a/styleguide/source/assets/js/modules/footnote.js
+++ b/styleguide/source/assets/js/modules/footnote.js
@@ -1,0 +1,23 @@
+export default function (window,document,$,undefined) {
+
+  $('.js-footnote').each(function(){
+    let $el = $(this),
+        $link = $el.find(".js-footnote-link"),
+        $messageLink = $link.clone(),
+        target = $link.attr('href');
+
+    $messageLink.text('');
+
+    $el.find(".js-footnote-message p:last-child").append($messageLink);
+
+    $el.on('click','.js-footnote-link', function(e) {
+      e.preventDefault();
+
+      let position = $(target).offset();
+      
+      $("html,body").stop(true,true).animate({scrollTop:position.top}, '750', function(){
+        $(target).focus();
+      });
+    });
+  });
+}(window,document,jQuery);

--- a/styleguide/source/assets/js/modules/richText.js
+++ b/styleguide/source/assets/js/modules/richText.js
@@ -1,5 +1,23 @@
 export default function (window,document,$,undefined) {
 
-  $('.js-ma-rich-text table').wrap( "<div class='ma__rich-text__table-wrapper'></div>" );
+  $('.js-ma-rich-text').each(function(){
+    let $el = $(this);
 
+    $el.find('table').wrap( "<div class='ma__rich-text__table-wrapper'></div>" );
+
+    $el.find('.js-rich-text-footnote').each(function() {
+      let $link = $(this),
+          target = $link.attr('href');
+      
+      $link.on('click',function(e) {
+        e.preventDefault();
+
+        let position = $(target).offset();
+        
+        $("html,body").stop(true,true).animate({scrollTop:position.top}, '750', function(){
+          $(target).focus();
+        });
+      });
+    });
+  });
 }(window,document,jQuery);

--- a/styleguide/source/assets/scss/01-atoms/_publish-state.scss
+++ b/styleguide/source/assets/scss/01-atoms/_publish-state.scss
@@ -1,0 +1,25 @@
+.ma__publish-state {
+  font-size: 2rem;
+  text-transform: uppercase;
+  letter-spacing: .09em;
+
+  @media ($bp-small-min) {
+    font-size: 3rem;
+  }
+
+  .pre-content > &,
+  .post-content > &,
+  .main-content--full .page-content > & {
+    @include ma-container;
+  }
+
+  &:before {
+    content: "\2013";
+    margin-right: .25em;
+  }
+
+  &:after {
+    content: "\2013";
+    margin-left: .25em;
+  }
+}

--- a/styleguide/source/assets/scss/01-atoms/_sidebar-heading.scss
+++ b/styleguide/source/assets/scss/01-atoms/_sidebar-heading.scss
@@ -2,6 +2,7 @@
   border-bottom: 2px solid;
   font-size: 1.188rem;
   letter-spacing: .09em;
+  padding-top: .75em;
   padding-bottom: .5em;
   text-transform: uppercase;
 }

--- a/styleguide/source/assets/scss/02-molecules/_contact-us.scss
+++ b/styleguide/source/assets/scss/02-molecules/_contact-us.scss
@@ -5,6 +5,13 @@
     border-top-style: solid;
     margin-top: 30px;
     padding-top: 30px;
+
+    @media ($bp-large-min){
+      .sidebar & {
+        margin-top: 20px;
+        padding-top: 20px;
+      }
+    }
   }
 
   &--accordion {

--- a/styleguide/source/assets/scss/02-molecules/_footnote.scss
+++ b/styleguide/source/assets/scss/02-molecules/_footnote.scss
@@ -1,0 +1,42 @@
+.ma__footnote {
+  position: relative;
+
+  & + & {
+    margin-top: 30px;
+  }
+
+  & > &__link {
+    border-width: 1px;
+    border-style: solid;
+    font-size: .8rem;
+    line-height: 1;
+    padding: .05em .35em .05em .25em;
+    position: absolute;
+      top: 5px;
+      left: 0;
+  }
+
+  &__rich-text {
+    font-size: 1.25rem;
+    padding-left: 30px;
+  }
+
+  &__rich-text &__link {
+    border: none;
+    margin-left: .25em;
+    transition: all 0.4s ease;
+
+    &:hover {
+      border: none;
+      margin-left: 0;
+      opacity: .7;
+    }
+
+    &:after {
+      content: "\0021A9";
+      cursor: pointer;
+      line-height: 1;
+      padding: .25em;
+    }
+  }
+}

--- a/styleguide/source/assets/scss/02-molecules/_listing-table.scss
+++ b/styleguide/source/assets/scss/02-molecules/_listing-table.scss
@@ -18,6 +18,12 @@
     }
   }
 
+  tbody {
+    @media ($bp-small-max) {
+      display: block;
+    }
+  }
+
   tr {
     @media ($bp-small-max) {
       display: block;
@@ -31,11 +37,13 @@
 
   td, th {
     font-size: 16px;
-    line-height: 1.5rem;
+    line-height: 1.5;
     padding: 10px 0;
+    vertical-align: top;
 
     @media ($bp-small-max) {
       display: block;
+      line-height: 1.25;
     }
   }
 

--- a/styleguide/source/assets/scss/02-molecules/_press-teaser.scss
+++ b/styleguide/source/assets/scss/02-molecules/_press-teaser.scss
@@ -13,8 +13,8 @@
 
     @media ($bp-large-min){
       .sidebar & {
-        margin-top: 25px;
-        padding-top: 25px;
+        margin-top: 20px;
+        padding-top: 20px;
       }
     }
   }

--- a/styleguide/source/assets/scss/03-organisms/_event-listing.scss
+++ b/styleguide/source/assets/scss/03-organisms/_event-listing.scss
@@ -22,6 +22,13 @@
     border-top-width: 1px;
     margin-top: 30px;
     padding-top: 30px;
+
+    @media ($bp-large-min){
+      .sidebar & {
+        margin-top: 20px;
+        padding-top: 20px;
+      }
+    }
   }
 
   &__more {

--- a/styleguide/source/assets/scss/03-organisms/_footnote-list.scss
+++ b/styleguide/source/assets/scss/03-organisms/_footnote-list.scss
@@ -1,0 +1,14 @@
+.ma__footnote-list {
+
+  .pre-content > &,
+  .post-content > &,
+  .main-content--full .page-content > & {
+    @include ma-container('restricted');
+  }
+
+  &__container {
+    border-top-style: dotted;
+    border-top-width: 2px;
+    padding-top: 30px;
+  }
+}

--- a/styleguide/source/assets/scss/03-organisms/_jump-links.scss
+++ b/styleguide/source/assets/scss/03-organisms/_jump-links.scss
@@ -14,7 +14,7 @@
   &__inner {
 
     @media ($bp-small-min) {
-      padding-bottom: 45px;
+      padding-bottom: 35px;
     }
   }
 
@@ -34,6 +34,10 @@
 
     @media ($bp-small-max) {
       display: none;
+    }
+
+    @media ($bp-small-min) {
+      margin-bottom: 15px;
     }
   }
 

--- a/styleguide/source/assets/scss/03-organisms/_page-header.scss
+++ b/styleguide/source/assets/scss/03-organisms/_page-header.scss
@@ -142,6 +142,11 @@ $page-header-widget-width: 350px;
     }
   }
 
+  &__publish-state {
+    margin-top: -20px;
+    margin-bottom: 35px;
+  }
+
   &__category {
     font-size: 1.5rem;
     font-weight: 700;

--- a/styleguide/source/assets/scss/03-organisms/_rich-text.scss
+++ b/styleguide/source/assets/scss/03-organisms/_rich-text.scss
@@ -25,6 +25,23 @@ $rich-text-spacing-mobile: 1.5rem;
     padding-right: 0;
   }
 
+  // extra specificity was needed to override & a { ... }
+  & &__footnote {
+    border-style: solid;
+    border-width: 1px;
+    font-size: .6em;
+    line-height: 1;
+    padding: 0 .3em;
+    position: relative;
+      top: .25em;
+    vertical-align: top;
+    transition: all ease .4s;
+
+    &:hover {
+      border-width: 1px;
+    }
+  }
+
   // rich text has an optional title
   h2:not(.ma__comp-heading),
   h3:not(.ma__comp-heading),

--- a/styleguide/source/assets/scss/06-theme/01-atoms/_publish-state.scss
+++ b/styleguide/source/assets/scss/06-theme/01-atoms/_publish-state.scss
@@ -1,0 +1,4 @@
+.ma__publish-state {
+  color: $c-font-medium;
+  font-weight: 800;
+}

--- a/styleguide/source/assets/scss/06-theme/02-molecules/_footnote.scss
+++ b/styleguide/source/assets/scss/06-theme/02-molecules/_footnote.scss
@@ -1,0 +1,11 @@
+.ma__footnote {
+
+  & > &__link {
+    border-color: rgba($c-font-link,.5);
+
+    &:hover {
+      background-color: $c-font-link;
+      color: $c-font-inverse;
+    }
+  }
+}

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_footnote-list.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_footnote-list.scss
@@ -1,0 +1,6 @@
+.ma__footnote-list {
+
+  &__container {
+    border-top-color: $c-bd-divider;
+  }
+}

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_rich-text.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_rich-text.scss
@@ -1,4 +1,14 @@
 .ma__rich-text {
+  
+  &__footnote {
+    border-color: rgba($c-font-link,.5);
+
+    &:hover {
+      background-color: $c-font-link;
+      color: $c-font-inverse;
+    }
+  }
+
   h2, h3, h4 {
     @include ma-comp-heading($c-theme-secondary);
   }

--- a/styleguide/source/assets/scss/base-theme.scss
+++ b/styleguide/source/assets/scss/base-theme.scss
@@ -96,6 +96,7 @@
 @import "06-theme/03-organisms/event-listing";
 @import "06-theme/03-organisms/feedback-form";
 @import "06-theme/03-organisms/footer";
+@import "06-theme/03-organisms/footnote-list";
 @import "06-theme/03-organisms/header";
 @import "06-theme/03-organisms/header-alert";
 @import "06-theme/03-organisms/icon-links";

--- a/styleguide/source/assets/scss/base-theme.scss
+++ b/styleguide/source/assets/scss/base-theme.scss
@@ -55,6 +55,7 @@
 @import "06-theme/02-molecules/event-filters";
 @import "06-theme/02-molecules/event-teaser";
 @import "06-theme/02-molecules/footer-links";
+@import "06-theme/02-molecules/footnote";
 @import "06-theme/02-molecules/header-contact";
 @import "06-theme/02-molecules/header-search";
 @import "06-theme/02-molecules/header-tags";

--- a/styleguide/source/assets/scss/base-theme.scss
+++ b/styleguide/source/assets/scss/base-theme.scss
@@ -29,6 +29,7 @@
 @import "06-theme/01-atoms/figure";
 @import "06-theme/01-atoms/forms";
 @import "06-theme/01-atoms/icon-list";
+@import "06-theme/01-atoms/publish-state";
 @import "06-theme/01-atoms/select-box";
 @import "06-theme/01-atoms/sidebar-heading";
 @import "06-theme/01-atoms/video";

--- a/styleguide/source/assets/scss/index.scss
+++ b/styleguide/source/assets/scss/index.scss
@@ -107,6 +107,7 @@
 @import "03-organisms/event-listing";
 @import "03-organisms/feedback-form";
 @import "03-organisms/footer";
+@import "03-organisms/footnote-list";
 @import "03-organisms/form-downloads";
 @import "03-organisms/header";
 @import "03-organisms/header-alert";

--- a/styleguide/source/assets/scss/index.scss
+++ b/styleguide/source/assets/scss/index.scss
@@ -33,6 +33,7 @@
 @import "01-atoms/figure";
 @import "01-atoms/forms";
 @import "01-atoms/icon-list";
+@import "01-atoms/publish-state";
 @import "01-atoms/select-box";
 @import "01-atoms/sidebar-heading";
 @import "01-atoms/site-logo";

--- a/styleguide/source/assets/scss/index.scss
+++ b/styleguide/source/assets/scss/index.scss
@@ -62,6 +62,7 @@
 @import "02-molecules/event-teaser";
 @import "02-molecules/field-submit";
 @import "02-molecules/footer-links";
+@import "02-molecules/footnote";
 @import "02-molecules/google-map";
 @import "02-molecules/header-contact";
 @import "02-molecules/header-search";


### PR DESCRIPTION
https://jira.state.ma.us/browse/DP-3825

Goal of this ticket was to create a Directive page using a Policy Advisory content type.

New Patterns:
1. Policy Advisory content type
2. Directive page
3. Footnote molecule
4. Footnote List organism
5. Published State atom

Changes to existing patterns:
1. Listing Table - Allowing rich text to be used in the description field ( |raw )
2. Page Header - added option for published state
3. Rich Text - styling for footnote links
4. Adjusted the spacing of list items in the right rail to match.

Fixes:
1. Updated content on Press content type to match the Press Listing organism used
2. Jump Link - updating padding to properly match designs
3. 