### PR TITLE
DP-5307: contain location banner in content width on location page

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-author/location-banner.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/location-banner.json
@@ -1,7 +1,6 @@
 {
   "locationBanner": {
     "bgTitle":"Mt Greylock State Park",
-    "bgWide":"../../assets/images/placeholder/1600x400.png",
     "bgNarrow":"../../assets/images/placeholder/800x400.png",
     "id": "GUID24872901570",
     "googleMap": {

--- a/styleguide/source/_patterns/03-organisms/by-author/location-banner.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/location-banner.twig
@@ -5,12 +5,6 @@
     #{{ locationBannerId }} {
       background-image: url('{{ locationBanner.bgNarrow }}');
     }
-    
-    @media (min-width: 801px) {
-      #{{ locationBannerId }} {
-        background-image: url('{{ locationBanner.bgWide }}');
-      }
-    }
   </style>
   <div class="ma__location-banner__map">
     {% set googleMap = locationBanner.actionMap ? locationBanner.actionMap : locationBanner.googleMap %}

--- a/styleguide/source/assets/scss/03-organisms/_location-banner.scss
+++ b/styleguide/source/assets/scss/03-organisms/_location-banner.scss
@@ -1,4 +1,5 @@
 .ma__location-banner {
+  @include ma-container;
   @include clearfix;
   margin-bottom: 70px;
 


### PR DESCRIPTION
## Description
Mayflower location banner organism only render one 800x400 image and is contained within the content max-width.

## Related Issue / Ticket
https://jira.state.ma.us/browse/DP-5307

## Steps to Test
1.  `cd styleguide`
1. `gulp`
1. Navigate to Location banner organism
1. Observe that it only uses the 800x400 image
1. Observe that the max-width is inline with the content's max-width

## Screenshots
N/A

## Additional Notes:
N/A

#### Impacted Areas in Application
*  Location pages

#### @TODO
N/A

#### Today I learned...
N/A