### PR TITLE
DP-3227 Contact Group passes item info into link

### DIFF
--- a/styleguide/source/_patterns/02-molecules/contact-group.twig
+++ b/styleguide/source/_patterns/02-molecules/contact-group.twig
@@ -12,7 +12,7 @@
       {% set link = {
         "href": item.link,
         "text": item.type == "address" ? "directions" : item.value,
-        "info": "",
+        "info": item.info,
         "property": item.type == "address" ? "url" : item.property
       } %}
     {% else %}


### PR DESCRIPTION
Passes `item.info` into the link object used for contact group items. Without this, text for screen readers can't be provided to these links.

The issue isn't immediately obvious when reviewing the style guide because Mayflower's sample JSON files use the new data model. When the old data model is used, however, the it causes issues.