### PR TITLE
DP-4968 Mayflower for a document download on a location page

### DIFF
--- a/styleguide/source/_patterns/05-pages/location-general-content.json
+++ b/styleguide/source/_patterns/05-pages/location-general-content.json
@@ -128,6 +128,10 @@
       "text": "Restrictions",
       "info": ""
     },{
+      "href": "downloads",
+      "text": "Downloads",
+      "info": ""
+    },{
       "href": "contacts",
       "text": "Contacts",
       "info": ""
@@ -501,6 +505,30 @@
           },{
             "text":"Lorem ipsum dolor sit amet, consectetur adipisicing elit."
           }]
+        }
+      }]
+    },
+
+    "formDownloads": {
+      "compHeading": {
+        "title": "Downloads",
+        "sub": true,
+        "color": "",
+        "id": "downloads",
+        "centered": ""
+      },
+      "downloadLinks": [{
+        "downloadLink": {
+          "iconSize": "",
+          "icon": "@atoms/05-icons/svg-doc-pdf.twig",
+          "decorativeLink": {
+            "text": "Southbridge RMV Map",
+            "href": "#",
+            "info": "",
+            "property": ""
+          },
+          "size": "1MB",
+          "format": "PDF"
         }
       }]
     },

--- a/styleguide/source/_patterns/05-pages/location-general-content.twig
+++ b/styleguide/source/_patterns/05-pages/location-general-content.twig
@@ -23,6 +23,8 @@
   {% include "@organisms/by-author/rich-text.twig" %}
   {% set richText = mainContent.restrictions %}
   {% include "@organisms/by-author/rich-text.twig" %}
+  {% set formDownloads = mainContent.formDownloads %}
+  {% include "@organisms/by-author/form-downloads.twig" %}
 {% endblock %}
 
 {% block sidebar %}


### PR DESCRIPTION
## Description
Add a section on the location page for downloads like a PDF map of the location

## Related Issue / Ticket
- https://jira.state.ma.us/browse/DP-4968
- https://jira.state.ma.us/browse/DP-4939

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->
1. Navigate to the location page (http://localhost:3000/?p=pages-location-general-content)
2. Observe in the sticky nav you now see "Downloads"
3. Click "Downloads"
4. Observe you see a section for "Downloads"
5. Observe the example is a PDF map

## Screenshots
N/A

## Additional Notes:
N/A

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->
* Location general content
* Form downloads

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->
N/A

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
N/A