### PR TITLE
Dp 4297 footnote fix

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,8 @@
 # Mayflower Release Notes
 
+## 5.5.1
+- DP-4297 - Adds conditional logic around footnote anchor in footnote molecule.
+
 ## 5.5.0
 
 Here comes another Mayflower release, hot off the summertime presses!  We've got 2 new page types and lots of little improvements and fixes coming your way.

--- a/styleguide/source/_patterns/02-molecules/footnote.twig
+++ b/styleguide/source/_patterns/02-molecules/footnote.twig
@@ -1,5 +1,5 @@
 <div class="ma__footnote js-footnote" tabindex="-1">
-  <a class="ma__footnote__link js-footnote-link" id="{{ footnote.id }}" href="{{ footnote.target }}">{{ footnote.number }}</a>
+  {% if footnote.number %}<a class="ma__footnote__link js-footnote-link" id="{{ footnote.id }}" href="{{ footnote.target }}">{{ footnote.number }}</a>{% endif %}
   <div class="ma__footnote__rich-text js-footnote-message">
     {% set richText = footnote.richText %}
     {% include "@organisms/by-author/rich-text.twig" %}

--- a/styleguide/source/_patterns/02-molecules/footnote.twig
+++ b/styleguide/source/_patterns/02-molecules/footnote.twig
@@ -1,5 +1,10 @@
-<div class="ma__footnote js-footnote" tabindex="-1">
-  {% if footnote.number %}<a class="ma__footnote__link js-footnote-link" id="{{ footnote.id }}" href="{{ footnote.target }}">{{ footnote.number }}</a>{% endif %}
+{# Option to remove js functionality and hide the footnote link (this is an implementation workaround). #}
+{% set footnoteJs = footnote.number ? '' : 'js-footnote' %}
+
+<div class="ma__footnote {{ footnoteJs }}" tabindex="-1">
+  {% if footnote.number %}
+    <a class="ma__footnote__link js-footnote-link" id="{{ footnote.id }}" href="{{ footnote.target }}">{{ footnote.number }}</a>
+  {% endif %}
   <div class="ma__footnote__rich-text js-footnote-message">
     {% set richText = footnote.richText %}
     {% include "@organisms/by-author/rich-text.twig" %}

--- a/styleguide/source/_patterns/02-molecules/footnote.twig
+++ b/styleguide/source/_patterns/02-molecules/footnote.twig
@@ -1,5 +1,5 @@
 {# Option to remove js functionality and hide the footnote link (this is an implementation workaround). #}
-{% set footnoteJs = footnote.number ? '' : 'js-footnote' %}
+{% set footnoteJs = footnote.number ? 'js-footnote' : '' %}
 
 <div class="ma__footnote {{ footnoteJs }}" tabindex="-1">
   {% if footnote.number %}


### PR DESCRIPTION
Footnotes have been simplified and there might not always be all of the data needed to display the footnote anchor. If there are no numbered footnotes hide the anchor.