### PR TITLE
DP-4318 Fix font size discrepency in the service page sidebar

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_link-list.scss
+++ b/styleguide/source/assets/scss/03-organisms/_link-list.scss
@@ -49,7 +49,7 @@
 
   .sidebar &__item {
     .ma__decorative-link {
-      font-size: 1.625rem;
+      font-size: 1.25rem;
       line-height: 1.2;
     }
   }


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Set the decorative link in the sidebar to be the same size as the social links

## Related Issue / Ticket
- https://jira.state.ma.us/browse/DP-4318

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Navigate to Service page (http://localhost:3000/?p=pages-service)
1. Observe you see a decorative link in the sidebar
1. Observe that the decorative link is the same size as the social links

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.
- [Invision](https://invis.io/8JAASW945#/217307063_Service_Page)


## Additional Notes:
N/A


#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->
*  Decorative link
* Service page

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->
N/A

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
N/A