### PR TITLE
DP-4198: Changes a tag to div to fix google translate.

### DIFF
--- a/styleguide/source/_patterns/02-molecules/callout-link.twig
+++ b/styleguide/source/_patterns/02-molecules/callout-link.twig
@@ -1,7 +1,8 @@
-<a class="ma__callout-link" href="{{ calloutLink.href }}">
+<div class="ma__callout-link">
   <span class="ma__callout-link__container">
     <span class="ma__callout-link__text">
-      {{ calloutLink.text }}{% if calloutLink.info %}<span class="ma__callout-link__info">{{ calloutLink.info }}</span>{% endif %}&nbsp;{% include "@atoms/05-icons/svg-arrow.twig" %}
+      <a href="{{ calloutLink.href }}">{{ calloutLink.text }}</a>
+      {% if calloutLink.info %}<span class="ma__callout-link__info">{{ calloutLink.info }}</span>{% endif %}&nbsp;{% include "@atoms/05-icons/svg-arrow.twig" %}
     </span>
   </span>
-</a>
+</div>

--- a/styleguide/source/_patterns/02-molecules/callout-link.twig
+++ b/styleguide/source/_patterns/02-molecules/callout-link.twig
@@ -1,7 +1,7 @@
 <div class="ma__callout-link">
   <span class="ma__callout-link__container">
     <span class="ma__callout-link__text">
-      <a class="js-clickable-link" href="{{ calloutLink.href }}">{{ calloutLink.text }}
+      <a href="{{ calloutLink.href }}">{{ calloutLink.text }}
         {% if calloutLink.info %}<span class="ma__callout-link__info">{{ calloutLink.info }}</span>{% endif %}&nbsp;{% include "@atoms/05-icons/svg-arrow.twig" %}
       </a>
     </span>

--- a/styleguide/source/_patterns/02-molecules/callout-link.twig
+++ b/styleguide/source/_patterns/02-molecules/callout-link.twig
@@ -1,8 +1,9 @@
 <div class="ma__callout-link">
   <span class="ma__callout-link__container">
     <span class="ma__callout-link__text">
-      <a href="{{ calloutLink.href }}">{{ calloutLink.text }}</a>
-      {% if calloutLink.info %}<span class="ma__callout-link__info">{{ calloutLink.info }}</span>{% endif %}&nbsp;{% include "@atoms/05-icons/svg-arrow.twig" %}
+      <a class="js-clickable-link" href="{{ calloutLink.href }}">{{ calloutLink.text }}
+        {% if calloutLink.info %}<span class="ma__callout-link__info">{{ calloutLink.info }}</span>{% endif %}&nbsp;{% include "@atoms/05-icons/svg-arrow.twig" %}
+      </a>
     </span>
   </span>
 </div>

--- a/styleguide/source/_patterns/02-molecules/callout-link.twig
+++ b/styleguide/source/_patterns/02-molecules/callout-link.twig
@@ -1,9 +1,3 @@
 <div class="ma__callout-link">
-  <span class="ma__callout-link__container">
-    <span class="ma__callout-link__text">
-      <a href="{{ calloutLink.href }}">{{ calloutLink.text }}
-        {% if calloutLink.info %}<span class="ma__callout-link__info">{{ calloutLink.info }}</span>{% endif %}&nbsp;{% include "@atoms/05-icons/svg-arrow.twig" %}
-      </a>
-    </span>
-  </span>
+  <a href="{{ calloutLink.href }}"><span class="ma__callout-link__container"><span class="ma__callout-link__text" aria-label={{ calloutLink.info }}>{{ calloutLink.text }}&nbsp;{% include "@atoms/05-icons/svg-arrow.twig" %}</span></span></a>
 </div>

--- a/styleguide/source/assets/scss/02-molecules/_callout-link.scss
+++ b/styleguide/source/assets/scss/02-molecules/_callout-link.scss
@@ -1,21 +1,15 @@
 .ma__callout-link {
   border: 3px solid;
-  cursor: pointer;
   display: inline-flex;
-    align-items: center;
-  padding: 15px 20px;
+    align-items: stretch;
 
-  @media ($bp-small-min) {
-    padding: 20px 30px;
-  }
-
-  .pre-content > &,
-  .post-content > &,
-  .main-content--full .page-content > & {
-    @include ma-container();
-    display: block;
-    width: 100%;
-  }
+  // .pre-content > &,
+  // .post-content > &,
+  // .main-content--full .page-content > & {
+  //   @include ma-container();
+  //   display: block;
+  //   width: 100%;
+  // }
 
   &:last-child {
     margin-bottom: 0;
@@ -26,14 +20,23 @@
   }
 
   a {
+    display: flex;
+      align-items: center;
+    padding: 15px 20px;
     font-size: 1.625rem;
     line-height: 1.3;
+    width: 100%;
+
+    @media ($bp-small-min) {
+      padding: 20px 30px;
+    }
   }
 
-  &__container {
+  &__container { // .ma__decorative-link 
     display: inline-block;
-    padding-right: 18px;
     vertical-align: middle;
+    padding-right: .8em;
+    width: 100%;
   }
 
   &__info {
@@ -42,14 +45,12 @@
 
   &__text {
     @include ma-link-underline;
-    font-size: 1.625rem;
     display: inline;
-    line-height: 1.3;
 
     svg {
       display: inline-block;
       height: .6em;
-      margin-right: -18px;
+      margin-right: -.8em;
       width: .6em;
     }
   }


### PR DESCRIPTION
**Description:** 

This pull request changes the anchor tags used to contain the markup within callout-link.twg to be a div instead. Without this change, google translate ends up duplicating the for every callout link on the homepage, breaking the Featured Actions section.

Making this change is also more consistent with other links that are rendered on the page that use divs.

**Jira:** 
https://jira.state.ma.us/browse/DP-4198

**To Test:**
- [ ] Go to the homepage and scroll down to the Featured Actions section. Verify that the Featured Actions section renders properly.
- [ ] Scroll back up and use the dropdown labeled "Select Language" to choose any other language than English. Scroll back down to the Featured Actions section and verify that the Featured Actions section is still rendered properly.

**Post Deploy Steps:**
N/A

**Relevant Screenshots/GIFs:**
N/A

**Additional Notes:**
N/A
---
