### PR TITLE
Type in 'non state' actor, remove spacing to follow AP style guide

### DIFF
--- a/styleguide/source/_patterns/05-pages/press-release~with-image.json
+++ b/styleguide/source/_patterns/05-pages/press-release~with-image.json
@@ -47,7 +47,7 @@
       },{
         "text": "Another Org"
       },{
-        "text": "A third party, non state organization"
+        "text": "A third party, nonstate organization"
       }]
     },
 


### PR DESCRIPTION
I removed the space in non state actor, to follow AP style guide. 

@jesconstantine  - can you review to ensure I did this pull request correctly? thank you! 