### PR TITLE
Hotfix deploy script - fix assets path

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -21,6 +21,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Migrate path
 
+## 5.6.1
+
+## Added
+
+## Changed
+- For developers - update the deploy script to not require an asset path by default for a prod or fork deploy and to not set the default to mayflower/assets for prod releases.
+
+## Removed
+
 ## 5.6.0
 
 ### Added

--- a/scripts/deploy-gh-pages.sh
+++ b/scripts/deploy-gh-pages.sh
@@ -193,7 +193,6 @@ cp ./source/_data/url.json.example ./source/_data/url.json
 
 # Determine the value of url.domain, url.assetsPath based on whether or not we have a cname argument
 domain="https://${owner}.github.io"
-#assetsPath="mayflower/assets"
 
 if [ ! "${cname}" = false ];
 then
@@ -204,6 +203,8 @@ then
     else
         assetsPath="assets"
     fi
+else
+    assetsPath="mayflower/assets"
 fi
 
 # Set url.domain and url.assetsPath

--- a/scripts/deploy-gh-pages.sh
+++ b/scripts/deploy-gh-pages.sh
@@ -193,7 +193,7 @@ cp ./source/_data/url.json.example ./source/_data/url.json
 
 # Determine the value of url.domain, url.assetsPath based on whether or not we have a cname argument
 domain="https://${owner}.github.io"
-assetsPath="mayflower/assets"
+#assetsPath="mayflower/assets"
 
 if [ ! "${cname}" = false ];
 then

--- a/styleguide/source/_patterns/05-pages/readme2.json
+++ b/styleguide/source/_patterns/05-pages/readme2.json
@@ -5,7 +5,7 @@
   },
 
   "errorPage": {
-    "type": "v5.6.0 (8/22/2017)",
+    "type": "v5.6.1 (8/22/2017)",
     "title": "Welcome to Mayflower, the Commonwealth's Design System",
     "message": "Use the navigation menu above to browse our patterns."
   }


### PR DESCRIPTION
This PR fixes the bug where deployments to production set an asset path to `mayflower/assets/` by default instead of `assets/`.  It allows successful deployment to production.

Tested already via deploying from the hotfix to production (eek!) and deploying from the hotfix to Jes' github pages.  Both were successful.