### PR TITLE
DP-3237 Merge callout stat divs to improve accessibility

### DIFF
--- a/styleguide/source/_patterns/02-molecules/callout-stats.twig
+++ b/styleguide/source/_patterns/02-molecules/callout-stats.twig
@@ -4,6 +4,6 @@
 
 {% set modifierClass = statsCallout.pull ? "ma__callout-stats--" ~ statsCallout.pull : "" %}
 <section class="ma__callout-stats {{modifierClass}}">
-  <div class="ma__callout-stats__stat">{{statsCallout.stat}}</div>
-  <div class="ma__callout-stats__content">{{statsCallout.content}}</div>
+  <span class="ma__callout-stats__stat">{{statsCallout.stat}}</span>
+  <span class="ma__callout-stats__content">{{statsCallout.content}}</span>
 </section>

--- a/styleguide/source/assets/scss/02-molecules/_callout-stats.scss
+++ b/styleguide/source/assets/scss/02-molecules/_callout-stats.scss
@@ -52,6 +52,7 @@
   }
 
   &__content {
+    display: block;
     font-size: 1.438rem;
     line-height: 1.3;
   }


### PR DESCRIPTION
When read by screen readers, the callout stats are read as two separate chunks because they're in two divs. By turning these into spans, they're read as one chunk of text.

The second span is manually styled like a block to avoid impacting the existing styling.