### PR TITLE
DP-4881: show subtitle on press release page

### DIFF
--- a/styleguide/source/_patterns/05-pages/press-release.json
+++ b/styleguide/source/_patterns/05-pages/press-release.json
@@ -3,7 +3,7 @@
     "category": "Press Release",
     "divider": false,
     "title": "Governor Baker Delivers State of the Commonwealth Address",
-    "subTitle": "",
+    "subTitle": "Governor Charlie Baker delivers his second State of the Commonwealth address from the House Chamber of the Massachusetts State House.",
     "headerTags": {
       "label": "Related to:",
       "taxonomyTerms": [{


### PR DESCRIPTION
This PR add an optional sub title to the press release page. 

JIRA ticket: https://jira.state.ma.us/browse/DP-4881 

### Testing instructions: 
* [ ] Pull down this branch, `cd styleguide` and run `gulp` locally
* [ ] Browse to the press release page: http://localhost:3000/?p=pages-press-release
* [ ] Observe you see a subtitle below the title
* [ ] Observe the styling matches that of other page headers that include subtitles
* [ ] Test at all browser sizes