### PR TITLE
DP-4858 Remove "DRAFT" from decision page

### DIFF
--- a/styleguide/source/_patterns/05-pages/board-decision.json
+++ b/styleguide/source/_patterns/05-pages/board-decision.json
@@ -15,9 +15,6 @@
       }]
     },
     "socialLinks": null,
-    "publishState": {
-      "text": "Draft"
-    },
     "optionalContents": [{
       "path": "@molecules/listing-table.twig",
       "data": {

--- a/styleguide/source/_patterns/05-pages/board-decision.json
+++ b/styleguide/source/_patterns/05-pages/board-decision.json
@@ -15,6 +15,7 @@
       }]
     },
     "socialLinks": null,
+    "publishState": null,
     "optionalContents": [{
       "path": "@molecules/listing-table.twig",
       "data": {


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Remove the draft indicator from the top of the decision page

## Related Issue / Ticket
https://jira.state.ma.us/browse/DP-4858

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->
1. Navigate to the decision page (http://localhost:3000/?p=pages-board-decision)
1. Observe you do not see "DRAFT" at the top of the page

## Screenshots
N/A

## Additional Notes:
N/A

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->
* Board Decision Page

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->
N/A

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
