### PR TITLE
DP-1900 - Changed decorative links within contact groups to display inline.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_contact-group.scss
+++ b/styleguide/source/assets/scss/02-molecules/_contact-group.scss
@@ -60,7 +60,7 @@
 
   .ma__content-link,
   .ma__decorative-link {
-    display: inline-block;
+    display: inline;
     width: auto;
 
     a {

--- a/styleguide/source/assets/scss/02-molecules/_contact-group.scss
+++ b/styleguide/source/assets/scss/02-molecules/_contact-group.scss
@@ -60,8 +60,7 @@
 
   .ma__content-link,
   .ma__decorative-link {
-    display: inline;
-    width: auto;
+    display: inline-block;
 
     a {
       hyphens: auto;


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:** 
I used the contact-group.css override that already existed to add a new CSS rule. This is to make decorative links inline **only** when they're within the contact group. Without this, Firefox renders these links with a hyphenated (or sometimes not) break.

See the following in Firefox (version 52.2.1 ESR):

- http://mayflower.digital.mass.gov/?p=pages-location-general-content (link for "Directions")
- https://pilot.mass.gov/locations/southbridge-rmv-service-center (link for "Directions" and "RMV contact form").

**Jira:** 
https://jira.state.ma.us/browse/DP-1900

**To Test:**
- [ ] Browse to any of the sample links above. Verify that the links for "Directions" or "RMV contact form" no longer word break as described.

**Post Deploy Steps:**
N/A

**Relevant Screenshots/GIFs:**
![mass gov_bluehills_reservation_directionslink_onfullbrowserpageload_linktextcuttoff_viapositioning](https://user-images.githubusercontent.com/5257660/29044449-81b211c8-7b8d-11e7-8ce4-761668122607.png)

**Additional Notes:**
N/A
