### PR TITLE
Trigger Browser Sync reload after Pattern Lab build

### DIFF
--- a/styleguide/tools/gulp/tasks/patternlab.js
+++ b/styleguide/tools/gulp/tasks/patternlab.js
@@ -9,8 +9,9 @@ var gulp         = require('gulp'),
 
 module.exports = function patternLabTask(config, env){
 
+    var bsPort = config.local.browserSyncPort || 3000;
     gulp.task('patternlab', function() {
-        run('php ' + config.patternLabRoot + '/core/console --generate --patternsonly').exec();
+        run('php ' + config.patternLabRoot + '/core/console --generate --patternsonly && browser-sync reload --port ' + bsPort).exec();
     });
 
     // gulp.task('patternlab', function(next) {


### PR DESCRIPTION
I **have not** tested this, but I bet this would work. I saw @legostud mention [here](https://github.com/drupal-pattern-lab/roadmap/issues/3#issuecomment-312676451) that this was an issue, so I took a look and the [browser sync docs on the CLI command reload](https://github.com/drupal-pattern-lab/roadmap/issues/3#issuecomment-312676451) might be what you're looking for. I [handle it a bit different](https://github.com/theme-tools/theme-tools/blob/master/packages/plugin-pattern-lab-php/pattern-lab.js#L23) in my tools. 

Cheers! Happy Pattern Labbing!