### PR TITLE
DP-3232 & DP-1369 Key Actions and Key Agencies showing multiple times throughout page

### DIFF
--- a/styleguide/source/_patterns/01-atoms/04-headings/comp-heading.md
+++ b/styleguide/source/_patterns/01-atoms/04-headings/comp-heading.md
@@ -28,6 +28,8 @@ compHeading: {
     type: string
   centered:
     type: boolean
+  sidebar: 
+    type: boolean
 }
 ~~~
 

--- a/styleguide/source/_patterns/01-atoms/04-headings/comp-heading.twig
+++ b/styleguide/source/_patterns/01-atoms/04-headings/comp-heading.twig
@@ -15,9 +15,13 @@
 
 {% if compHeading.sub %}
   <h3 
-    class="ma__comp-heading {{ colored }} {{ centered }}" 
+    class="ma__comp-heading--centered {{ colored }} {{ centered }}" 
     {% if compHeading.id %}id="{{compHeading.id}}"{% endif %} tabindex="-1">
     {{ compHeading.title }}
+  </h3>
+  <h3 class="ma__comp-heading--sidebar"
+    {% if sidebarHeading.id %}id="{{sidebarHeading.id}}"{% endif %}>
+    {{sidebarHeading.title}}
   </h3>
 {% else %}
   <h2 

--- a/styleguide/source/_patterns/01-atoms/04-headings/comp-heading.twig
+++ b/styleguide/source/_patterns/01-atoms/04-headings/comp-heading.twig
@@ -1,6 +1,4 @@
-{% if compHeading.color %}
-  {% set colored = "ma__comp-heading--" ~ compHeading.color %}
-{% endif %}
+{% set colored = compHeading.color ? "ma__comp-heading--" ~ compHeading.color : "" %}
 
 {# string value is backward compatible for v5.0.0 #}
 {% if compHeading.centered == 'true' or compHeading.centered == 1 %}
@@ -13,24 +11,17 @@
   {% set centered = "ma__comp-heading--centered" %}
 {% endif %}
 
-{% if compHeading.sub %}
-  <h3 
-    class="ma__comp-heading {{ colored }} {{ centered }}" 
-    {% if compHeading.id %}id="{{compHeading.id}}"{% endif %} tabindex="-1">
-    {{ compHeading.title }}
-  </h3>
-{% else %}
-  <h2 
-    class="ma__comp-heading {{ colored }} {{ centered }}" {% if compHeading.id %}
-    id="{{compHeading.id}}"{% endif %}
-    tabindex="-1">
-    {{ compHeading.title }}
-  </h2>
-{% endif %}
-{% if compHeading.sidebar %}
-<h3 class="ma__comp-heading--sidebar"
-    {% if sidebarHeading.id %}id="{{sidebarHeading.id}}"{% endif %}>
-    {{sidebarHeading.title}}
-  </h3>
-{% endif %}
+{% set headingLevel = compHeading.sub ? 3 : 2 %}
+
+{% set sidebar = compHeading.sidebar ? 'ma__comp-heading--sidebar' : '' %}
+
+
+<h{{ headingLevel }} 
+  class="ma__comp-heading {{ colored }} {{ centered }} {{sidebar }}" 
+  {% if compHeading.id %}
+    id="{{compHeading.id}}"
+  {% endif %} 
+  tabindex="-1">
+  {{ compHeading.title }}
+</h{{ headingLevel }}>
 

--- a/styleguide/source/_patterns/01-atoms/04-headings/comp-heading.twig
+++ b/styleguide/source/_patterns/01-atoms/04-headings/comp-heading.twig
@@ -15,7 +15,7 @@
 
 {% if compHeading.sub %}
   <h3 
-    class="ma__comp-heading--centered {{ colored }} {{ centered }}" 
+    class="ma__comp-heading {{ colored }} {{ centered }}" 
     {% if compHeading.id %}id="{{compHeading.id}}"{% endif %} tabindex="-1">
     {{ compHeading.title }}
   </h3>

--- a/styleguide/source/_patterns/01-atoms/04-headings/comp-heading.twig
+++ b/styleguide/source/_patterns/01-atoms/04-headings/comp-heading.twig
@@ -11,17 +11,24 @@
   {% set centered = "ma__comp-heading--centered" %}
 {% endif %}
 
-{% set headingLevel = compHeading.sub ? 3 : 2 %}
-
 {% set sidebar = compHeading.sidebar ? 'ma__comp-heading--sidebar' : '' %}
 
-
-<h{{ headingLevel }} 
-  class="ma__comp-heading {{ colored }} {{ centered }} {{sidebar }}" 
-  {% if compHeading.id %}
-    id="{{compHeading.id}}"
-  {% endif %} 
-  tabindex="-1">
-  {{ compHeading.title }}
-</h{{ headingLevel }}>
-
+{% if compHeading.sub %}
+  <h3
+    class="ma__comp-heading {{ colored }} {{ centered }} {{sidebar }}" 
+    {% if compHeading.id %}
+      id="{{compHeading.id}}"
+    {% endif %} 
+    tabindex="-1">
+    {{ compHeading.title }}
+  </h3>
+{% else %}
+  <h2 
+    class="ma__comp-heading {{ colored }} {{ centered }} {{sidebar }}" 
+    {% if compHeading.id %}
+      id="{{compHeading.id}}"
+    {% endif %} 
+    tabindex="-1">
+    {{ compHeading.title }}
+  </h2>
+{% endif %}

--- a/styleguide/source/_patterns/01-atoms/04-headings/comp-heading.twig
+++ b/styleguide/source/_patterns/01-atoms/04-headings/comp-heading.twig
@@ -19,10 +19,6 @@
     {% if compHeading.id %}id="{{compHeading.id}}"{% endif %} tabindex="-1">
     {{ compHeading.title }}
   </h3>
-  <h3 class="ma__comp-heading--sidebar"
-    {% if sidebarHeading.id %}id="{{sidebarHeading.id}}"{% endif %}>
-    {{sidebarHeading.title}}
-  </h3>
 {% else %}
   <h2 
     class="ma__comp-heading {{ colored }} {{ centered }}" {% if compHeading.id %}
@@ -30,5 +26,11 @@
     tabindex="-1">
     {{ compHeading.title }}
   </h2>
+{% endif %}
+{% if compHeading.sidebar %}
+<h3 class="ma__comp-heading--sidebar"
+    {% if sidebarHeading.id %}id="{{sidebarHeading.id}}"{% endif %}>
+    {{sidebarHeading.title}}
+  </h3>
 {% endif %}
 

--- a/styleguide/source/_patterns/01-atoms/04-headings/comp-heading~as-sidebar-heading.json
+++ b/styleguide/source/_patterns/01-atoms/04-headings/comp-heading~as-sidebar-heading.json
@@ -1,9 +1,10 @@
 {
   "compHeading": {
     "title": "Employment",
-    "sub": false,
+    "sub": true,
     "color": "",
     "id": "employment",
-    "centered": false
+    "centered": false,
+    "sidebar": true
   }
 }

--- a/styleguide/source/_patterns/01-atoms/04-headings/comp-heading~centered.json
+++ b/styleguide/source/_patterns/01-atoms/04-headings/comp-heading~centered.json
@@ -1,9 +1,9 @@
 {
   "compHeading": {
     "title": "Employment",
-    "sub": "",
+    "sub": false,
     "color": "",
     "id": "employment",
-    "centered": "true"
+    "centered": true
   }
 }

--- a/styleguide/source/_patterns/01-atoms/04-headings/comp-heading~yellow.json
+++ b/styleguide/source/_patterns/01-atoms/04-headings/comp-heading~yellow.json
@@ -1,9 +1,9 @@
 {
   "compHeading": {
     "title": "Employment",
-    "sub":"",
+    "sub": false,
     "color": "yellow",
     "id": "",
-    "centered": ""
+    "centered": false
   }
 }

--- a/styleguide/source/_patterns/01-atoms/04-headings/sidebar-heading.twig
+++ b/styleguide/source/_patterns/01-atoms/04-headings/sidebar-heading.twig
@@ -1,1 +1,1 @@
-<h3 class="ma__sidebar-heading" aria-labelledby="{{compHeading.id}}">{{sidebarHeading.title}}</h3>
+<h3 class="ma__sidebar-heading">{{sidebarHeading.title}}</h3>

--- a/styleguide/source/_patterns/01-atoms/04-headings/sidebar-heading.twig
+++ b/styleguide/source/_patterns/01-atoms/04-headings/sidebar-heading.twig
@@ -1,1 +1,1 @@
-<h3 class="ma__sidebar-heading">{{sidebarHeading.title}}</h3>
+<h3 class="ma__sidebar-heading" aria-labelledby="{{compHeading.id}}">{{sidebarHeading.title}}</h3>

--- a/styleguide/source/_patterns/03-organisms/by-author/key-actions.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/key-actions.json
@@ -2,7 +2,7 @@
   "keyActions": {
     "compHeading": {
       "title": "Key Actions",
-      "sub":true,
+      "sub": false,
       "id": "key-action-id"
     },
     "links":[{

--- a/styleguide/source/_patterns/03-organisms/by-author/key-actions.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/key-actions.json
@@ -2,7 +2,8 @@
   "keyActions": {
     "compHeading": {
       "title": "Key Actions",
-      "sub":true
+      "sub":true,
+      "id": "key-action-id"
     },
     "links":[{
       "text": "Register to Vote",

--- a/styleguide/source/_patterns/03-organisms/by-author/key-actions.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/key-actions.twig
@@ -8,7 +8,7 @@
       {% set sidebarHeading = keyActions.sidebarHeading %}
       {% include "@atoms/04-headings/sidebar-heading.twig" %}
     {% endif %}
-    <div class="ma__key-actions__items" aria-labelledby="{{compHeading.id}}">
+    <div class="ma__key-actions__items" aria-labelledby="">
       {% for link in keyActions.links %}
         {% if link.image %}
           {% set illustratedLink = link %}

--- a/styleguide/source/_patterns/03-organisms/by-author/key-actions.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/key-actions.twig
@@ -1,14 +1,15 @@
+{# backward compatible for version 5.5 #}
+{% if keyActions.sidebarHeading %}
+  {% set keyActions = keyActions|merge({"compHeading": { "title": keyActions.sidebarHeading.title, "sidebar" : true }}) %}
+{% endif %}
+
 <section class="ma__key-actions">
   <div class="ma__key-actions__container">
     {% if keyActions.compHeading %}
       {% set compHeading = keyActions.compHeading %}
       {% include "@atoms/04-headings/comp-heading.twig" %}
     {% endif %}
-    {% if keyActions.sidebarHeading %}
-      {% set sidebarHeading = keyActions.sidebarHeading %}
-      {% include "@atoms/04-headings/sidebar-heading.twig" %}
-    {% endif %}
-    <div class="ma__key-actions__items" aria-labelledby="">
+    <div class="ma__key-actions__items" aria-labelledby="{{ keyActions.compHeading.id }}">
       {% for link in keyActions.links %}
         {% if link.image %}
           {% set illustratedLink = link %}

--- a/styleguide/source/_patterns/03-organisms/by-author/key-actions.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/key-actions.twig
@@ -8,7 +8,7 @@
       {% set sidebarHeading = keyActions.sidebarHeading %}
       {% include "@atoms/04-headings/sidebar-heading.twig" %}
     {% endif %}
-    <div class="ma__key-actions__items">
+    <div class="ma__key-actions__items" aria-labelledby="{{compHeading.id}}">
       {% for link in keyActions.links %}
         {% if link.image %}
           {% set illustratedLink = link %}

--- a/styleguide/source/assets/scss/01-atoms/_comp-heading.scss
+++ b/styleguide/source/assets/scss/01-atoms/_comp-heading.scss
@@ -1,20 +1,21 @@
 .ma__comp-heading {
   @include ma-comp-heading;
 
+  &:not(&--sidebar) {
+    @include ma-comp-heading;
+  }
+
+  &--sidebar,
+   .sidebar & {
+    @include ma-sidebar-heading;
+  }
+
   &--centered {
     text-align: center;
 
     &:after {
       left: 50%;
       transform: translateX(-50%);
-    }
-  }
-
-  .sidebar & {
-    @include ma-sidebar-heading;
-
-    &:after {
-      display: none;
     }
   }
 

--- a/styleguide/source/assets/scss/01-atoms/_comp-heading.scss
+++ b/styleguide/source/assets/scss/01-atoms/_comp-heading.scss
@@ -8,15 +8,15 @@
   &--sidebar,
    .sidebar & {
     @include ma-sidebar-heading;
-  }
-
-  &--centered {
-    text-align: center;
 
     &:after {
       left: 50%;
       transform: translateX(-50%);
     }
+  }
+
+  &--centered {
+    text-align: center;
   }
 
   .sidebar--colored & {

--- a/styleguide/source/assets/scss/01-atoms/_comp-heading.scss
+++ b/styleguide/source/assets/scss/01-atoms/_comp-heading.scss
@@ -1,22 +1,25 @@
 .ma__comp-heading {
-  @include ma-comp-heading;
 
   &:not(&--sidebar) {
     @include ma-comp-heading;
   }
 
   &--sidebar,
-   .sidebar & {
+  .sidebar & {
     @include ma-sidebar-heading;
+
+    &:after {
+      display: none;
+    }
+  }
+
+  &--centered:not(&--sidebar) {
+    text-align: center;
 
     &:after {
       left: 50%;
       transform: translateX(-50%);
     }
-  }
-
-  &--centered {
-    text-align: center;
   }
 
   .sidebar--colored & {

--- a/styleguide/source/assets/scss/06-theme/01-atoms/_comp-heading.scss
+++ b/styleguide/source/assets/scss/06-theme/01-atoms/_comp-heading.scss
@@ -1,15 +1,16 @@
 .ma__comp-heading {
   @include ma-comp-heading($c-theme-secondary);
 
-  .sidebar & {
+  .sidebar &,
+  &--sidebar {
     @include ma-sidebar-heading($c-bd-divider,$c-font-base);
   }
 
   .sidebar--colored & {
     @include ma-heading-colored($c-bg-comp-title);
   }
-}
 
-.ma__comp-heading--yellow {
-  @include ma-border-decorative($c-theme-yellow, 1);
+  &--yellow {
+    @include ma-border-decorative($c-theme-yellow, 1);
+  }
 }


### PR DESCRIPTION
For accessibility reasons added an aria-labelledby to the key actions section and used the compHeading.id to identify each of the key actions section. This is also happening in the key agencies section on the sidebar. 

JIRA ticket: https://jira.state.ma.us/browse/DP-3232 & https://jira.state.ma.us/browse/DP-1369

The key actions are being used both on the Guide (harden-content type) and the Stacked Layout (prototype - current homepage) at the moment. Used the compHeading.id instead of compHeading.title not to duplicate the key action title.