### PR TITLE
DP-4103 - Add `align-self` style to section title to fix wrapping.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_section-links.scss
+++ b/styleguide/source/assets/scss/02-molecules/_section-links.scss
@@ -93,7 +93,8 @@
   &__title {
     @include ma-h3;
     margin-bottom: 15px;
-
+    align-self: stretch;
+    
     a {
       border: none;
     }


### PR DESCRIPTION
This PR adds an update to add the `align-self` style to the section titles, which fixes the issue happening on IE11.

https://jira.state.ma.us/browse/DP-4103

After the update, the titles should wrap inside the content divs:
![dp-4103](https://user-images.githubusercontent.com/1103479/28831857-e5bcf6c2-76a8-11e7-9c1e-d156561a62d0.png)

