### PR TITLE
DP-3236 Callout Alert conditionally adds js-clickable class

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-author/callout-alert.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/callout-alert.twig
@@ -1,6 +1,6 @@
 {% set calloutAlert = calloutAlert.decorativeLink %}
 
-<section class="ma__callout-alert js-clickable">
+<section class="ma__callout-alert {{ calloutAlert.href ? 'js-clickable' : ''}}">
   {% if calloutAlert.href %}
     <a class="ma__callout-alert__content" 
       href="{{ calloutAlert.href }}"


### PR DESCRIPTION
https://jira.state.ma.us/browse/DP-3236

Callout Alerts have optional links, but the `js-clickable` class was being added whether there was actually a link or not. In cases where there wasn't a link, the alert was still clickable, but clicking it caused issues.

Simple fix: add the link conditionally.