### PR TITLE
DP-3195 Improve keyboard navigation of main menu

### DIFF
--- a/styleguide/source/_patterns/02-molecules/main-nav.twig
+++ b/styleguide/source/_patterns/02-molecules/main-nav.twig
@@ -5,15 +5,15 @@
       {% set menuId =  'menu' ~ loop.index %}
       <li class="ma__main-nav__item {{ nav.active ? 'is-active' : '' }} {{ nav.subNav ? 'has-subnav js-main-nav-toggle' : 'js-main-nav-top-link' }}">
         {% if nav.subNav %}
-          <button id="{{ buttonId }}" class="ma__main-nav__top-link" aria-haspopup="true" aria-expanded="false" aria-controls="{{ menuId }}">{{ nav.text }}</button>
+          <button id="{{ buttonId }}" class="ma__main-nav__top-link" aria-haspopup="true" aria-expanded="false" aria-controls="{{ menuId }}" tabindex="{{ loop.first? 0 : -1 }}">{{ nav.text }}</button>
           <div class="ma__main-nav__subitems js-main-nav-content is-closed">
             <ul id="{{ menuId }}" role="menu" aria-labelledby="{{ buttonId }}" class="ma__main-nav__container">
-              <li role="menuitem" class="ma__main-nav__subitem"><a href="{{ nav.href }}" class="ma__main-nav__link">{{ nav.text }}</a></li>
+              <li role="menuitem" class="ma__main-nav__subitem"><a href="{{ nav.href }}" class="ma__main-nav__link" tabindex="-1">{{ nav.text }}</a></li>
               {% for subNav in nav.subNav %}
-                <li role="menuitem" class="ma__main-nav__subitem"><a href="{{ subNav.href }}" class="ma__main-nav__link">{{ subNav.text }}</a></li>
+                <li role="menuitem" class="ma__main-nav__subitem"><a href="{{ subNav.href }}" class="ma__main-nav__link" tabindex="-1">{{ subNav.text }}</a></li>
               {% endfor %}
               <li role="menuitem" class="ma__main-nav__subitem">
-                <a href="{{ nav.href }}" class="ma__main-nav__link">
+                <a href="{{ nav.href }}" class="ma__main-nav__link" tabindex="-1">
                   {% include "@atoms/05-icons/svg-arrow-bent.twig" %}
                   <span>{{ nav.text }}</span>
                 </a>
@@ -21,7 +21,7 @@
             </ul>
           </div>
         {% else %}
-          <button id="{{ buttonId }}" class="ma__main-nav__top-link">{{ nav.text }}</button>
+          <button id="{{ buttonId }}" class="ma__main-nav__top-link" tabindex="{{ loop.first? 0 : -1 }}">{{ nav.text }}</button>
         {% endif %}
       </li>
     {% endfor %}

--- a/styleguide/source/assets/js/modules/mainNav.js
+++ b/styleguide/source/assets/js/modules/mainNav.js
@@ -33,34 +33,42 @@ export default function (window,document,$,undefined) {
           $topLevelLink = $topLevelItem.find('.ma__main-nav__top-link'),
           $dropdownLinks = $link.find('.ma__main-nav__subitem .ma__main-nav__link'),
           dropdownLinksLength = $dropdownLinks.length,
-          focusIndexInDropdown = $dropdownLinks.index($focusedElement),
-          isShift = !!e.shiftKey; // typecast to boolean
+          focusIndexInDropdown = $dropdownLinks.index($focusedElement);
 
-      // up/down arrows or tab key
-      if(e.keyCode === 40 || e.keyCode === 38 || e.keyCode === 9) {
+      // tab key
+      if(e.keyCode === 9) {
+        // Close any currently-open menu
+        hide($openContent);
+        $link.removeClass(openClass);
+        $topLevelLink.attr('aria-expanded','false');
+        return;
+      }
+
+      // up/down arrows
+      if(e.keyCode === 40 || e.keyCode === 38) {
         e.preventDefault();
         // If menubar focus
         //  - Open pull down menu and select appropriate menu item
         //
         // If dropdown focus
         //  - Change selected menu item
-        let up = e.keyCode === 38 || (e.keyCode === 9 && isShift);
         if(!open) {
           show($topLevelItem.find('.js-main-nav-content'));
           $topLevelLink.focus().attr('aria-expanded', 'true');
           $link.addClass(openClass);
         }
-        if(up) {
+        // Up arrow was used
+        if(e.keyCode === 38) {
           if(focusIndexInDropdown <= 1 ) {
             focusIndexInDropdown = dropdownLinksLength;
           }
           $dropdownLinks[focusIndexInDropdown-1].focus();
         } else {
           // If focused element isn't in dropdown, start with the 0th item instead.
-          let newIndex = Math.max(0, focusIndexInDropdown);
+          focusIndexInDropdown = Math.max(0, focusIndexInDropdown);
           // Focus should wrap around at end of list. Skip 0th item.
-          newIndex = Math.max(1, (newIndex + 1) % dropdownLinksLength);
-          $dropdownLinks[newIndex].focus();
+          focusIndexInDropdown = Math.max(1, (focusIndexInDropdown + 1) % dropdownLinksLength);
+          $dropdownLinks[focusIndexInDropdown].focus();
         }
         return;
       }

--- a/styleguide/source/assets/js/modules/mainNav.js
+++ b/styleguide/source/assets/js/modules/mainNav.js
@@ -32,6 +32,7 @@ export default function (window,document,$,undefined) {
           $topLevelItem = $focusedElement.parents('.ma__main-nav__item'),
           $topLevelLink = $topLevelItem.find('.ma__main-nav__top-link'),
           $dropdownLinks = $link.find('.ma__main-nav__subitem .ma__main-nav__link'),
+          dropdownLinksLength = $dropdownLinks.length,
           focusIndexInDropdown = $dropdownLinks.index($focusedElement),
           isShift = !!e.shiftKey; // typecast to boolean
 
@@ -44,52 +45,40 @@ export default function (window,document,$,undefined) {
         // If dropdown focus
         //  - Select next menu item
         e.preventDefault();
-        if(open) {
-          if(focusIndexInDropdown === ($dropdownLinks.length-1) ) {
-            return;
-          } else {
-            if(focusIndexInDropdown === -1) {
-              $dropdownLinks[1].focus();
-            } else {
-              $dropdownLinks[focusIndexInDropdown+1].focus();
-            }
-            return;
-          }
-        } else {
+        if(!open) {
           show($topLevelItem.find('.js-main-nav-content'));
           $topLevelLink.attr('aria-expanded', 'true');
           $link.addClass(openClass);
-          if($dropdownLinks[1]) {
-            $dropdownLinks[1].focus();
-          }
-          return;
         }
+        // If focused element isn't in dropdown, start with the 0th item instead.
+        let newIndex = Math.max(0, focusIndexInDropdown);
+        // Focus should wrap around at end of list. Skip 0th item.
+        newIndex = Math.max(1, (newIndex + 1) % dropdownLinksLength);
+        $dropdownLinks[newIndex].focus();
+        return;
       }
 
        // up arrow or shift+tab keys
        if((e.keyCode === 38) || (e.keyCode === 9 && isShift)) {
         // hide content
         // If menubar focus
-        //  - Open pull down menu and select first menu item
+        //  - Open pull down menu and select last menu item
         //
         // If dropdown focus
         //  - Select previous menu item
         e.preventDefault();
-        if(open) {
-          if(focusIndexInDropdown <= 1 ) { // not 0 bc of hidden first link
-            hide($openContent);
-            $topLevelLink.focus().attr('aria-expanded', 'false');
-            return;
-          } else {
-            $dropdownLinks[focusIndexInDropdown-1].focus();
-            return;
-          }
-        } else {
+        if(!open) {
           show($topLevelItem.find('.js-main-nav-content'));
           $topLevelLink.focus().attr('aria-expanded', 'true');
           $link.addClass(openClass);
-          return;
         }
+        // If focused element isn't in dropdown, or is 0th (hidden) or 1st item,
+        // it needs to wrap around to the last element.
+        if(focusIndexInDropdown <= 1 ) {
+          focusIndexInDropdown = dropdownLinksLength;
+        }
+        $dropdownLinks[focusIndexInDropdown-1].focus();
+        return;
       }
 
       // esc key
@@ -114,9 +103,9 @@ export default function (window,document,$,undefined) {
         hide($openContent);
         $topLevelLink.attr('aria-expanded','false');
         let index = $topLevelLinks.index($topLevelLink)-1;
-        if($topLevelLinks[index]) {
-          $topLevelLinks[index].focus();
-        }
+        let linkCount = $topLevelLinks.length;
+        index = ((index % linkCount) + linkCount) % linkCount;
+        $topLevelLinks[index].focus();
         return;
 
       }
@@ -132,9 +121,9 @@ export default function (window,document,$,undefined) {
         hide($openContent);
         $topLevelLink.attr('aria-expanded','false');
         let index = $topLevelLinks.index($topLevelLink)+1;
-        if($topLevelLinks[index]) {
-          $topLevelLinks[index].focus();
-        }
+        let linkCount = $topLevelLinks.length;
+        index = ((index % linkCount) + linkCount) % linkCount;
+        $topLevelLinks[index].focus();
         return;
       }
 

--- a/styleguide/source/assets/js/modules/mainNav.js
+++ b/styleguide/source/assets/js/modules/mainNav.js
@@ -13,7 +13,6 @@ export default function (window,document,$,undefined) {
         $parent = $(this),
         $mainNavToggle = $parent.find('.js-main-nav-toggle'),
         $mainNavItems = $parent.find('.js-main-nav-toggle, .js-main-nav-top-link'),
-        previousKey = null,
         breakpoint = 800; // matches CSS breakpoint for Main Nav
 
     $mainNavItems.on('keydown', function(e) {
@@ -23,15 +22,24 @@ export default function (window,document,$,undefined) {
           open = $link.hasClass(openClass),
           $openContent = $parent.find('.js-main-nav-content.' + openClass),
           $focusedElement = $(document.activeElement),
+          keycode = e.keyCode,
       // relevant if open..
           $topLevelItem = $focusedElement.parents('.ma__main-nav__item'),
           $topLevelLink = $topLevelItem.find('.ma__main-nav__top-link'),
           $dropdownLinks = $link.find('.ma__main-nav__subitem .ma__main-nav__link'),
           dropdownLinksLength = $dropdownLinks.length,
-          focusIndexInDropdown = $dropdownLinks.index($focusedElement);
+          focusIndexInDropdown = $dropdownLinks.index($focusedElement),
+          action = {
+            'skip': keycode === 9,
+            'close': keycode === 27,
+            'left': keycode === 37,
+            'right': keycode === 39,
+            'up': keycode === 38,
+            'down': keycode === 40
+          };
 
       // tab key
-      if(e.keyCode === 9) {
+      if(action.skip) {
         // Close any currently-open menu
         hide($openContent);
         $link.removeClass(openClass);
@@ -40,7 +48,7 @@ export default function (window,document,$,undefined) {
       }
 
       // up/down arrows
-      if(e.keyCode === 40 || e.keyCode === 38) {
+      if(action.up || action.down) {
         e.preventDefault();
         // If menubar focus
         //  - Open pull down menu and select appropriate menu item
@@ -52,8 +60,7 @@ export default function (window,document,$,undefined) {
           $topLevelLink.attr('aria-expanded', 'true');
           $link.addClass(openClass);
         }
-        // Up arrow was used
-        if(e.keyCode === 38) {
+        if(action.up) {
           if(focusIndexInDropdown <= 1 ) {
             focusIndexInDropdown = dropdownLinksLength;
           }
@@ -70,7 +77,7 @@ export default function (window,document,$,undefined) {
       }
 
       // esc key
-      if(e.keyCode === 27) {
+      if(action.close) {
         // Close menu and return focus to menubar
         e.preventDefault();
         hide($openContent);
@@ -80,9 +87,8 @@ export default function (window,document,$,undefined) {
       }
 
       // left or right arrow keys
-      if(e.keyCode === 37 || e.keyCode === 39) {
-        let leftArrow = e.keyCode === 37,
-            index = $topLevelLinks.index($topLevelLink),
+      if(action.left || action.right) {
+        let index = $topLevelLinks.index($topLevelLink),
             linkCount = $topLevelLinks.length;
 
         e.preventDefault();
@@ -95,7 +101,7 @@ export default function (window,document,$,undefined) {
         hide($openContent);
         $topLevelLink.attr('aria-expanded','false');
         // Get previous item if left arrow, next item if right arrow.
-        index += (leftArrow ? -1 : 1);
+        index += (action.left ? -1 : 1);
         // Wrap around if at the end of the set of menus.
         index = ((index % linkCount) + linkCount) % linkCount;
         $topLevelLinks[index].focus();

--- a/styleguide/source/assets/js/modules/mainNav.js
+++ b/styleguide/source/assets/js/modules/mainNav.js
@@ -91,37 +91,23 @@ export default function (window,document,$,undefined) {
         return;
       }
 
-      // left arrow key
-      if(e.keyCode === 37) {
+      // left or right arrow keys
+      if(e.keyCode === 37 || e.keyCode === 39) {
         e.preventDefault();
         // hide content
         // If menubar focus
-        //  - Previous menubar item
+        //  - Change menubar item
         //
         // If dropdown focus
         //  - Open previous pull down menu and select first item
         hide($openContent);
         $topLevelLink.attr('aria-expanded','false');
-        let index = $topLevelLinks.index($topLevelLink)-1;
-        let linkCount = $topLevelLinks.length;
-        index = ((index % linkCount) + linkCount) % linkCount;
-        $topLevelLinks[index].focus();
-        return;
-
-      }
-      // right arrow key
-      if(e.keyCode === 39) {
-        e.preventDefault();
-        // hide content
-        // If menubar focus
-        //  - Next menubar item
-        //
-        // If dropdown focus
-        //  - Open next pull menu and select first item
-        hide($openContent);
-        $topLevelLink.attr('aria-expanded','false');
-        let index = $topLevelLinks.index($topLevelLink)+1;
-        let linkCount = $topLevelLinks.length;
+        let leftArrow = e.keyCode === 37,
+            index = $topLevelLinks.index($topLevelLink),
+            linkCount = $topLevelLinks.length;
+        // Get previous item if left arrow, next item if right arrow.
+        index += (leftArrow ? -1 : 1);
+        // Wrap around if at the end of the set of menus.
         index = ((index % linkCount) + linkCount) % linkCount;
         $topLevelLinks[index].focus();
         return;

--- a/styleguide/source/assets/js/modules/mainNav.js
+++ b/styleguide/source/assets/js/modules/mainNav.js
@@ -102,10 +102,6 @@ export default function (window,document,$,undefined) {
         return;
       }
 
-      if(open || (typeof(e.keycode) !== "undefined")) {
-        return;
-      }
-
     });
     $mainNavItems.on('mouseenter', function(e) {
       $(this).children('button').attr("aria-expanded","true");

--- a/styleguide/source/assets/js/modules/mainNav.js
+++ b/styleguide/source/assets/js/modules/mainNav.js
@@ -36,48 +36,32 @@ export default function (window,document,$,undefined) {
           focusIndexInDropdown = $dropdownLinks.index($focusedElement),
           isShift = !!e.shiftKey; // typecast to boolean
 
-      // down arrow or tab key
-      if((e.keyCode === 40) || (e.keyCode === 9 && !isShift)) {
-        // hide content
+      // up/down arrows or tab key
+      if(e.keyCode === 40 || e.keyCode === 38 || e.keyCode === 9) {
+        e.preventDefault();
         // If menubar focus
-        //  - Open pull down menu and select first menu item
+        //  - Open pull down menu and select appropriate menu item
         //
         // If dropdown focus
-        //  - Select next menu item
-        e.preventDefault();
-        if(!open) {
-          show($topLevelItem.find('.js-main-nav-content'));
-          $topLevelLink.attr('aria-expanded', 'true');
-          $link.addClass(openClass);
-        }
-        // If focused element isn't in dropdown, start with the 0th item instead.
-        let newIndex = Math.max(0, focusIndexInDropdown);
-        // Focus should wrap around at end of list. Skip 0th item.
-        newIndex = Math.max(1, (newIndex + 1) % dropdownLinksLength);
-        $dropdownLinks[newIndex].focus();
-        return;
-      }
-
-       // up arrow or shift+tab keys
-       if((e.keyCode === 38) || (e.keyCode === 9 && isShift)) {
-        // hide content
-        // If menubar focus
-        //  - Open pull down menu and select last menu item
-        //
-        // If dropdown focus
-        //  - Select previous menu item
-        e.preventDefault();
+        //  - Change selected menu item
+        let up = e.keyCode === 38 || (e.keyCode === 9 && isShift);
         if(!open) {
           show($topLevelItem.find('.js-main-nav-content'));
           $topLevelLink.focus().attr('aria-expanded', 'true');
           $link.addClass(openClass);
         }
-        // If focused element isn't in dropdown, or is 0th (hidden) or 1st item,
-        // it needs to wrap around to the last element.
-        if(focusIndexInDropdown <= 1 ) {
-          focusIndexInDropdown = dropdownLinksLength;
+        if(up) {
+          if(focusIndexInDropdown <= 1 ) {
+            focusIndexInDropdown = dropdownLinksLength;
+          }
+          $dropdownLinks[focusIndexInDropdown-1].focus();
+        } else {
+          // If focused element isn't in dropdown, start with the 0th item instead.
+          let newIndex = Math.max(0, focusIndexInDropdown);
+          // Focus should wrap around at end of list. Skip 0th item.
+          newIndex = Math.max(1, (newIndex + 1) % dropdownLinksLength);
+          $dropdownLinks[newIndex].focus();
         }
-        $dropdownLinks[focusIndexInDropdown-1].focus();
         return;
       }
 
@@ -113,8 +97,7 @@ export default function (window,document,$,undefined) {
         return;
       }
 
-      // key code 9 is the tab key
-      if(open || (typeof(e.keycode) !== "undefined" && e.keycode !== 9)) {
+      if(open || (typeof(e.keycode) !== "undefined")) {
         return;
       }
 

--- a/styleguide/source/assets/js/modules/mainNav.js
+++ b/styleguide/source/assets/js/modules/mainNav.js
@@ -17,11 +17,6 @@ export default function (window,document,$,undefined) {
         breakpoint = 800; // matches CSS breakpoint for Main Nav
 
     $mainNavItems.on('keydown', function(e) {
-      if(windowWidth <= breakpoint) {
-        // only for desktop
-        return;
-      }
-
       // Grab all the DOM info we need...
       let $link = $(this),
           $topLevelLinks = $parent.find('.ma__main-nav__top-link'),

--- a/styleguide/source/assets/js/modules/mainNav.js
+++ b/styleguide/source/assets/js/modules/mainNav.js
@@ -54,7 +54,7 @@ export default function (window,document,$,undefined) {
         //  - Change selected menu item
         if(!open) {
           show($topLevelItem.find('.js-main-nav-content'));
-          $topLevelLink.focus().attr('aria-expanded', 'true');
+          $topLevelLink.attr('aria-expanded', 'true');
           $link.addClass(openClass);
         }
         // Up arrow was used

--- a/styleguide/source/assets/js/modules/mainNav.js
+++ b/styleguide/source/assets/js/modules/mainNav.js
@@ -22,13 +22,14 @@ export default function (window,document,$,undefined) {
           open = $link.hasClass(openClass),
           $openContent = $parent.find('.js-main-nav-content.' + openClass),
           $focusedElement = $(document.activeElement),
-          keycode = e.keyCode,
       // relevant if open..
           $topLevelItem = $focusedElement.parents('.ma__main-nav__item'),
           $topLevelLink = $topLevelItem.find('.ma__main-nav__top-link'),
           $dropdownLinks = $link.find('.ma__main-nav__subitem .ma__main-nav__link'),
           dropdownLinksLength = $dropdownLinks.length,
           focusIndexInDropdown = $dropdownLinks.index($focusedElement),
+      // Easy access to the key that was pressed.
+          keycode = e.keyCode,
           action = {
             'skip': keycode === 9,
             'close': keycode === 27,
@@ -37,6 +38,11 @@ export default function (window,document,$,undefined) {
             'up': keycode === 38,
             'down': keycode === 40
           };
+
+      // Default behavior is prevented for all actions except 'skip'.
+      if (action.close || action.left || action.right || action.up || action.down) {
+        e.preventDefault();
+      }
 
       // tab key
       if(action.skip) {
@@ -49,7 +55,6 @@ export default function (window,document,$,undefined) {
 
       // up/down arrows
       if(action.up || action.down) {
-        e.preventDefault();
         // If menubar focus
         //  - Open pull down menu and select appropriate menu item
         //
@@ -79,7 +84,6 @@ export default function (window,document,$,undefined) {
       // esc key
       if(action.close) {
         // Close menu and return focus to menubar
-        e.preventDefault();
         hide($openContent);
         $link.removeClass(openClass);
         $topLevelLink.focus().attr('aria-expanded','false');
@@ -91,7 +95,6 @@ export default function (window,document,$,undefined) {
         let index = $topLevelLinks.index($topLevelLink),
             linkCount = $topLevelLinks.length;
 
-        e.preventDefault();
         // hide content
         // If menubar focus
         //  - Change menubar item

--- a/styleguide/source/assets/js/modules/mainNav.js
+++ b/styleguide/source/assets/js/modules/mainNav.js
@@ -143,18 +143,6 @@ export default function (window,document,$,undefined) {
         }
       }
     });
-    $mainNavToggle.last()
-      .find('.js-main-nav-content li')
-        .last()
-          .find('a').on('keydown', function(e) {
-            e.stopPropagation();
-            // previous key was not a shift
-            if(e.keyCode === 9 && previousKey !== 16) {  // tab arrow\
-              let $openContent = $parent.find('.js-main-nav-content.' + openClass);
-              hide($openContent);
-            }
-            previousKey = e.keyCode;
-      });
 
     $('.js-close-sub-nav').on('click', function(){
       let $openContent = $parent.find('.js-main-nav-content.' + openClass);

--- a/styleguide/source/assets/js/modules/mainNav.js
+++ b/styleguide/source/assets/js/modules/mainNav.js
@@ -59,6 +59,7 @@ export default function (window,document,$,undefined) {
           }
           $dropdownLinks[focusIndexInDropdown-1].focus();
         } else {
+          // Down arrow was used.
           // If focused element isn't in dropdown, start with the 0th item instead.
           focusIndexInDropdown = Math.max(0, focusIndexInDropdown);
           // Focus should wrap around at end of list. Skip 0th item.
@@ -80,6 +81,10 @@ export default function (window,document,$,undefined) {
 
       // left or right arrow keys
       if(e.keyCode === 37 || e.keyCode === 39) {
+        let leftArrow = e.keyCode === 37,
+            index = $topLevelLinks.index($topLevelLink),
+            linkCount = $topLevelLinks.length;
+
         e.preventDefault();
         // hide content
         // If menubar focus
@@ -89,9 +94,6 @@ export default function (window,document,$,undefined) {
         //  - Open previous pull down menu and select first item
         hide($openContent);
         $topLevelLink.attr('aria-expanded','false');
-        let leftArrow = e.keyCode === 37,
-            index = $topLevelLinks.index($topLevelLink),
-            linkCount = $topLevelLinks.length;
         // Get previous item if left arrow, next item if right arrow.
         index += (leftArrow ? -1 : 1);
         // Wrap around if at the end of the set of menus.
@@ -122,11 +124,11 @@ export default function (window,document,$,undefined) {
       }
     });
     $mainNavToggle.children('button, a').on('click', function(e) {
-      let $el = $(this);
-      let $elParent = $(this).parent();
-      let $content = $elParent.find('.js-main-nav-content');
-      let $openContent = $parent.find('.js-main-nav-content.' + openClass);
-      let isOpen = $content.hasClass(openClass);
+      let $el = $(this),
+          $elParent = $el.parent(),
+          $content = $elParent.find('.js-main-nav-content'),
+          $openContent = $parent.find('.js-main-nav-content.' + openClass),
+          isOpen = $content.hasClass(openClass);
 
       // mobile
       if(windowWidth <= breakpoint) {


### PR DESCRIPTION
This addresses a number of accessibility issues with the main menu:
* The buttons and links in the menu should all have `tabindex="-1"` except for the first one, which should be `0`
* Tab/Shift-Tab shouldn’t navigate through the menu items (that's what arrow keys are for, and it makes it take a very long time to skip past the menu)
* Menu bar and submenus should wrap around if you try to go past the end of a list
* Using the down or up arrows on a top-level menu item should expand that menu and move to the first or last items, respectively, rather than toggle the menu open and closed

With left/right and up/down arrows behaving so similarly, it was possible to consolidate and cut down on the code needed for those overall.