### PR TITLE
fix callout time alignment when text wraps

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -9,13 +9,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ```
 
 **For example**
-- DP-1234: The short description text on a [service detail](http://mayflower.digital.mass.gov/?p=pages-detail-for-service-howto-location) page banner ([@organisms/by-template/page-banner](http://mayflower.digital.mass.gov/?p=organisms-page-banner)) should now render ([PR #493](https://github.com/massgov/mayflower/pull/493)) 
+- DP-1234: The short description text on a [service detail](http://mayflower.digital.mass.gov/?p=pages-detail-for-service-howto-location) page banner ([@organisms/by-template/page-banner](http://mayflower.digital.mass.gov/?p=organisms-page-banner)) should now render ([PR #493](https://github.com/massgov/mayflower/pull/493))
 
 ## Upcoming (add in progress changes here)
 
 ### Added
 
 ### Changed
+- DP-6145 Fix icon overlap bug in time callout organism
 
 ### Removed
 
@@ -25,9 +26,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Thanks!
 
-We want to give a quick shout out and thanks to all of our friends who have helped to get Mayflower to where it is today through there contributions over the last year: @jasonstanbery, @reenybeeny, @iansholtys, @labbydev, @nstriedinger, @lukewertz, @gleroux02, and @plusjeff.  
+We want to give a quick shout out and thanks to all of our friends who have helped to get Mayflower to where it is today through there contributions over the last year: @jasonstanbery, @reenybeeny, @iansholtys, @labbydev, @nstriedinger, @lukewertz, @gleroux02, and @plusjeff.
 
-And a special warm thanks to our largest contributor by far, @legostud, for all of the thoughtfulness, care, and ingenuity with which you've crafted this project!  
+And a special warm thanks to our largest contributor by far, @legostud, for all of the thoughtfulness, care, and ingenuity with which you've crafted this project!
 
 We hope to see you all around in code. :)
 
@@ -36,7 +37,7 @@ We hope to see you all around in code. :)
 - DP-4968 - The [Location page](http://mayflower.digital.mass.gov/?p=pages-location-general-content) now supports a "Downloads" section which could be helpful for adding a pdf map, for example.
 - DP-4581 / 5023 - We've added sort and filter functionality to the [Event Listing](http://mayflower.digital.mass.gov/?p=pages-event-listing) page! Now you can enter a town or zip to sort events by proximity and you can filter events by a future date time frame.  (Also, developers will notice that the Event and Location listing js is shared, since the functionality is so similar.) ([PR #589](https://github.com/massgov/mayflower/pull/589))
 - DP-5341 - We've created a new pattern called [Collapsible Content](http://mayflower.digital.mass.gov/?p=organisms-collapsible-content)!  Eventually this pattern could be used for functionality like [Contact Us as accordion](https://mayflower.digital.mass.gov/?p=molecules-contact-us-collapsed-with-more-link) where it will accept child patterns using the `path / data` construct similar to Rich Text, sidebar widgets, etc. ([PR #581](https://github.com/massgov/mayflower/pull/581))
-- DP-4323 / 4325 - We've finished documenting all the patterns! (PRs [#545](https://github.com/massgov/mayflower/pull/545), [#546](https://github.com/massgov/mayflower/pull/546)). 
+- DP-4323 / 4325 - We've finished documenting all the patterns! (PRs [#545](https://github.com/massgov/mayflower/pull/545), [#546](https://github.com/massgov/mayflower/pull/546)).
 
 ### Changed
 
@@ -45,7 +46,7 @@ We hope to see you all around in code. :)
 - DP-4318 - Users will notice that the font size for links in the sidebar are more consistent.  (See example on the ["Social" and "Offered By" on the Service page](http://mayflower.digital.mass.gov/?p=pages-service)). ([PR #588](https://github.com/massgov/mayflower/pull/588))
 - DP-5653 - Our [Location listing](http://mayflower.digital.mass.gov/?p=pages-location-listing) and [Event listing](http://mayflower.digital.mass.gov/?p=pages-event-listing) page geosort functionality is now 8 times more cost effective (from 2 api credits down to .25 api credits!) ([PR #602](https://github.com/massgov/mayflower/pull/602))
 - DP-3763 - Users will notice that the zoom level has been set to a more appropriate level on maps which have only 1 marker (i.e. on the [Location page (general content)](http://mayflower.digital.mass.gov/?p=pages-location-general-content)). ([PR #604](https://github.com/massgov/mayflower/pull/604))
-- DP-5234 / 5177 - We've made some backwards-compatible updates to several patterns.  See [PR #571](https://github.com/massgov/mayflower/pull/571) for details. 
+- DP-5234 / 5177 - We've made some backwards-compatible updates to several patterns.  See [PR #571](https://github.com/massgov/mayflower/pull/571) for details.
 - Github #565 - Devs will notice that we've updated some npm packages. ([PR #565](https://github.com/massgov/mayflower/pull/565))
 
 ### Removed
@@ -141,17 +142,17 @@ We hope to see you all around in code. :)
 ## 5.6.0
 
 ### Added
-- DP-4181 - Folks browsing through the repository will notice new documentation which explains how to get set up, develop, and make other contributions to Mayflower!  This documentation is linked from the [shiny new repo readme](https://github.com/massgov/mayflower). ([PR #532](https://github.com/massgov/mayflower/pull/532)) 
+- DP-4181 - Folks browsing through the repository will notice new documentation which explains how to get set up, develop, and make other contributions to Mayflower!  This documentation is linked from the [shiny new repo readme](https://github.com/massgov/mayflower). ([PR #532](https://github.com/massgov/mayflower/pull/532))
 - DP-4053 - Developers can now follow a documented build + deploy process to ship their code to their own GitHub Pages where their work can be seen and tested! This documentation is linked from the [shiny new repo readme](https://github.com/massgov/mayflower). ([PR #530](https://github.com/massgov/mayflower/pull/530))
 - DP-4046 - The change above is possible because we can now host Mayflower from a subdirectory (i.e. <myname>.github.io/mayflower)! ([PR #503](https://github.com/massgov/mayflower/pull/503))
 - DP-4080 - Developers, reviewers, and release managers can (and should!) now follow documentation on Semantic Versioning as it applies to Mayflower.  This means we have guidelines to help reviewers understand what kind of change the code they are reviewing is and to help release managers understand what kind of version of Mayflower they are releasing. This documentation is linked from the [shiny new repo readme](https://github.com/massgov/mayflower). ([PR #504](https://github.com/massgov/mayflower/pull/504))
 - We documented all the things!  Well, almost all. :)  Check out patterns used on [Service](http://mayflower.digital.mass.gov/?p=pages-service), [How-To's](http://mayflower.digital.mass.gov/?p=pages-howto), [Guides](http://mayflower.digital.mass.gov/?p=pages-guide), [Locations](http://mayflower.digital.mass.gov/?p=pages-location-park-content), [Topics](http://mayflower.digital.mass.gov/?p=pages-topic), and [Events](http://mayflower.digital.mass.gov/?p=pages-event) and prepare ready to be informed! (Remember you can navigate to child patterns by clicking links down in the "Lineage" section.)  More goodness coming soon. (PRs [#521](https://github.com/massgov/mayflower/pull/521), [#523](https://github.com/massgov/mayflower/pull/523), [#524](https://github.com/massgov/mayflower/pull/524), [#527](https://github.com/massgov/mayflower/pull/527), [#529](https://github.com/massgov/mayflower/pull/529), [#533](https://github.com/massgov/mayflower/pull/533))
 
 ### Changed
-- Outside contribution from @sghoweri - Developers will notice that we now use a fork of Pattern Lab maintained by a Drupal Pattern Lab GitHub organization, with hopes of innovating, and iterating on Pattern Lab and merging changes back upstream to the main Pattern Lab fork.  
+- Outside contribution from @sghoweri - Developers will notice that we now use a fork of Pattern Lab maintained by a Drupal Pattern Lab GitHub organization, with hopes of innovating, and iterating on Pattern Lab and merging changes back upstream to the main Pattern Lab fork.
 
   This also allows us to see pattern inheritance: browse to a pattern, click the cog icon in the top-right corner, click show pattern info, and see where else patterns are used and which child patterns a given pattern contains. (PRs [#488](https://github.com/massgov/mayflower/pull/488) and [#519](https://github.com/massgov/mayflower/pull/519))  Thanks Salem!
- - Outside contribution from @evanlovely - Developers will notice an improvement to the automatic  build + browser reload during local development. ([PR #506](https://github.com/massgov/mayflower/pull/506)) Thanks Evan! 
+ - Outside contribution from @evanlovely - Developers will notice an improvement to the automatic  build + browser reload during local development. ([PR #506](https://github.com/massgov/mayflower/pull/506)) Thanks Evan!
 - Developers will notice standardization on a pattern for writing pattern modification classes, this accounts for nearly all of the backwards-compatible `.twig` changes in this release.
 - Developers and implementers will notice that [`@molecules/footnote`](http://mayflower.digital.mass.gov/?p=molecules-footnote) now has an option to render as plain text (as seen in Mass.gov Regulation pages, etc.) ([PR #541](https://github.com/massgov/mayflower/pull/541))
 - Contribution from our very own @meghandavis - See that typo on the [Press Listing page](http://mayflower.digital.mass.gov/?p=pages-press-listing)?  Nope.  That's because it's fixed!  Thanks Meghan!!
@@ -166,10 +167,10 @@ We hope to see you all around in code. :)
 ## 5.5.0
 
 Here comes another Mayflower release, hot off the summertime presses!  We've got 2 new page types and lots of little improvements and fixes coming your way.
- 
+
  **JIRA fans can check out the [release tickets](https://jira.state.ma.us/projects/DP/versions/14642) for more information.*
  **Mayflower project consumers can take a look at PR's below to confirm, make, and test any markup changes introduced by this release prior to updating in production.*
- 
+
 ### New Features
 - New page type: [Board Decisions](http://mayflower.digital.mass.gov/?p=pages-board-decision), which is used for rulings, decisions and opinions issued by agency boards or individuals given the authority to decide specific matters. ([@pages/board-decision](http://mayflower.digital.mass.gov/?p=pages-board-decision), See [PR #494](https://github.com/massgov/mayflower/pull/494))
 - We've also added an example [Form Page](http://mayflower.digital.mass.gov/?p=pages-form-page-example) to highlight form styles (projects likely implement forms using other services) (See [PR #490](https://github.com/massgov/mayflower/pull/490) - Markup)
@@ -183,7 +184,7 @@ Here comes another Mayflower release, hot off the summertime presses!  We've got
 - The short description text on a [service detail](http://mayflower.digital.mass.gov/?p=pages-detail-for-service-howto-location) page banner ([@organisms/by-template/page-banner](http://mayflower.digital.mass.gov/?p=organisms-page-banner)) should render (See [PR #493](https://github.com/massgov/mayflower/pull/493))
 - Assistive tech like screenreaders will now read callout stats ([@molecules/callout-stats](http://mayflower.digital.mass.gov/?p=molecules-callout-stats)) more naturally (See [PR #500](https://github.com/massgov/mayflower/pull/500) - Markup + CSS)
 - Semantic search form ([@molecules/header-search]()) label and placeholder text are more understandable (See [PR #485](https://github.com/massgov/mayflower/pull/485) - Markup + demo content)
- 
+
 ## 5.4.0
 In this new minor release, we've introduced two new Law pages: Policy Advisory and Executive Order, along with several improvements and fixes.
 
@@ -211,7 +212,7 @@ In this new minor release, we've introduced two new Law pages: Policy Advisory a
 - Page banner images (`@organisms/page_banner.scss`) will scale as large as possible (be zoomed out) to cover the page banner. (DP-4310)
 
 ## 5.3.0
-We've added some functionality to the location listings organism ([@organisms/by-author/location-listing](http://mayflower.digital.mass.gov/?p=organisms-location-listing))!  You can sort, filter, and paginate listing results! 
+We've added some functionality to the location listings organism ([@organisms/by-author/location-listing](http://mayflower.digital.mass.gov/?p=organisms-location-listing))!  You can sort, filter, and paginate listing results!
 
 Note: The location listing organism is made up of lots of other patterns:
   - [@molecules/location-filters](http://mayflower.digital.mass.gov/?p=molecules-location-filters)
@@ -219,7 +220,7 @@ Note: The location listing organism is made up of lots of other patterns:
   - [@molecules/google-map](http://mayflower.digital.mass.gov/?p=molecules-google-map)
   - [@molecules/pagination](http://mayflower.digital.mass.gov/?p=molecules-pagination)
   - [@organisms/by-author/image-promos](http://mayflower.digital.mass.gov/?p=organisms-image-promos)
-  
+
   And of course, you can still use those patterns in other components!
 
 ## 5.2.0
@@ -345,7 +346,7 @@ If you'd like to read about these changes in JIRA:
 1. We've revisited how we named our Sass color variables.  Instead of using $c-theme-blue for example we are now using $c-theme-primary.  This update will make it easy for others to create new color schemes for the Mayflower Patterns.
 2. The Location Listing page (Pages > Map listing human services) has been updated from the MVP version to the final version.  The Filters area was expanded to include additonal choices.  The Results area was updated to include tags to show which filters are currently being applied along with pagination.  The Results are also using a newer design that highlights the active or hovered location and makes the corresponding map marker bounce.
 3. For the Image Promo pattern, we've changed the description from being a required field to being an optional field.
-4. After testing the transition page with low to no vision users, we identified that changing the message from a paragraph to an H1 tag was an added benefit.    
+4. After testing the transition page with low to no vision users, we identified that changing the message from a paragraph to an H1 tag was an added benefit.
 
 ### FIXED
 
@@ -412,7 +413,7 @@ If you'd like to read about this changes in JIRA:
     * The new header layout includes a a spot for a description and a nifty new image size.
     * We've introduced some new variations to the card component (Molecules > Section Links) on the Topic Page:
         * You can now choose between regular links (by default) or callout links (Molecules > Section Links Callout Links).  This will help to call out How-To's and tasks associated with a service on a given topic page.
-        * For those times when we don't want to fill the card up with too many links but we want people to know there are more goodies, we've add an optional more link to the bottom of the card.   
+        * For those times when we don't want to fill the card up with too many links but we want people to know there are more goodies, we've add an optional more link to the bottom of the card.
 
 ## 3.6.0
 
@@ -428,7 +429,7 @@ If you'd like to read about these changes in JIRA:
 ### NEW FEATURES
 - Ahem... introducing the latest page type to our family: Services! (Pages > Service Unemployment Benefits).  This is a great page type to use to help surface tons of information related to services, including: branding information, instructional videos, links to how-to's, location information listings, etc.
 - We're making Org Landing Pages (Pages > Org Landing Page) more machine and search friendly by adding a Government Organization structured data pattern (Meta > Schema > Government Organization) to the bottom of the page markup.
-- For Mayflower implementers, we've created an example Guide page which shows all of the possible elements that can go into a Guide section (Pages > Guide Section Example)  
+- For Mayflower implementers, we've created an example Guide page which shows all of the possible elements that can go into a Guide section (Pages > Guide Section Example)
 
 ### IMPROVEMENTS
 - We've revisited the guide page with some updates.  We've consolidated the formerly 3 guide pages into one shiny new guide page with just those components that our content friends have identified as being pertinent:

--- a/styleguide/source/_patterns/03-organisms/by-author/callout-time.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/callout-time.json
@@ -1,6 +1,6 @@
 {
   "calloutTime": {
     "icon": "@atoms/05-icons/svg-dog.twig",
-    "text": "Text preceded by a variable icon"
+    "text": "Text preceded by a variable icon which wraps on narrow screens"
   }
 }

--- a/styleguide/source/assets/scss/03-organisms/_callout-time.scss
+++ b/styleguide/source/assets/scss/03-organisms/_callout-time.scss
@@ -15,9 +15,13 @@
     font-size: 0;
     height: 30px;
     position: absolute;
-      top: 0;
+      top: 16%;
       left: 0;
     width: 30px;
+
+    @media ($bp-medium-min) {
+      top: 10%;
+    }
 
     & > svg {
       height: 30px;

--- a/styleguide/source/assets/scss/03-organisms/_callout-time.scss
+++ b/styleguide/source/assets/scss/03-organisms/_callout-time.scss
@@ -15,9 +15,8 @@
     font-size: 0;
     height: 30px;
     position: absolute;
-      top: 50%;
+      top: 0;
       left: 0;
-    transform: translateY(-50%);
     width: 30px;
 
     & > svg {
@@ -29,6 +28,7 @@
   &__text {
     font-size: 1.438rem;
     font-style: italic;
+    display: inline-block;
     padding-left: 42px; // width of icon and margin
   }
 }


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
The callout time organism icon overlaps text when text is long and wraps on narrow screens, this PR adjust alignment to avoid overlap.

## Related Issue / Ticket

- [JIRA issue](https://jira.state.ma.us/browse/DP-6145)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. view `http://localhost:3000/?p=organisms-callout-time` and resize viewport
2. ensure that icon does not overlap and matches design direction as specified in JIRA tickets

## Screenshots
![icon-callout](https://user-images.githubusercontent.com/1397914/31514173-c96eb0fc-af5e-11e7-9d95-b8b0bca0e587.gif)



## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
