### PR TITLE
change map marker title from Email to Online

### DIFF
--- a/styleguide/source/assets/js/templates/googleMapInfo.html
+++ b/styleguide/source/assets/js/templates/googleMapInfo.html
@@ -17,7 +17,7 @@
   {{/if}}
   {{#if email}}
     <div class="ma__info-window__email">
-      <span class="ma__info-window__label">Email:</span>
+      <span class="ma__info-window__label">Online:</span>
       <a class="ma__info-window__email-link" href="mailto:{{email}}">{{email}}</a>
     </div>
   {{/if}}


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Change map marker title from Email to Online

## Related Issue / Ticket

- [DP-5513 Map marker label says "email" but should be "online"](https://jira.state.ma.us/browse/DP-5513)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Go to the org page in Mayflower: http://localhost:3000/?p=pages-organization
2. Click a marker to display its location info.
3. Find its web site url is labeled "Online" instead of "Email."

## Screenshots
<img width="588" alt="mayflower-after" src="https://user-images.githubusercontent.com/9633303/31035084-aae50476-a534-11e7-89bd-5eac2efb94bd.png">

## Additional Notes:
This replaces https://github.com/massgov/mayflower/pull/609
Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
