### PR TITLE
DP-6111: Add initial work for no event state.

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing-as-grid.md
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing-as-grid.md
@@ -1,5 +1,5 @@
 ### Description
-This is a variant of the [Event Listing](./?p=organisms-event-listing) pattern showing how it can be renedered as a grid.
+This is a variant of the [Event Listing](./?p=organisms-event-listing) pattern showing how it can be rendered as a grid.
 
 ### How to generate
 * set the `grid` variable to true

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing-past-as-grid.md
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing-past-as-grid.md
@@ -1,0 +1,6 @@
+### Description
+This is a variant of the [Event Listing](./?p=organisms-event-listing) pattern showing how it can be renedered as a grid when there are no upcoming events but there are past events.
+
+### How to generate
+* set the `grid` variable to true
+* set the "emptyText" and "pastMore" variables to the eventListing array.

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing-past-as-sidebar.md
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing-past-as-sidebar.md
@@ -1,0 +1,5 @@
+### Description
+This is a variant of the [Event Listing](./?p=organisms-event-listing) pattern showing how it should be rendered in the Right Rail when there are no upcoming events but there are past events.
+
+### How to generate
+* set the "emptyText" and "pastMore" variables to the eventListing array.

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing.md
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing.md
@@ -24,10 +24,16 @@ eventListing: {
   sidebarHeading:{
     type: compHeading / optional
   },
+  emptyText: {
+    type: string / optional
+  }
   events:[{
     type: eventTeaser / required
   }],
   more:{
+    type: link / optional
+  }
+  pastMore:{
     type: link / optional
   }
 }

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing.twig
@@ -13,15 +13,26 @@
       {% include "@atoms/04-headings/sidebar-heading.twig" %}
       {% set teaserHeading = (sidebarHeading.level ? : teaserHeading) + 1 %}
     {% endif %}
-    <ul class="ma__event-listing__items js-event-listing-items">
-      {% for eventTeaser in eventListing.events %}
-        {% set eventTeaser = eventTeaser|merge({"level":teaserHeading}) %}
-        <li class="ma__event-listing__item js-event-listing-item">
-          {% include "@molecules/event-teaser.twig" %}
-        </li>
-      {% endfor %}
-    </ul>
-    {% if eventListing.more %}
+    {% if eventListing.events %}
+      <ul class="ma__event-listing__items js-event-listing-items">
+        {% for eventTeaser in eventListing.events %}
+          {% set eventTeaser = eventTeaser|merge({"level":teaserHeading}) %}
+          <li class="ma__event-listing__item js-event-listing-item">
+            {% include "@molecules/event-teaser.twig" %}
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <div class="ma__event-listing__empty">
+        {{ eventListing.emptyText }}
+      </div>
+    {% endif %}
+    {% if eventListing.pastMore and eventListing.pastEvents == true %}
+        <div class="ma__event-listing__past">
+          {% set link = eventListing.pastMore %}
+          {% include "@atoms/11-text/link.twig" %}
+        </div>
+    {% elseif eventListing.more and eventListing.events %}
       <div class="ma__event-listing__more">
         {% set link = eventListing.more %}
         {% include "@atoms/11-text/link.twig" %}

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing.twig
@@ -22,17 +22,19 @@
           </li>
         {% endfor %}
       </ul>
-    {% else %}
+    {% endif %}
+    {% if eventListing.emptyText %}
       <div class="ma__event-listing__empty">
         {{ eventListing.emptyText }}
       </div>
     {% endif %}
-    {% if eventListing.pastMore and eventListing.pastEvents == true %}
-        <div class="ma__event-listing__past">
-          {% set link = eventListing.pastMore %}
-          {% include "@atoms/11-text/link.twig" %}
-        </div>
-    {% elseif eventListing.more and eventListing.events %}
+    {% if eventListing.pastMore %}
+      <div class="ma__event-listing__past">
+        {% set link = eventListing.pastMore %}
+        {% include "@atoms/11-text/link.twig" %}
+      </div>
+    {% endif %}
+    {% if eventListing.more %}
       <div class="ma__event-listing__more">
         {% set link = eventListing.more %}
         {% include "@atoms/11-text/link.twig" %}

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing~as-grid.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing~as-grid.json
@@ -61,6 +61,12 @@
       "text": "view all events at this location",
       "chevron": true,
       "label": ""
+    },
+    "pastMore":{
+      "href": "#",
+      "text": "See past events",
+      "info": "view all past events for this location",
+      "chevron": true
     }
   }
 }

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing~as-grid.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing~as-grid.json
@@ -61,12 +61,6 @@
       "text": "view all events at this location",
       "chevron": true,
       "label": ""
-    },
-    "pastMore":{
-      "href": "#",
-      "text": "See past events",
-      "info": "view all past events for this location",
-      "chevron": true
     }
   }
 }

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing~past-as-grid.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing~past-as-grid.json
@@ -1,0 +1,24 @@
+{
+  "eventListing": {
+    "grid": true,
+    "compHeading":{
+      "title": "Upcoming Events"
+    },
+    "emptyText": "No upcoming events scheduled",
+    "pastEvents": true,
+    "events": null,
+    "more":{
+      "href": "#",
+      "text": "view all events at this location",
+      "chevron": true,
+      "label": ""
+    },
+    "pastMore":{
+      "href": "#",
+      "text": "See past events",
+      "info": "view all past events for this location",
+      "chevron": true
+    }
+  }
+}
+ 

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing~past-as-grid.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing~past-as-grid.json
@@ -5,14 +5,7 @@
       "title": "Upcoming Events"
     },
     "emptyText": "No upcoming events scheduled",
-    "pastEvents": true,
     "events": null,
-    "more":{
-      "href": "#",
-      "text": "view all events at this location",
-      "chevron": true,
-      "label": ""
-    },
     "pastMore":{
       "href": "#",
       "text": "See past events",

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing~past-as-sidebar.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing~past-as-sidebar.json
@@ -5,18 +5,11 @@
       "title": "Upcoming Events"
     },
     "emptyText": "No upcoming events scheduled",
-    "pastEvents": true,
     "events": null,
-    "more":{
-      "href": "#",
-      "text": "view all events at this location",
-      "info": "view all upcoming events for this location",
-      "chevron": true
-    },
     "pastMore":{
       "href": "#",
       "text": "See past events",
-      "info": "view all past events for this location",
+      "info": "View all past events for this location",
       "chevron": true
     }
   }

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing~past-as-sidebar.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing~past-as-sidebar.json
@@ -1,0 +1,24 @@
+{
+  "eventListing": {
+    "compHeading" : null,
+    "sidebarHeading":{
+      "title": "Upcoming Events"
+    },
+    "emptyText": "No upcoming events scheduled",
+    "pastEvents": true,
+    "events": null,
+    "more":{
+      "href": "#",
+      "text": "view all events at this location",
+      "info": "view all upcoming events for this location",
+      "chevron": true
+    },
+    "pastMore":{
+      "href": "#",
+      "text": "See past events",
+      "info": "view all past events for this location",
+      "chevron": true
+    }
+  }
+}
+ 

--- a/styleguide/source/_patterns/05-pages/location-general-content.json
+++ b/styleguide/source/_patterns/05-pages/location-general-content.json
@@ -768,14 +768,7 @@
         "title": "Upcoming Events"
       },
       "emptyText": "No upcoming events scheduled",
-      "pastEvents": true,
       "events": null,
-      "more":{
-        "href": "#",
-        "text": "view all events at this location",
-        "chevron": true,
-        "label": ""
-      },
       "pastMore":{
         "href": "#",
         "text": "See past events",

--- a/styleguide/source/_patterns/05-pages/location-general-content.json
+++ b/styleguide/source/_patterns/05-pages/location-general-content.json
@@ -767,38 +767,20 @@
       "sidebarHeading":{
         "title": "Upcoming Events"
       },
-      "events":[{
-        "title": {
-          "href": "#",
-          "text": "Winter Birding Event",
-          "info": "",
-          "property": ""
-        },
-        "location": "Lanesborough, MA",
-        "date": {
-          "summary": "March 30, 2017" 
-        },
-        "time": "12 p.m. - 2 p.m.",
-        "description": "Event description. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Magnam tempora itaque fuga quasi vero sint, sapiente soluta sit molestias architecto deleniti sunt eum incidunt laboriosam quos repudiandae nesciunt eligendi? Aliquid."
-      },{
-        "title": {
-          "href": "#",
-          "text": "First Day Hike",
-          "info": "",
-          "property": ""
-        },
-        "location": "Lanesborough, MA",
-        "date": {
-          "summary": "March 30, 2017 - April 10, 2017"
-        },
-        "time": "12 p.m. - 2 p.m.",
-        "description": ""
-      }],
+      "emptyText": "No upcoming events scheduled",
+      "pastEvents": true,
+      "events": null,
       "more":{
         "href": "#",
         "text": "view all events at this location",
         "chevron": true,
         "label": ""
+      },
+      "pastMore":{
+        "href": "#",
+        "text": "See past events",
+        "info": "view all past events for this location",
+        "chevron": true
       }
     }
   }

--- a/styleguide/source/_patterns/05-pages/organization.json
+++ b/styleguide/source/_patterns/05-pages/organization.json
@@ -532,6 +532,8 @@
       "data": {
         "eventListing": {
           "grid": true,
+          "emptyText": "No upcoming events scheduled",
+          "pastEvents": true,
           "compHeading":{
             "title": "Upcoming Events",
             "sub": "",
@@ -539,46 +541,18 @@
             "id": "",
             "centered": ""
           },
-          "events":[{
-            "title": {
-              "href": "#",
-              "text": "Winter Birding Event",
-              "info": "",
-              "property": ""
-            },
-            "location": "Lanesborough, MA",
-            "date": {
-              "summary": "March 30, 2017",
-              "startMonth": "Mar",
-              "startDay": "30",
-              "endMonth": "",
-              "endDay": ""
-            },
-            "time": "12 p.m. - 2 p.m.",
-            "description": "Event description. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Magnam tempora itaque fuga quasi vero sint, sapiente soluta sit molestias architecto deleniti sunt eum incidunt laboriosam quos repudiandae nesciunt eligendi? Aliquid."
-          },{
-            "title": {
-              "href": "#",
-              "text": "First Day Hike",
-              "info": "",
-              "property": ""
-            },
-            "location": "Lanesborough, MA",
-            "date": {
-              "summary": "March 30, 2017 - April 10, 2017",
-              "startMonth": "Mar",
-              "startDay": "30",
-              "endMonth": "Apr",
-              "endDay": "10"
-            },
-            "time": "12 p.m. - 2 p.m.",
-            "description": ""
-          }],
+          "events": null,
           "more":{
             "href": "#",
             "text": "See all events",
             "chevron": true,
             "label": "See all events for Executive Office of Health and Human Services"
+          },
+          "pastMore":{
+            "href": "#",
+            "text": "See past events",
+            "info": "view all past events for Executive Office of Health and Human Services",
+            "chevron": true
           }
         }
       }

--- a/styleguide/source/_patterns/05-pages/organization.json
+++ b/styleguide/source/_patterns/05-pages/organization.json
@@ -533,7 +533,6 @@
         "eventListing": {
           "grid": true,
           "emptyText": "No upcoming events scheduled",
-          "pastEvents": true,
           "compHeading":{
             "title": "Upcoming Events",
             "sub": "",
@@ -542,12 +541,6 @@
             "centered": ""
           },
           "events": null,
-          "more":{
-            "href": "#",
-            "text": "See all events",
-            "chevron": true,
-            "label": "See all events for Executive Office of Health and Human Services"
-          },
           "pastMore":{
             "href": "#",
             "text": "See past events",

--- a/styleguide/source/assets/scss/03-organisms/_event-listing.scss
+++ b/styleguide/source/assets/scss/03-organisms/_event-listing.scss
@@ -144,11 +144,20 @@ $event-listing-bp-show-grid: $bp-medium-min;
   }
 
 
-  &__more {
-    margin-top: 30px;
+  &__more,
+  &__past {
+    margin-top: 20px;
 
     @media ($bp-large-min) {
-      margin-top: 45px;
+      margin-top: 35px;
+    }
+
+    .sidebar & {
+      margin-top: 15px;
+
+      @media ($bp-large-min) {
+        margin-top: 25px;
+      }
     }
   }
 

--- a/styleguide/source/assets/scss/03-organisms/_event-listing.scss
+++ b/styleguide/source/assets/scss/03-organisms/_event-listing.scss
@@ -16,7 +16,7 @@ $event-listing-bp-show-grid: $bp-medium-min;
   }
 
   &__empty {
-    font-size: 1.25rem;
+    font-size: 1.5rem;
     margin-bottom: .25em;
 
     .ma__page-header & {

--- a/styleguide/source/assets/scss/03-organisms/_event-listing.scss
+++ b/styleguide/source/assets/scss/03-organisms/_event-listing.scss
@@ -15,6 +15,15 @@ $event-listing-bp-show-grid: $bp-medium-min;
     @include ma-component-spacing;
   }
 
+  &__empty {
+    font-size: 1.25rem;
+    margin-bottom: .25em;
+
+    .ma__page-header & {
+      font-size: 1.813rem;
+    }
+  }
+
   &--grid &__container {
     
     @media ($event-listing-bp-show-grid) {

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_event-listing.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_event-listing.scss
@@ -1,5 +1,10 @@
 .ma__event-listing {
 
+  &__empty {
+    font-style: italic;
+    font-weight: 500;
+  }
+
   &--grid &__item {
     border-color: $c-bd-divider;
 


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
Adds link and empty text when there are no upcoming events, but past events are available.

## Related Issue / Ticket

- https://jira.state.ma.us/browse/DP-6111

## Steps to Test
1. Go to http://localhost:3000/?p=pages-organization there should be no upcoming events anymore, but the text for "no upcoming events scheduled" should display as well as a link to past events.
2. Go to http://localhost:3000/?p=pages-location-general-content there should be no upcoming events anymore, but the text for "no upcoming events scheduled" should display as well as a link to past events.
3. The organism has been built to show event lists with no upcoming events in sidebar: http://localhost:3000/patterns/03-organisms-by-author-event-listing-past-as-sidebar/03-organisms-by-author-event-listing-past-as-sidebar.html
4. The organism has been built to show event lists with no upcoming events in grid format: http://localhost:3000/patterns/03-organisms-by-author-event-listing-past-as-grid/03-organisms-by-author-event-listing-past-as-grid.html

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
