### PR TITLE
DP-5915--Updates spacing on section links

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_section-links.scss
+++ b/styleguide/source/assets/scss/02-molecules/_section-links.scss
@@ -94,7 +94,7 @@
     @include ma-h3;
     margin-bottom: 15px;
     align-self: stretch;
-    
+
     a {
       border: none;
     }
@@ -166,10 +166,9 @@
     @include ma-reset-list;
   }
 
-
   // skip the first item
   &__item + &__item {
-    margin-top: .75em;
+    margin-top: 1em;
   }
 
   // Make child content callout links full width
@@ -181,5 +180,6 @@
 
   &__item > .ma__decorative-link {
     font-size: 1.625rem;
+    line-height: 1.3;
   }
 }


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
Updates section links component by updating line height on anchors to
1.3 and increasing margin top on list items to 1em (except first one).

## Related Issue / Ticket

- [JIRA issue]()
https://jira.state.ma.us/browse/DP-5915

## Steps to Test
* Visit either http://localhost:3000/?p=molecules-section-links, or once changes have been merged http://mayflower.digital.mass.gov/?p=molecules-section-links
* Compare with attached screenshots in ticket (before)
* Spacing for list items should have increased and spacing in text within anchor should have decreased for better readability. 

1. 

## Screenshots
Refer to screenshot included in Jira ticket.


## Additional Notes:

These changes may not be available for local test depending on how they are merged into project.

#### Impacted Areas in Application
Mayflower's **02-molecules/_section-links** as well as https://www.mass.gov/topics/housing-property

* 

#### @TODO
N/A

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
