### PR TITLE
Comp Heading - fixing incorrect logic for centering text

### DIFF
--- a/styleguide/source/_patterns/01-atoms/04-headings/comp-heading.twig
+++ b/styleguide/source/_patterns/01-atoms/04-headings/comp-heading.twig
@@ -3,7 +3,7 @@
 {% endif %}
 
 {# string value is backward compatible for v5.0.0 #}
-{% if compHeading.centered or compHeading.centered == 'true' %}
+{% if compHeading.centered == true or compHeading.centered == 'true' %}
   {% set centered = "ma__comp-heading--centered" %}
 {% endif %}
 


### PR DESCRIPTION
Original code to determine centering would see the string value "false" as a truthie value.

{# string value is backward compatible for v5.0.0 #}
{% if compHeading.centered or compHeading.centered == 'true' %}
  {% set centered = "ma__comp-heading--centered" %}
{% endif %}

