### PR TITLE
DP-4717 -- Use sentence case for header tags pattern

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_header-tags.scss
+++ b/styleguide/source/assets/scss/02-molecules/_header-tags.scss
@@ -1,7 +1,6 @@
 .ma__header-tags {
   font-size: 16px;
   letter-spacing: .1em;
-  text-transform: uppercase;
 
   &__terms {
     display: inline;

--- a/styleguide/source/assets/scss/02-molecules/_header-tags.scss
+++ b/styleguide/source/assets/scss/02-molecules/_header-tags.scss
@@ -22,7 +22,6 @@
       margin-bottom: .5em;
       margin-right: .3em;
       padding: 3px 8px;
-      text-transform: capitalize;
 
       &:last-child {
         margin-right: 0;

--- a/styleguide/source/assets/scss/02-molecules/_header-tags.scss
+++ b/styleguide/source/assets/scss/02-molecules/_header-tags.scss
@@ -1,11 +1,13 @@
 .ma__header-tags {
   font-size: 16px;
   letter-spacing: .1em;
+  text-transform: uppercase;
 
   &__terms {
     display: inline;
     letter-spacing: 0;
     margin-left: .5em;
+    text-transform: none;
 
     @media ($bp-x-small-max) {
       display: block;


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
Remove the css rule for the @molecules/header-tags pattern which currently forces this title case: text-transform: capitalize;

## Related Issue / Ticket

- https://jira.state.ma.us/browse/DP-4517
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Read ticket.
2. Verify that CSS rule has been removed by visiting a page with the relationship indicator.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
