### PR TITLE
DP-3235 Added aria label for downloads links

### DIFF
--- a/styleguide/source/_patterns/02-molecules/download-link.twig
+++ b/styleguide/source/_patterns/02-molecules/download-link.twig
@@ -14,7 +14,8 @@
     {% else %}
       <a 
         class="ma__download-link__file-link" 
-        href="{{ downloadLink.decorativeLink.href}}">
+        href="{{ downloadLink.decorativeLink.href}}"
+        aria-label="Open {{ downloadLink.format?: '' }} file for {{ downloadLink.decorativeLink.text }}">
           {{ downloadLink.decorativeLink.text }}
       </a>
       {% if downloadLink.format or downloadLink.size %}


### PR DESCRIPTION
The file format icon and label, and the frequent proximity to Downloads headlines, make the purpose of these links more evident to sighted users. For screen readers, the purpose is less intuitive, particularly if files aren't well-named. This resolves this issue by adding an aria label which makes it clear that this will open a file. The file format is included in the label if available.