### PR TITLE
Make the location listing page work in IE 11

### DIFF
--- a/styleguide/source/_meta/_01-foot.twig
+++ b/styleguide/source/_meta/_01-foot.twig
@@ -12,9 +12,8 @@
       window.initGoogleMaps = function() {
         // Set a flag that the library has loaded, in case google maps js misses event.
         window.googleMapsLoaded = true;
-        let mapsLibLoadEvent = new CustomEvent('ma:LibrariesLoaded:GoogleMaps');
         // Emit an event that the library has loaded.
-        document.dispatchEvent(mapsLibLoadEvent);
+        $(document).trigger('ma:LibrariesLoaded:GoogleMaps');
       }
     </script>
     <!-- @todo set up config for api keys -->

--- a/styleguide/source/assets/js/helpers/getElementOuterHtml.js
+++ b/styleguide/source/assets/js/helpers/getElementOuterHtml.js
@@ -1,0 +1,18 @@
+/**
+  * Get outerHTML of elements, taking care
+  * of SVG elements in IE as well.
+  *
+  * @param {Element} jquery object el
+  * @return {String}
+  */
+
+export default function (el) {
+  if (el.outerHTML) {
+    return el.outerHTML
+  }
+  else {
+    let container = document.createElement('div');
+        container.appendChild(el.cloneNode(true));
+    return container.innerHTML;
+  }
+}

--- a/styleguide/source/assets/js/helpers/getElementOuterHtml.js
+++ b/styleguide/source/assets/js/helpers/getElementOuterHtml.js
@@ -2,7 +2,7 @@
   * Get outerHTML of elements, taking care
   * of SVG elements in IE as well.
   *
-  * @param {Element} dom element el
+  * @param {Element} DOM object
   * @return {String}
   */
 

--- a/styleguide/source/assets/js/helpers/getElementOuterHtml.js
+++ b/styleguide/source/assets/js/helpers/getElementOuterHtml.js
@@ -2,7 +2,7 @@
   * Get outerHTML of elements, taking care
   * of SVG elements in IE as well.
   *
-  * @param {Element} jquery object el
+  * @param {Element} dom element el
   * @return {String}
   */
 

--- a/styleguide/source/assets/js/modules/locationListing.js
+++ b/styleguide/source/assets/js/modules/locationListing.js
@@ -738,7 +738,9 @@ export default function (window,document,$,undefined) {
   function doesPromoContainTags(haystack, needle) {
     return needle.every(function(v) {
       return Boolean(haystack.filter(function(item){
-        return Object.values(item).indexOf(v) !== -1;
+        // return Object.values(item).indexOf(v) !== -1;
+        // Object.values shim for IE11
+        return Object.keys(item).map(function(i) { return item[i]; }).indexOf(v) !== -1;
       }).length);
     });
   }

--- a/styleguide/source/assets/js/modules/locationListing.js
+++ b/styleguide/source/assets/js/modules/locationListing.js
@@ -1,5 +1,6 @@
 import sticky from "../helpers/sticky.js";
 import getTemplate from "../helpers/getHandlebarTemplate.js";
+import getOuterHtml from "../helpers/getElementOuterHtml.js";
 
 export default function (window,document,$,undefined) {
   // Active state classes for location listing rows.
@@ -600,7 +601,10 @@ export default function (window,document,$,undefined) {
    */
   function getSvgFromTag(tag) {
     // Get the existing corresponding icon markup so we don't have to worry about outdated markup.
-    return $('.js-filter-by-tags').find("#" + tag).parent().siblings('svg').prop('outerHTML');
+    // return $('.js-filter-by-tags').find("#" + tag).parent().siblings('svg').prop('outerHTML');
+    // Get outerHtml of svgElement shim for IE
+    // See: https://stackoverflow.com/questions/12592417/outerhtml-of-an-svg-element
+    return getOuterHtml($('.js-filter-by-tags').find("#" + tag).parent().siblings('svg')[0]);
   }
 
   /**


### PR DESCRIPTION
The Location Listing page was generating an error in IE11.  JavaScript code used in the foot.twig file was trying to use ES6 javascript which is not supported.  I replaced that code with a jQuery trigger event instead.

### To test
1. browse to the location listing page in staging with IE 11: https://jesconstantine.github.io/mayflower/?p=pages-location-listing

Make sure the zip sort, tag filter, pagination, and filter clearing all work

Here's a screenshot of the location listing functioning in IE11 with:
- tag filter applied (indicated by the results heading tags)
- svgs rendering in the updated results

![image](https://user-images.githubusercontent.com/3279883/30066275-67405c56-9225-11e7-9966-67f8faf8d708.png)
