### PR TITLE
Hotfix: DP-5466 Make location listing zip sort work with no autocomplete selection, submit on enter

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -21,6 +21,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Migrate Path
 
+## 5.7.1
+
+### Added
+
+### Changed
+
+- DP-5466 - Users can now enter in a zip or town in the town/zip location listing filter and press enter (i.e. without selecting an item from the autocomplete dropdown) to sort locations.
+
+### Removed
+
+### Migration path
+
 ## 5.7.0
 
 ### Added

--- a/styleguide/source/_patterns/05-pages/readme2.json
+++ b/styleguide/source/_patterns/05-pages/readme2.json
@@ -5,7 +5,7 @@
   },
 
   "errorPage": {
-    "type": "v5.7.0 (8/30/2017)",
+    "type": "v5.7.1 (9/6/2017)",
     "title": "Welcome to Mayflower, the Commonwealth's Design System",
     "message": "Use the navigation menu above to browse our patterns."
   }

--- a/styleguide/source/assets/js/modules/locationFilters.js
+++ b/styleguide/source/assets/js/modules/locationFilters.js
@@ -26,15 +26,6 @@ export default function (window,document,$,undefined) {
       renderForm({clearedFilter: data.clearedFilter, $form: $el});
     });
 
-    // Don't submit the form when a user selects the autocomplete dropdown item with enter
-    $el.keydown(function(e) {
-      if (e.keyCode === 13) {
-        if  ($(e.target).is($('.js-filter-by-location', $el).find('input'))) {
-          e.preventDefault();
-        }
-      }
-    });
-
     // Handle global form submission.
     $el.submit(function(e){
       e.preventDefault();

--- a/styleguide/source/assets/js/modules/locationListing.js
+++ b/styleguide/source/assets/js/modules/locationListing.js
@@ -290,6 +290,9 @@ export default function (window,document,$,undefined) {
    *  An object with the current state masterData instance and an array of their related sorted markers to send to map.
    */
   function transformData(data, transformation) {
+    // This data transformation potentially involves asynchronous google geocoding.
+    // This jQuery deferered object allows us to wait for a return before moving on inside of the parent function (which invokes this function).
+    // @see https://api.jquery.com/jquery.deferred/
     let promise = $.Deferred();
     let transformReturn = {};
 
@@ -307,6 +310,7 @@ export default function (window,document,$,undefined) {
         transformReturn.place = autocompletePlace;
         // Sort the markers and instance of locationListing masterData.
         transformReturn.data = sortDataAroundPlace(place, filteredData);
+        // Return the data sorted by location and the autocomplete place object
         promise.resolve(transformReturn);
       }
       // If place argument was populated from locationFilter (zipcode text input) but not from Place autocomplete.
@@ -317,11 +321,13 @@ export default function (window,document,$,undefined) {
         geocodeAddressString(place, function(result) {
           transformReturn.data = sortDataAroundPlace(result, filteredData);
           transformReturn.place = result;
+          // Return the data sorted by location and the geocoded place object
           promise.resolve(transformReturn);
         });
       }
     }
     else {
+      // Return the data sorted by alphabet and the empty place object
       promise.resolve({data: sortedData, place: place});
     }
 

--- a/styleguide/source/assets/js/modules/locationListing.js
+++ b/styleguide/source/assets/js/modules/locationListing.js
@@ -81,13 +81,11 @@ export default function (window,document,$,undefined) {
         // transformData() returns a jQuery deferred object which allows us to wait for any asynchronous js execution to return before executing the .done(callback).
         // @see: https://api.jquery.com/deferred.done/
         transformData(masterData, formValues).done(function (transformation) {
-          console.log(transformation);
           masterData = transformation.data; // preserve state
           // Update the results heading based on the current items state.
           transformation.data.resultsHeading = transformResultsHeading({data: transformation.data});
           // Update pagination data structure, reset to first page
           transformation.data.pagination = transformPaginationData({data: transformation.data});
-          console.log('transformation data: ', transformation.data);
           // Render the listing page.
           renderListingPage({data: transformation.data});
           // Get the associated markers based on the listing items.
@@ -110,7 +108,6 @@ export default function (window,document,$,undefined) {
           transformation.data.resultsHeading = transformResultsHeading({data: transformation.data});
           // Update pagination data structure, reset to first page
           transformation.data.pagination = transformPaginationData({data: transformation.data});
-          console.log('transformation data: ', transformation.data);
           // Render the listing page.
           renderListingPage({data: transformation.data});
           // Get the associated markers based on the listing items.

--- a/styleguide/source/assets/js/modules/locationListing.js
+++ b/styleguide/source/assets/js/modules/locationListing.js
@@ -78,6 +78,8 @@ export default function (window,document,$,undefined) {
 
       // Handle location listings form interaction (triggered by locationFilters.js).
       $locationFilter.on('ma:LocationFilter:FormSubmitted', function (e, formValues) {
+        // transformData() returns a jQuery deferred object which allows us to wait for any asynchronous js execution to return before executing the .done(callback).
+        // @see: https://api.jquery.com/deferred.done/
         transformData(masterData, formValues).done(function (transformation) {
           console.log(transformation);
           masterData = transformation.data; // preserve state
@@ -97,6 +99,8 @@ export default function (window,document,$,undefined) {
 
       // Handle active filter/tag button interactions (triggered by resultsHeading.js).
       $resultsHeading.on('ma:ResultsHeading:ActiveTagClicked', function (e, clearedFilter) {
+        // transformData() returns a jQuery deferred object which allows us to wait for any asynchronous js execution to return before executing the .done(callback).
+        // @see: https://api.jquery.com/deferred.done/
         transformData(masterData, clearedFilter).done(function (transformation) {
           masterData = transformation.data; // preserve state
           transformation.clearedFilter = clearedFilter;


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
This PR fixes the location listing such that when a user types in a value for the location sort (i.e. "02360" or "plymouth" or "boston mass") and does not select a value from the google places autocomplete dropdown, the sort still works.  

It also makes it so that [ENTER] keypress after either typing in a value in the location sort text field OR using the keyboard to arrow down and select a value from the google places autocomplete dropdown submits the form and updates the location listing.

The technical steps taken were:

- User more accurate logic to determine if an autocomplete dropdown option was selected
https://github.com/massgov/mayflower/pull/583/files#diff-d51af0e96f1e03f1a7e9ec2b37f923edL280

- Implement a jQuery deferred object to wait for location string geocoding before transforming and rendering data
https://github.com/massgov/mayflower/pull/583/files#diff-d51af0e96f1e03f1a7e9ec2b37f923edR300

- Remove the preventDefault() code on enter keypress to allow enter to submit the form
https://github.com/massgov/mayflower/pull/583/files#diff-2b291a049a37ff3f87a047512a083f6bL29

## Related Issue / Ticket

- [JIRA DP-5466](https://jira.state.ma.us/browse/DP-5466)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

- [ ] Browse to: https://jesconstantine.github.io/mayflower/?p=pages-location-listing
- [ ] Type in a location string i.e. "02360" or "plymouth" or "boston ma" into the zip/town input and press ENTER
- [ ] Verify that the locations are sorted by proximity to your location
- [ ] Start typing a location string i.e. "02360" or "plymouth" or "boston ma" into the zip/town input and use the arrow keys to enter into the dropdown and press ENTER to select an option
- [ ] Verify that the locations are sorted by proximity to your location
- [ ] Start typing a nonsensical string i.e. "blorp" into the zip/town input and press ENTER
- [ ] Verify that nothing happens (displaying error messaging is part of a future feature ticket)
- [ ] Verify that you can repeat the steps above and get a subsequent sort to function after "blorping" :)


## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* Location listing pages, organisms
* Event listing pages, organisms (because this is shared code in #564, /cc: @nstriedinger @gleroux02 )

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

* Add functionality to display a friendly error message when a user enters non-geocodable locations i.e. "blorp"

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->

* [jQuery deferred objects](https://api.jquery.com/category/deferred-object/) are helpful!