### PR TITLE
DP-5233 Fix basic table styles for tables in rich text editors

### DIFF
--- a/styleguide/source/assets/scss/06-theme/01-atoms/_table.scss
+++ b/styleguide/source/assets/scss/06-theme/01-atoms/_table.scss
@@ -1,3 +1,4 @@
+.ma__rich-text table,
 .rich-text table,
 .ma__table {
   thead {
@@ -18,7 +19,7 @@
 }
 
 .ma__table {
-  
+
   @media ($bp-small-max) {
     thead + tbody,
     tbody:first-child {
@@ -26,7 +27,7 @@
     }
 
     td {
-      
+
       &:before {
         color: $c-font-heading;
         font-weight: 500;
@@ -41,7 +42,7 @@
 }
 
 .ma__table--wide {
-  
+
   @media ($bp-medium-max) {
     thead + tbody,
     tbody:first-child {
@@ -49,7 +50,7 @@
     }
 
     td {
-      
+
       &:before {
         color: $c-font-heading;
         font-weight: 500;

--- a/styleguide/source/assets/scss/06-theme/01-atoms/_table.scss
+++ b/styleguide/source/assets/scss/06-theme/01-atoms/_table.scss
@@ -1,5 +1,4 @@
 .ma__rich-text table,
-.rich-text table,
 .ma__table {
   thead {
     background-color: $c-bg-subtle;


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Add a missing class, **.ma__rich-text** to apply the styles to tables in rich text editor.
The class is currently used in Drupal, which is not in Mayflower. That's causing some styles are not applied to tables in rich text editor.

## Related Issue / Ticket

- [DP-5233 Fix basic table styles for tables in rich text editors](https://jira.state.ma.us/browse/DP-5233)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->
**Note:** 

- Pre-release tag for testing in Drupal with this branch is available:  [5.7.4-alpha](https://github.com/massgov/mayflower/releases/tag/5.7.4-alpha)
- Sample test page - [https://pilot.mass.gov/decision/financial-impact-of-early-voting-in-the-city-of-woburn-and-the-town-of-oxford](https://pilot.mass.gov/decision/financial-impact-of-early-voting-in-the-city-of-woburn-and-the-town-of-oxford)
- The table heading background color is applied to `<thead>`.  If `<thead>` is missing from a table, no background color is applied to the top row of the table.

1. Build with the pre-release tag in Drupal. 
2. See tables in rich text editor and their styles match to the [styleguide](http://mayflower.digital.mass.gov/?p=viewall-atoms-table).

**Styleguide**
<img width="578" alt="pattern_lab_-_viewall-atoms-table" src="https://user-images.githubusercontent.com/9633303/30332420-3a50b4ce-97a8-11e7-9531-9f8d70c33e81.png">


## Screenshots
Before
<img width="630" alt="dp-5233_before" src="https://user-images.githubusercontent.com/9633303/30335758-2e4194ec-97b1-11e7-88c7-afecb5b68fe6.png">

After
<img width="507" alt="dp-5223_after" src="https://user-images.githubusercontent.com/9633303/30335763-332f9f8a-97b1-11e7-9356-9bc0e3c5055e.png">


## Additional Notes:

No Drupal change required for DP-5233.

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
