### PR TITLE
SP-3561 Change the suggested page from Related Parks to Related Locations

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.json
@@ -1,6 +1,6 @@
 {
   "suggestedPages": {
-    "title": "Related Parks",
+    "title": "Related Locations",
     "view":"",
     "buttonMinor" : {
       "href": "#",

--- a/styleguide/source/_patterns/05-pages/location-park-content.json
+++ b/styleguide/source/_patterns/05-pages/location-park-content.json
@@ -714,7 +714,7 @@
   "COMMENT":"****POSTCONTENT COMPONENTS****",
 
   "suggestedPages": {
-    "title": "Related Parks",
+    "title": "Related Locations",
     "buttonMinor" : {
       "href": "#",
       "text": "Do Something"


### PR DESCRIPTION
Per a request from Harlan in the JIRA ticket was to change the suggested locations section title from "Related Parks" to "Related Location". The reason being for this change is that area could be used for other locations not just Park pages.

Jira Ticket:  https://jira.state.ma.us/browse/DP-3561

To review `http://localhost:3000/?p=organisms-suggested-pages` and `http://localhost:3000/?p=pages-location-park-content`
