### PR TITLE
DP-3225 Aria role for Wait Time

### DIFF
--- a/styleguide/source/_patterns/02-molecules/wait-time.twig
+++ b/styleguide/source/_patterns/02-molecules/wait-time.twig
@@ -1,4 +1,4 @@
-<section class="ma__wait-time">
+<section class="ma__wait-time" role="status" aria-live=“polite”>
   <h2 class="ma__wait-time__title">
     {% include "@atoms/05-icons/svg-wait-time.twig" %}
     <span>Wait Time</span>


### PR DESCRIPTION
To update the "Wait Time" with the aria role `role="status" aria-live=“polite”` to let the screen reader know when a change to the wait time has occurred. 

JIRA ticket https://jira.state.ma.us/browse/DP-3225

Testing:
This can't be tested in Mayflower for we don't have wait time being updated.

I used the live site RMV page `https://pilot.mass.gov/locations/natick-rmv-service-center` and added the `role="status" aria-live="polite"` into the inspector tool to test. I used Chrome and VoiceOver

Below are the screenshots:
 ![screen shot 2017-07-13 at 3 22 48 pm](https://user-images.githubusercontent.com/19477691/28184294-d073bbba-67e0-11e7-872b-6786cfb6b709.jpg)

![screen shot 2017-07-13 at 3 23 12 pm](https://user-images.githubusercontent.com/19477691/28184301-d99c61ce-67e0-11e7-8e4c-61bb16d10834.jpg)

