### PR TITLE
DP-4877: Add vertical spacing between entries in the press relea…

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_press-status.scss
+++ b/styleguide/source/assets/scss/02-molecules/_press-status.scss
@@ -54,5 +54,6 @@
 
   &__name {
     font-size: 1.25rem;
+    margin-bottom: 10px;
   }
 }

--- a/styleguide/source/assets/scss/02-molecules/_press-status.scss
+++ b/styleguide/source/assets/scss/02-molecules/_press-status.scss
@@ -54,6 +54,6 @@
 
   &__name {
     font-size: 1.25rem;
-    margin-bottom: 10px;
+    margin-bottom: .5em;
   }
 }


### PR DESCRIPTION
This PR adds additional spacing between entries in the press release signees. 

JIRA ticket: https://jira.state.ma.us/browse/DP-4877

### Testing instructions:
* [ ] Pull down this branch, `cd styleguide` and run `gulp` locally
* [ ] Browse to the press release page: http://localhost:3000/?p=pages-press-release
* [ ] Ensure that you see additional spacing between the press release signee's names
* [ ] Update the `press-release.json` so that one of the names spans multiple lines
* [ ] Ensure that you can clearly differentiate between the individual press release signee's names even if the name spans multiple lines
* [ ] Test at all browser sizes