### PR TITLE
DP-3234 Added visually-hidden h1 prefix content

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-template/illustrated-header.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/illustrated-header.twig
@@ -1,10 +1,11 @@
 <section class="ma__illustrated-header">
   <div class="ma__illustrated-header__container">
     <div class="ma__illustrated-header__content">
-      <div class="ma__illustrated-header__category">
+      <div class="ma__illustrated-header__category" aria-hidden="true">
         {{illustratedHeader.category}}
       </div>
       {% set pageHeader = illustratedHeader.pageHeader %}
+      {% set pageHeader = pageHeader|merge({ 'prefix': illustratedHeader.category }) %}
       {% include "@organisms/by-template/page-header.twig" %}
     </div>
   </div>

--- a/styleguide/source/_patterns/03-organisms/by-template/page-header.json
+++ b/styleguide/source/_patterns/03-organisms/by-template/page-header.json
@@ -2,6 +2,7 @@
   "pageHeader": {
     "category": "",
     "divider": false,
+    "prefix": "",
     "title": "Get a State Park Pass",
     "subTitle": "Do you regularly visit Massachusetts parks or beaches? Our MassParks Pass offers you a significant savings over daily parking charges.",
     "headerTags": null,

--- a/styleguide/source/_patterns/03-organisms/by-template/page-header.md
+++ b/styleguide/source/_patterns/03-organisms/by-template/page-header.md
@@ -26,6 +26,8 @@ Description: Page Header with multiple spots (see optional content + widgets pro
 pageHeader:
   divider: 
     type: boolean
+  prefix:
+    type: string / optional
   title:
     type: string
   subTitle:

--- a/styleguide/source/_patterns/03-organisms/by-template/page-header.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/page-header.twig
@@ -1,6 +1,4 @@
-{% if pageHeader.widgets %}
-  {% set widgetsClass = "ma__page-header--has-widgets" %}
-{% endif %}
+{% set widgetsClass = pageHeader.widgets ? "ma__page-header--has-widgets" : "" %}
 {% set prefix = pageHeader.category|default(pageHeader.prefix) %}
 
 <section class="ma__page-header {{ widgetsClass }}">
@@ -33,7 +31,7 @@
       <h1 
       class="ma__page-header__title"
       {% if schemaPageType %} property="name"{% endif %}>
-        {% if prefix %}<span class="visually-hidden">{{ prefix }} </span>{% endif %}
+        {% if prefix %}<span class="visually-hidden">{{ prefix }}&nbsp;</span>{% endif %}
         {{pageHeader.title}}
       </h1>
     {% if pageHeader.subTitle %}

--- a/styleguide/source/_patterns/03-organisms/by-template/page-header.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/page-header.twig
@@ -1,6 +1,7 @@
 {% if pageHeader.widgets %}
   {% set widgetsClass = "ma__page-header--has-widgets" %}
 {% endif %}
+{% set prefix = pageHeader.category|default(pageHeader.prefix) %}
 
 <section class="ma__page-header {{ widgetsClass }}">
   {% if pageHeader.headerTags.taxonomyTerms or pageHeader.socialLinks.items %}
@@ -25,13 +26,16 @@
         </div>
       {% endif %}
       {% if pageHeader.category %}
-        <div class="ma__page-header__category">
+        <div class="ma__page-header__category" aria-hidden="true">
           {{ pageHeader.category }}
         </div>
       {% endif %}
       <h1 
       class="ma__page-header__title"
-      {% if schemaPageType %} property="name"{% endif %}>{{pageHeader.title}}</h1>
+      {% if schemaPageType %} property="name"{% endif %}>
+        {% if prefix %}<span class="visually-hidden">{{ prefix }}: </span>{% endif %}
+        {{pageHeader.title}}
+      </h1>
     {% if pageHeader.subTitle %}
       <div class="ma__page-header__sub-title">{{pageHeader.subTitle}}</div>
     {% endif %}

--- a/styleguide/source/_patterns/03-organisms/by-template/page-header.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/page-header.twig
@@ -33,7 +33,7 @@
       <h1 
       class="ma__page-header__title"
       {% if schemaPageType %} property="name"{% endif %}>
-        {% if prefix %}<span class="visually-hidden">{{ prefix }}: </span>{% endif %}
+        {% if prefix %}<span class="visually-hidden">{{ prefix }} </span>{% endif %}
         {{pageHeader.title}}
       </h1>
     {% if pageHeader.subTitle %}


### PR DESCRIPTION
Although categories above `<h1>` tags are readily apparent to sighted users, they don't translate as well to assistive technologies. To address this, the category is now hidden from screen readers, and is added (but visually-hidden) at the start of the `<h1>`.

Because illustrated headers display the category differently and don't leverage the `pageHeader.category` property, a `pageHeader.prefix` property is added to provide a heading prefix in the absence of a category.