### PR TITLE
DP-4042 - Page Banner - fixing description message on service page

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-template/page-banner.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/page-banner.twig
@@ -1,13 +1,6 @@
-{% if pageBanner.size %}
-  {% set sizeClass = "ma__page-banner--" ~ pageBanner.size %}
-{% endif %}
+{% set sizeClass = pageBanner.size ? "ma__page-banner--" ~ pageBanner.size : '' %}
 
-{% if pageBanner.color %}
-  {% set colorClass = "ma__page-banner--" ~ pageBanner.color %}
-{% endif %}
-
-{# adding ma__page-banner--child shows a different version #}
-
+{% set colorClass = pageBanner.color ? "ma__page-banner--" ~ pageBanner.color : '' %}
 
 <section class="ma__page-banner {{ sizeClass }} {{ colorClass }}">
   {% if pageBanner.size == "columns" %}
@@ -51,13 +44,13 @@
           <span> {{ pageBanner.titleSubText }}</span>
         {% endif %}
       </h1>
-      {% if pageBanner.description and ( pageBanner.size and not pageBanner.size == "columns" ) %}
+      {% if pageBanner.description and not pageBanner.size == "columns" %}
         <p class="ma__page-banner__description">
           {{ pageBanner.description }}
         </p>
       {% endif %}
     </div>
-    {% if pageBanner.description and ( pageBanner.size and pageBanner.size == "columns" ) %}
+    {% if pageBanner.description and pageBanner.size == "columns" %}
       <p class="ma__page-banner__description">
         {{ pageBanner.description }}
       </p>

--- a/styleguide/source/assets/scss/03-organisms/_page-banner.scss
+++ b/styleguide/source/assets/scss/03-organisms/_page-banner.scss
@@ -46,6 +46,7 @@ $page-banner-icon-width: $column + $gutter;
   }
 
   &--columns &__container {
+    @include clearfix;
     height: auto;
     min-height: 450px;
   }


### PR DESCRIPTION
The Page Banner was assuming that pageBanner.size was always set to a value when determining whether or not to show the description.  On the service page that variable was not set to a value causing the conditional in incorrectly fail.

I also corrected how the class variables were being set to make sure a value was always set even if it was '' to prevent inheriting values from other patterns.