### PR TITLE
DP-5636 Drop shadows on homepage - mobile

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_stacked-row-section.scss
+++ b/styleguide/source/assets/scss/03-organisms/_stacked-row-section.scss
@@ -1,9 +1,12 @@
 .ma__stacked-row-section {
 
   @media ($bp-large-max) {
+    box-shadow: 0 0.5rem 0.5rem -0.25rem rgba(1, 1, 1, 0.25);
     padding-bottom: 45px;
 
-    &:last-child {
+    // Removes box-shadow on homepage and last item.
+    &:last-child,
+    .is-front & {
       box-shadow: none;
     }
   }

--- a/styleguide/source/assets/scss/03-organisms/_stacked-row-section.scss
+++ b/styleguide/source/assets/scss/03-organisms/_stacked-row-section.scss
@@ -1,7 +1,6 @@
 .ma__stacked-row-section {
 
   @media ($bp-large-max) {
-    box-shadow: 0 0.5rem 0.5rem -0.25rem rgba(1, 1, 1, 0.25);
     padding-bottom: 45px;
 
     &:last-child {
@@ -38,7 +37,7 @@
   &--restricted &__title {
     max-width: 820px;
   }
-  
+
   .main-content {
 
     @media ($bp-large-max) {


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
https://jira.state.ma.us/browse/DP-5636
Some section breakers on homepage were showing box shadows that are not part
of the design requirements.  I went ahead and removed them.

## Related Issue / Ticket

- DP-5636
- N/A

## Steps to Test
* Visit Mass.gov's homepage
* Scroll through the page and look at the various row sections.  They should not have any box shadow.

## Screenshots
* Homepage showing box shadow: http://take.ms/KeuFT
* Homepage NOT showing box shadow: http://take.ms/BGHRj

## Additional Notes:

N/A

#### Impacted Areas in Application
Homepage mobile only.

#### @TODO
N/A

#### Today I learned...
Today I learned how to fix bugs in the mayflower repo.