### PR TITLE
DP-3235 Added aria-label for file download links

### DIFF
--- a/styleguide/source/_patterns/02-molecules/download-link.twig
+++ b/styleguide/source/_patterns/02-molecules/download-link.twig
@@ -13,9 +13,9 @@
       {% include "@atoms/decorative-link.twig" %}
     {% else %}
       <a 
-        class="ma__download-link__file-link" 
-        aria-label="Open {{ downloadLink.format }} file{% if downloadLink.size %}, {{ downloadLink.size }},{% endif %} for {{ downloadLink.decorativeLink.text }}"
+        class="ma__download-link__file-link"
         href="{{ downloadLink.decorativeLink.href}}">
+        <span class="visually-hidden">Open {{ downloadLink.format }} file{% if downloadLink.size %}, {{ downloadLink.size }},{% endif %} for</span>
           {{ downloadLink.decorativeLink.text }}
       </a>
       {% if downloadLink.format or downloadLink.size %}

--- a/styleguide/source/_patterns/02-molecules/download-link.twig
+++ b/styleguide/source/_patterns/02-molecules/download-link.twig
@@ -14,6 +14,7 @@
     {% else %}
       <a 
         class="ma__download-link__file-link" 
+        aria-label="Open {{ downloadLink.format }} file{% if downloadLink.size %}, {{ downloadLink.size }},{% endif %} for {{ downloadLink.decorativeLink.text }}"
         href="{{ downloadLink.decorativeLink.href}}">
           {{ downloadLink.decorativeLink.text }}
       </a>


### PR DESCRIPTION
Similar to the change made in PR 487, but with the inclusion of the file size (if provided) in the aria-label per external reviewer feedback