### PR TITLE
DP-5175 Service + Service Detail page more links - UAT updates

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-author/link-list.md
+++ b/styleguide/source/_patterns/03-organisms/by-author/link-list.md
@@ -35,6 +35,8 @@ linkList : {
     type: boolean
   links : [{
     type: array of decorativeLink / required
-  }]
+  }],
+  more:
+    type: decorativeLink / optional
 }
 ~~~

--- a/styleguide/source/_patterns/03-organisms/by-author/link-list~with-description.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/link-list~with-description.json
@@ -59,6 +59,12 @@
       "text":"Lorem ipsum dolor sit ",
       "info": "",
       "property": ""
-    }]
+    }],
+    "more": {
+      "href": "#",
+      "text": "See all 10 related services",
+      "chevron": true,
+      "label": "See all of the resources for Executive Office of Health and Human Services"
+    }
   }
 }

--- a/styleguide/source/_patterns/05-pages/detail-for-service-howto-location.json
+++ b/styleguide/source/_patterns/05-pages/detail-for-service-howto-location.json
@@ -228,12 +228,77 @@
         "sub": true
       },
       "downloadLinks": [{
+          "downloadLink": {
+            "iconSize": "",
+            "icon": "@atoms/05-icons/svg-doc-pdf.twig",
+            "decorativeLink": {
+              "text": "Stretch Code Adoption by Community",
+              "href": "http://www.mass.gov/eea/docs/doer/green-communities/grant-program/stretch-code-towns-adoption-by-community-map-and-list.pdf",
+              "info": "",
+              "property": ""
+            },
+            "size": "",
+            "format": "form"
+          }
+        },{
+        "downloadLink": {
+          "iconSize": "",
+          "icon": "@atoms/05-icons/svg-doc-docx.twig",
+          "decorativeLink": {
+            "text": "Name of Doc",
+            "href": "#",
+            "info": "",
+            "property": ""
+          },
+          "size": "",
+          "format": "form"
+        }
+      },{
         "downloadLink": {
           "iconSize": "",
           "icon": "@atoms/05-icons/svg-doc-pdf.twig",
           "decorativeLink": {
-            "text": "Stretch Code Adoption by Community",
-            "href": "http://www.mass.gov/eea/docs/doer/green-communities/grant-program/stretch-code-towns-adoption-by-community-map-and-list.pdf",
+            "text": "Work Search Activity Log",
+            "href": "#",
+            "info": "",
+            "property": ""
+          },
+          "size": "",
+          "format": "form"
+        }
+      },{
+        "downloadLink": {
+          "iconSize": "",
+          "icon": "@atoms/05-icons/svg-doc-docx.twig",
+          "decorativeLink": {
+            "text": "Name of another doc",
+            "href": "#",
+            "info": "",
+            "property": ""
+          },
+          "size": "",
+          "format": "form"
+        }
+      },{
+        "downloadLink": {
+          "iconSize": "",
+          "icon": "@atoms/05-icons/svg-doc-pdf.twig",
+          "decorativeLink": {
+            "text": "Another pdf",
+            "href": "#",
+            "info": "",
+            "property": ""
+          },
+          "size": "",
+          "format": "form"
+        }
+      },{
+        "downloadLink": {
+          "iconSize": "",
+          "icon": "@atoms/05-icons/svg-doc-docx.twig",
+          "decorativeLink": {
+            "text": "Helpful resource",
+            "href": "#",
             "info": "",
             "property": ""
           },
@@ -243,7 +308,7 @@
       }],
       "more": {
         "href": "#",
-        "text": "See all 15 Resources",
+        "text": "See all 15 additional resources",
         "chevron": true,
         "label": "See all of the resources for Executive Office of Health and Human Services"
       }

--- a/styleguide/source/_patterns/05-pages/service.json
+++ b/styleguide/source/_patterns/05-pages/service.json
@@ -172,32 +172,6 @@
         "image": "",
         "text": "Log in to UI Online for recipients",
         "href": "#"
-      },{
-        "image": "",
-        "text": "Check your status ",
-        "href": "#",
-        "label": ""
-      },{
-        "image": "",
-        "text": "Log work hours",
-        "href": "#"
-      },{
-        "image": "",
-        "text": "Appeal your status",
-        "href": "#"
-      },{
-        "image": "",
-        "text": "Find an unemployment location",
-        "href": "#"
-      },{
-        "image": "",
-        "text": "Log in to UI Online for recipients",
-        "href": "#"
-      },{
-        "image": "",
-        "text": "Check your status ",
-        "href": "#",
-        "label": ""
       }]
     }
   },
@@ -236,17 +210,18 @@
         "type": "",
         "label": ""
       },{
+        "image": "",
+        "text": "Another helpful link",
+        "href": "#",
+        "label": ""
+      },{
         "image": "/assets/images/placeholder/130x160.png",
-        "text": "Name of optional guide",
+        "text": "Another helpful guide",
         "href": "#",
         "label": "Guide:"
       },{
         "image": "",
-        "text": "Learn about the appeals process",
-        "href": "#"
-      },{
-        "image": "",
-        "text": "Learn about on the job training programs",
+        "text": "Last visible helpful link",
         "type": "",
         "label": ""
       }]
@@ -369,22 +344,22 @@
             "stacked": true,
             "links" : [{
               "href":"#",
-              "text":"Job Search Help"
+              "text":"Job search help"
             },{
               "href":"#",
-              "text":"Job Training"
+              "text":"Job training"
             },{
               "href":"#",
-              "text":"Career Counseling"
+              "text":"Career counseling"
             },{
               "href":"#",
-              "text":"Job Search Help"
+              "text":"A related service"
             },{
               "href":"#",
-              "text":"Job Training"
+              "text":"Another related service"
             },{
               "href":"#",
-              "text":"Career Counseling"
+              "text":"Yet another related service"
             }],
             "more": {
               "href": "#",
@@ -447,7 +422,7 @@
                 "iconSize": "small",
                 "icon": "@atoms/05-icons/svg-doc-docx.twig",
                 "decorativeLink": {
-                  "text": "Name of Doc",
+                  "text": "Name of another doc",
                   "href": "#",
                   "info": "",
                   "property": ""
@@ -460,7 +435,7 @@
                 "iconSize": "small",
                 "icon": "@atoms/05-icons/svg-doc-pdf.twig",
                 "decorativeLink": {
-                  "text": "Work Search Activity Log",
+                  "text": "Another pdf",
                   "href": "#",
                   "info": "",
                   "property": ""
@@ -473,7 +448,7 @@
                 "iconSize": "small",
                 "icon": "@atoms/05-icons/svg-doc-docx.twig",
                 "decorativeLink": {
-                  "text": "Name of Doc",
+                  "text": "Helpful resource",
                   "href": "#",
                   "info": "",
                   "property": ""

--- a/styleguide/source/assets/scss/01-atoms/_video.scss
+++ b/styleguide/source/assets/scss/01-atoms/_video.scss
@@ -1,13 +1,13 @@
 .ma__video {
   @include clearfix;
-  
+
   &__container {
     padding: 13px;
   }
 
   @media ($bp-small-min) {
-  
-    &--right &__container {
+
+    &--right {
       float: right;
       margin-left: 1em;
       margin-bottom: 1em;


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
This is a follow-up PR to #551 and it addresses the UAT requests from @cmajel for DP-5175 (see specificts in test script below)

It also fixed an alignment bug in the `floated right` variant of the `@atoms/09-media/video` pattern as seen [in dev on a service page](http://dev.massgov.velir.com/?p=pages-service); seems related to https://github.com/massgov/mayflower/pull/510/files


## Related Issue / Ticket

- [JIRA issue](https://jira.state.ma.us/browse/DP-5175)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

(already passed UAT)

1. Pull down the branch
1. `cd styleguide` and `gulp`
1. browse to the service and service detail page
1. Verify the conditions outlined in the list above are met:
  - [ ] For the service detail page, can we make the example show a list of 6 resources and then show 
the "see all"? I know devs sometimes take Mayflower literally so reflecting the caps as much as possible I think will be helpful.
  - [ ] On service detail can fix the capitalization + labeling so it is "See all 15 addition resources" rather than "See all 15 Resources"? That keeps it consistent with our treatment on the service page.
1. Browse to the service page and verify that the video is floated right and content flows around it
