### PR TITLE
DP-5175 create more links for service + service detail page components

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-author/form-downloads.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/form-downloads.json
@@ -43,6 +43,12 @@
         "size": "",
         "format": "form"
       }
-    }]
+    }],
+    "more": {
+      "href": "#",
+      "text": "See all 10 additional resources",
+      "chevron": true,
+      "label": "See all of the resources for Executive Office of Health and Human Services"
+    }
   }
 }

--- a/styleguide/source/_patterns/03-organisms/by-author/form-downloads.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/form-downloads.twig
@@ -15,4 +15,10 @@
       {% endfor %}
     </div>
   {% endif %}
+  {% if formDownloads.more %}
+    <div class="ma__form-downloads__see-all">
+      {% set decorativeLink = formDownloads.more %}
+      {% include "@atoms/decorative-link.twig" %}
+    </div>
+  {% endif %}
 </section>

--- a/styleguide/source/_patterns/03-organisms/by-author/link-list.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/link-list.json
@@ -49,6 +49,12 @@
       "text":"Department of Public Utilities (DPU)",
       "info": "",
       "property": ""
-    }]
+    }],
+    "more": {
+      "href": "#",
+      "text": "See all 10 related services",
+      "chevron": true,
+      "label": "See all of the resources for Executive Office of Health and Human Services"
+    }
   }
 }

--- a/styleguide/source/_patterns/03-organisms/by-author/link-list.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/link-list.twig
@@ -45,4 +45,10 @@
       </ul>
     {% endif %}
   </div>
+  {% if linkList.more %}
+    <div class="ma__link-list__see-all">
+      {% set decorativeLink = linkList.more %}
+      {% include "@atoms/decorative-link.twig" %}
+    </div>
+  {% endif %}
 </section>

--- a/styleguide/source/_patterns/03-organisms/by-author/link-list~centered.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/link-list~centered.json
@@ -49,6 +49,12 @@
       "text":"Department of Public Utilities (DPU)",
       "info": "",
       "property": ""
-    }]
+    }],
+    "more": {
+      "href": "#",
+      "text": "See all 10 related services",
+      "chevron": true,
+      "label": "See all of the resources for Executive Office of Health and Human Services"
+    }
   }
 }

--- a/styleguide/source/_patterns/03-organisms/by-author/link-list~short.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/link-list~short.json
@@ -24,6 +24,12 @@
       "text":"Department of Conservation and Recreation (DCR)",
       "info": "",
       "property": ""
-    }]
+    }],
+    "more": {
+      "href": "#",
+      "text": "See all 10 related services",
+      "chevron": true,
+      "label": "See all of the resources for Executive Office of Health and Human Services"
+    }
   }
 }

--- a/styleguide/source/_patterns/05-pages/detail-for-service-howto-location.json
+++ b/styleguide/source/_patterns/05-pages/detail-for-service-howto-location.json
@@ -240,7 +240,13 @@
           "size": "",
           "format": "form"
         }
-      }]
+      }],
+      "more": {
+        "href": "#",
+        "text": "See all 15 Resources",
+        "chevron": true,
+        "label": "See all of the resources for Executive Office of Health and Human Services"
+      }
     }
   },{
     "richText": {

--- a/styleguide/source/_patterns/05-pages/service.json
+++ b/styleguide/source/_patterns/05-pages/service.json
@@ -134,7 +134,12 @@
       "generalHeading":"All How-Tos:",
       "hideFilter": true,
 
-      "seeAll": null,
+      "seeAll": {
+        "type": "internal",
+        "href": "http://www.google.com",
+        "text": "See all 15 How-To's",
+        "info": ""
+      },
 
       "featuredLinks": [{
         "image": "",
@@ -163,6 +168,36 @@
         "image": "",
         "text": "Find an unemployment location",
         "href": "#"
+      },{
+        "image": "",
+        "text": "Log in to UI Online for recipients",
+        "href": "#"
+      },{
+        "image": "",
+        "text": "Check your status ",
+        "href": "#",
+        "label": ""
+      },{
+        "image": "",
+        "text": "Log work hours",
+        "href": "#"
+      },{
+        "image": "",
+        "text": "Appeal your status",
+        "href": "#"
+      },{
+        "image": "",
+        "text": "Find an unemployment location",
+        "href": "#"
+      },{
+        "image": "",
+        "text": "Log in to UI Online for recipients",
+        "href": "#"
+      },{
+        "image": "",
+        "text": "Check your status ",
+        "href": "#",
+        "label": ""
       }]
     }
   },
@@ -177,11 +212,30 @@
       "generalHeading":"",
       "hideFilter": true,
 
-      "seeAll": null,
+      "seeAll": {
+        "type": "internal",
+        "href": "http://www.google.com",
+        "text": "See all 10 pages",
+        "info": ""
+      },
 
       "featuredLinks": "",
 
       "links": [{
+        "image": "/assets/images/placeholder/130x160.png",
+        "text": "Name of optional guide",
+        "href": "#",
+        "label": "Guide:"
+      },{
+        "image": "",
+        "text": "Learn about the appeals process",
+        "href": "#"
+      },{
+        "image": "",
+        "text": "Learn about on the job training programs",
+        "type": "",
+        "label": ""
+      },{
         "image": "/assets/images/placeholder/130x160.png",
         "text": "Name of optional guide",
         "href": "#",
@@ -322,7 +376,22 @@
             },{
               "href":"#",
               "text":"Career Counseling"
-            }]
+            },{
+              "href":"#",
+              "text":"Job Search Help"
+            },{
+              "href":"#",
+              "text":"Job Training"
+            },{
+              "href":"#",
+              "text":"Career Counseling"
+            }],
+            "more": {
+              "href": "#",
+              "text": "See all 10 related services",
+              "chevron": true,
+              "label": "See all of the resources for Executive Office of Health and Human Services"
+            }
           }
         }
       }]
@@ -360,7 +429,65 @@
                 "size": "107KB",
                 "format": "DOCX"
               }
-            }]
+            },{
+              "downloadLink": {
+                "iconSize": "small",
+                "icon": "@atoms/05-icons/svg-doc-pdf.twig",
+                "decorativeLink": {
+                  "text": "Work Search Activity Log",
+                  "href": "#",
+                  "info": "",
+                  "property": ""
+                },
+                "size": "1MB",
+                "format": "PDF"
+              }
+            },{
+              "downloadLink": {
+                "iconSize": "small",
+                "icon": "@atoms/05-icons/svg-doc-docx.twig",
+                "decorativeLink": {
+                  "text": "Name of Doc",
+                  "href": "#",
+                  "info": "",
+                  "property": ""
+                },
+                "size": "107KB",
+                "format": "DOCX"
+              }
+            },{
+              "downloadLink": {
+                "iconSize": "small",
+                "icon": "@atoms/05-icons/svg-doc-pdf.twig",
+                "decorativeLink": {
+                  "text": "Work Search Activity Log",
+                  "href": "#",
+                  "info": "",
+                  "property": ""
+                },
+                "size": "1MB",
+                "format": "PDF"
+              }
+            },{
+              "downloadLink": {
+                "iconSize": "small",
+                "icon": "@atoms/05-icons/svg-doc-docx.twig",
+                "decorativeLink": {
+                  "text": "Name of Doc",
+                  "href": "#",
+                  "info": "",
+                  "property": ""
+                },
+                "size": "107KB",
+                "format": "DOCX"
+              }
+            }],
+            "more": {
+              "href": "#",
+              "text": "See all 10 additional resources",
+              "chevron": true,
+              "label": "See all of the resources for Executive Office of Health and Human Services"
+            }
           }
         }
       }]

--- a/styleguide/source/assets/scss/03-organisms/_action-finder.scss
+++ b/styleguide/source/assets/scss/03-organisms/_action-finder.scss
@@ -164,10 +164,20 @@ $action-finder-bp: 900px;
     z-index: 2;
   }
 
+  &--no-background &__see-all {
+    margin-top: -40px;
+  }
+
   &__see-all-container {
     @include ma-container;
     padding-top: 14px;
     padding-bottom: 14px;
     text-align: right;
+  }
+
+  &--no-background &__see-all-container {
+    padding-top: 0;
+    padding-bottom: 48px;
+    text-align: left;
   }
 }

--- a/styleguide/source/assets/scss/03-organisms/_form-downloads.scss
+++ b/styleguide/source/assets/scss/03-organisms/_form-downloads.scss
@@ -5,4 +5,8 @@
   .main-content--full .page-content > & {
     @include ma-container;
   }
+
+  &__see-all {
+    margin-top: 1rem;
+  }
 }

--- a/styleguide/source/assets/scss/03-organisms/_link-list.scss
+++ b/styleguide/source/assets/scss/03-organisms/_link-list.scss
@@ -53,4 +53,8 @@
       line-height: 1.2;
     }
   }
+
+  &__see-all {
+    margin-top: 1rem;
+  }
 }

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_action-finder.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_action-finder.scss
@@ -91,4 +91,23 @@ $action-finder-border-color: tint($c-theme-primary,50%);
       }
     }
   }
+
+  &--no-background &__see-all {
+    background-color: $c-bg-section;;
+
+    .ma__decorative-link {
+
+      a {
+        color: $c-font-link;
+
+        &:hover {
+          border-color: rgba($c-font-link, .5);
+        }
+      }
+
+      svg {
+        fill: rgba($c-font-link, .5);
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR creates an optional "more link" for form downloads and link list organism.  It also styles the action finder organism's "more link" for the no-background variant.  All of the styles are based on designs in [JIRA design ticket](https://jira.state.ma.us/browse/DP-4765)

JIRA ticket:
https://jira.state.ma.us/browse/DP-5175

To test:
- [ ] Pull down this branch, `cd styleguide` and run `gulp` locally
- [ ] Browse to the service page: http://localhost:3000/?p=pages-service
- [ ] Ensure that you can see the more links at the bottom of:
  - [ ] "What would you like to do" > "All How To's"
  - [ ] "What you need to know"
  - [ ] "Related Services"
  - [ ] "Additional Resources"
- [ ] Browse to the service detail page: http://localhost:3000/?p=pages-detail-for-service-howto-location
- [ ] Ensure that you can see the more links at the bottom of:
  - [ ] "Stretch Code Adoption by Community" > "Additional Resources"
Optionally, browse to the child components to make sure the variants sans-more links still render properly:
- [ ] Form downloads: http://localhost:3000/?p=organisms-form-downloads
- [ ] Link list: http://localhost:3000/?p=organisms-link-list

TODO: 
Add these as variants, update documentation
