### PR TITLE
updated Node install instructions to fix gulp

### DIFF
--- a/docs/machine-setup.md
+++ b/docs/machine-setup.md
@@ -4,7 +4,8 @@ In order to run Mayflower locally, you need to have some things installed and se
 
 1. Install PHP ([v5.6.4](https://secure.php.net/get/php-5.6.4.tar.bz2/from/a/mirror))
     - See steps for [windows](https://www.sitepoint.com/how-to-install-php-on-windows/) || [mac os](https://ryanwinchester.ca/posts/install-php-5-6-in-osx-10-with-homebrew)
-2. Install NodeJS ([v6.9.4](https://nodejs.org/en/blog/release/v6.9.4/))
-    - If you need a different version of NodeJS for another project, you can use a tool like [N](https://github.com/tj/n) or [NVM](https://www.sitepoint.com/quick-tip-multiple-versions-node-nvm/) to manage multiple versions.
+2. Install NodeJS ([v6.9.4+](https://treehouse.github.io/installation-guides/mac/node-mac.html))
+    - Switch Node Package Manager (NPM) to the correct directory `npm config set prefix /usr/local`
+    - If you need a different version of NodeJS for another project, you can use a tool like [N](https://github.com/tj/n) or [NVM](https://github.com/creationix/nvm) to manage multiple versions.
 3. Install GulpJS [globally](https://docs.npmjs.com/getting-started/installing-npm-packages-globally) 
     - Run `npm install -g gulp-cli` from your command line


### PR DESCRIPTION
## Description
`gulp` wasn't working even though I followed the instructions in the README. This PR updates the instructions in the README, specifically to change the folder where NPM is installed per [this website](http://blog.webbb.be/command-not-found-node-npm/). Added instructions immediately after installing Node rather than waiting until people using the README had already tried and failed to get `gulp` to work. 

## Related Issue / Ticket

- None

## Steps to Test
1. Un-set up your machine (uninstall Node, uninstall Gulp, uninstall NPM, uninstall NVM or N).
2. Follow the revised [README instructions](https://github.com/hackajesse/mayflower/blob/readme-update/docs/machine-setup.md) for setting up Mayflower as a demo/tester, paying extra attention to step number 1 when installing Node.
3. After you get through setting up your machine, follow the Demo Install instructions. 
4. Confirm `gulp` works and go to  http://localhost:3000/ (or port shown in gulp output if you've configured it differently) to see that Mayflower displays.


#### Today I learned...
Updating a README can be a more involved process than one might expect. 