### PR TITLE
remove outline on forced focused elements that are non-interactive

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/global/_elements.scss
+++ b/styleguide/source/assets/scss/01-atoms/global/_elements.scss
@@ -89,3 +89,14 @@ h6 {
   @include ma-visually-hidden;
 }
 
+h1,
+h2,
+h3,
+h4,
+p,
+main,
+div {
+  &[tabindex="-1"]:focus {
+    outline: none;
+  }
+}


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
Removes outline on focused, non-interactive elements. This focus using `tabindex=-1` is used for directing screenreaders on the page, and doesn't need additional visual indication.

## Related Issue / Ticket

- [JIRA issue](https://jira.state.ma.us/browse/DP-3060)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Visit a how-to page.
2. Ensure that navigating to different sections via the sidebar does not add an outline to headings. 

## Screenshots
<img width="788" alt="screen shot 2017-10-11 at 11 27 39 am" src="https://user-images.githubusercontent.com/1397914/31450359-3b7e85ac-ae77-11e7-8c97-6972f5dc19e1.png">



## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* Sticky nav

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
