### PR TITLE
DP-3199: Allow maps to be keyboard accessible

### DIFF
--- a/styleguide/source/assets/js/modules/googleMap.js
+++ b/styleguide/source/assets/js/modules/googleMap.js
@@ -59,6 +59,39 @@ export default function (window,document,$,undefined) {
       // Trigger map initialized event, broadcast master markers.
       $el.trigger('ma:GoogleMap:MapInitialized', [markers]);
 
+      // Add keyboard navigation only after the map is rendered (becoming idle).
+      google.maps.event.addListenerOnce(map, 'idle', function() {
+        let $mapItems = $(".js-google-map").find(
+          'div[title="Show street map"],' +
+          'div[title="Show street map with terrain"],' +
+          'div[title="Show satellite imagery"],' +
+          'div[title="Zoom in to show 45 degree view"],' +
+          'div[title="Show imagery with street names"],' +
+          'div[title="Pan up"],' +
+          'div[title="Pan down"],' +
+          'div[title="Pan left"],' +
+          'div[title="Pan right"],' +
+          'div[title="Return to the last result"],' +
+          'div[title="Zoom in"],' +
+          'div[title="Zoom out"],' +
+          'img[title="Rotate map 90 degrees"],' +
+          '.gmnoprint area'
+        );
+        $mapItems.each(function(i, o){
+          $(o).attr({
+            role: 'button',
+            tabindex: '0',
+            'aria-label': o.title
+          }).bind('keydown', function(ev){
+            // If enter is pressed on one of these elements, trigger a click of the element.
+            if (ev.which == 13){
+              ev.preventDefault();
+              $(o).trigger('click');
+            }
+          });
+        });
+      });
+
       // Listen for map recenter event
       $el.on("ma:GoogleMap:MapRecenter", function (event, markerIndex) {
         if (typeof markers[markerIndex] === "undefined") {
@@ -129,6 +162,7 @@ export default function (window,document,$,undefined) {
         }),
         label: data.label,
         infoWindow: data.infoWindow,
+        title: 'Marker: ' + data.infoWindow.name
       };
       let marker =  new google.maps.Marker(markerData);
       let infoData = infoTransform(markerData.infoWindow);


### PR DESCRIPTION
This adds a role, tabindex, and aria-label to google map buttons and markers and adds an event listener to trigger a click if enter is pressed.  I believe there will be more work in order to make maps fully accessible, but this is a step in that direction.

Related to JIRA ticket: https://jira.state.ma.us/browse/DP-3199

To test:

- [ ] Pull the branch down and build locally.
- [ ] Navigate to the map organism: http://localhost:3000/patterns/03-organisms-by-author-mapped-locations/03-organisms-by-author-mapped-locations.html.
- [ ] Use your tab and shift tab to go through the items in the map.
- [ ] There is no indicator when markers gain focus, but if you enter on either of the two tabs past the "See a list of all locations ->" link, you should see the marker open to show the information block.
- [ ] You should be able to tab to and enter on the + or - zoom buttons.  
- [ ] You should be able to press enter on 'Satellite' to switch to satellite view.
- [ ] Shift tab from satellite view and press enter to return to the map view.

**Note: this does not cover being able to do keyboard navigation for the street view (small orange person icon).** 