### PR TITLE
Dp 3631 event colored heading

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing.twig
@@ -2,15 +2,15 @@
 
 <section class="ma__event-listing {{ gridClass }}">
   <div class="ma__event-listing__container">
-    {% if eventListing.coloredHeading %}
-      {% set coloredHeading = eventListing.coloredHeading %}
-      {% include "@atoms/04-headings/colored-heading.twig" %}
-    {% elseif eventListing.compHeading %}
+    {% if eventListing.compHeading %}
       {% set compHeading = eventListing.compHeading %}
       {% include "@atoms/04-headings/comp-heading.twig" %}
     {% elseif eventListing.sidebarHeading %}
       {% set sidebarHeading = eventListing.sidebarHeading %}
       {% include "@atoms/04-headings/sidebar-heading.twig" %}
+    {% elseif eventListing.coloredHeading %}
+      {% set coloredHeading = eventListing.coloredHeading %}
+      {% include "@atoms/04-headings/colored-heading.twig" %}
     {% endif %}
     <ul class="ma__event-listing__items">
       {% for eventTeaser in eventListing.events %}

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing.twig
@@ -2,11 +2,13 @@
 
 <section class="ma__event-listing {{ gridClass }}">
   <div class="ma__event-listing__container">
-    {% if eventListing.compHeading %}
+    {% if eventListing.coloredHeading %}
+      {% set coloredHeading = eventListing.coloredHeading %}
+      {% include "@atoms/04-headings/colored-heading.twig" %}
+    {% elseif eventListing.compHeading %}
       {% set compHeading = eventListing.compHeading %}
       {% include "@atoms/04-headings/comp-heading.twig" %}
-    {% endif %}
-    {% if eventListing.sidebarHeading %}
+    {% elseif eventListing.sidebarHeading %}
       {% set sidebarHeading = eventListing.sidebarHeading %}
       {% include "@atoms/04-headings/sidebar-heading.twig" %}
     {% endif %}


### PR DESCRIPTION
Adds support for colored heading to eventListing displays, per discussion and requirements in DP-3631

This also adds elseif, as I'm not sure the template was intended to support both displays potentially at the same time.