### PR TITLE
DP-4026 Fixed background-repeat issue with illustrated link

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_illustrated-link.scss
+++ b/styleguide/source/assets/scss/02-molecules/_illustrated-link.scss
@@ -65,6 +65,7 @@ $illustrated-link-image-width: 130px;
   &__image {
     background-position: center right;
     background-size: cover;
+    background-repeat: no-repeat;
     width: $illustrated-link-image-width;
     flex-grow: 0;
     flex-shrink: 0;


### PR DESCRIPTION
https://jira.state.ma.us/browse/DP-4026

Some background images were visible in a 1px column on the right side of the illustrated link. Setting background to `no-repeat` fixes this.