### PR TITLE
DP-2352 Fix link word breaks in Firefox

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_content-link.scss
+++ b/styleguide/source/assets/scss/01-atoms/_content-link.scss
@@ -3,6 +3,7 @@
   overflow-wrap: break-word;
   word-wrap: break-word;
   word-break: break-word;
+  max-width: 100%;
 
   &--chevron {
     @include ma-chevron;


### PR DESCRIPTION
Without a width or max-width constraint, Firefox prefers to let a link get wider rather than breaking a word, even when CSS rules dictate otherwise. This can be demonstrated in Mayflower by viewing the Contact Group molecule and editing one the text in Inspector/dev tools so a phone number link has a very long word, then putting a width limit on an ancestor element (for example, `ma__contact-group`). I've done this, with the addition of a background color, for demonstration purposes in the screenshot below.

![wrapping](https://user-images.githubusercontent.com/18170074/27051334-b69469f8-4f83-11e7-8425-d2f1a8c29d86.png)

To fix, this, I’ve added a `max-width: 100%` to `.ma__content-link` where the word break rules are applied. This provides a good base rule to prevent the link from breaking out of its container when that's an issue, and should be fairly innocuous when it isn't an issue.