### PR TITLE
DP-3189 Improved text readability in Contact Group

### DIFF
--- a/styleguide/source/assets/scss/06-theme/02-molecules/_contact-group.scss
+++ b/styleguide/source/assets/scss/06-theme/02-molecules/_contact-group.scss
@@ -20,11 +20,6 @@
     font-weight: 300;
   }
 
-  &__details {
-    font-weight: 300;
-    font-style: italic;
-  }
-
   .ma__content-link--phone {
     font-weight: 300;
   }


### PR DESCRIPTION
The light text and italics compromise readability, particularly on Chrome for Windows.