### PR TITLE
Dp 5636 remove stacked row box shadows

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Removed
 - DP-5914 - Remove extra padding on callout links
+- DP-5636 - On mobile, remove dropshadow between rows on stacked row section.
 
 ### Migrate Path
 

--- a/styleguide/source/assets/scss/03-organisms/_stacked-row-section.scss
+++ b/styleguide/source/assets/scss/03-organisms/_stacked-row-section.scss
@@ -1,11 +1,8 @@
 .ma__stacked-row-section {
 
   @media ($bp-large-max) {
-    box-shadow: 0 0.5rem 0.5rem -0.25rem rgba(1, 1, 1, 0.25);
     padding-bottom: 45px;
 
-    &:last-child {
-      box-shadow: none;
     }
   }
 

--- a/styleguide/source/assets/scss/03-organisms/_stacked-row-section.scss
+++ b/styleguide/source/assets/scss/03-organisms/_stacked-row-section.scss
@@ -3,6 +3,9 @@
   @media ($bp-large-max) {
     padding-bottom: 45px;
 
+    & ~ & {
+      border-top-width: 1px;
+      border-top-style: solid;
     }
   }
 
@@ -35,7 +38,7 @@
   &--restricted &__title {
     max-width: 820px;
   }
-  
+
   .main-content {
 
     @media ($bp-large-max) {

--- a/styleguide/source/assets/scss/04-templates/_stacked-row.scss
+++ b/styleguide/source/assets/scss/04-templates/_stacked-row.scss
@@ -6,6 +6,9 @@
     @media ($bp-large-max) {
       padding-bottom: 45px;
 
+      & ~ & {
+        border-top-width: 1px;
+        border-top-style: solid;
       }
     }
 

--- a/styleguide/source/assets/scss/04-templates/_stacked-row.scss
+++ b/styleguide/source/assets/scss/04-templates/_stacked-row.scss
@@ -4,11 +4,8 @@
   &__section {
 
     @media ($bp-large-max) {
-      box-shadow: 0 0.5rem 0.5rem -0.25rem rgba(1, 1, 1, 0.25);
       padding-bottom: 45px;
 
-      &:last-child {
-        box-shadow: none;
       }
     }
 

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_stacked-row-section.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_stacked-row-section.scss
@@ -1,6 +1,10 @@
 .ma__stacked-row-section {
 
-  & ~ & &__container:before {
+  & ~ & {
     border-color: $c-bd-divider;
+    
+    &__container:before {
+      border-color: $c-bd-divider;
+    }
   }
 }

--- a/styleguide/source/assets/scss/06-theme/04-templates/_stacked-row.scss
+++ b/styleguide/source/assets/scss/06-theme/04-templates/_stacked-row.scss
@@ -1,6 +1,10 @@
 .ma__stacked-row {
 
-  &__section ~ &__section &__container:before {
+  &__section ~ &__section {
     border-color: $c-bd-divider;
+    
+    &__container:before {
+      border-color: $c-bd-divider;
+    }
   }
 }


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
When viewing the Mass.gov homepage on mobile, there are drop shadows below every row or section. See attached for reference.
Expected: keep rule consistent across all screen sizes, no drop shadow, between rows, like on desktop.



## Related Issue / Ticket

- [JIRA issue](https://jira.state.ma.us/browse/DP-5636)
- [original PR](https://github.com/massgov/mass/pull/1432)
- [updated PR](https://github.com/massgov/mass/pull/1447)

## Steps to Test
- Before: [Mayflower stacked row template](http://mayflower.digital.mass.gov/?p=templates-stacked-row-template)
- After: [UAT stacked row template](https://clairesunstudio.github.io/mayflower/?p=templates-stacked-row-template)
- [ ] resize window to < 910px
- [ ] look for section breaks and see rule consistent across all screen sizes, expand full-width, no drop shadow


## Screenshots
- Before
![screen shot 2017-10-16 at 1 52 55 pm](https://user-images.githubusercontent.com/5789411/31627073-fc01c31a-b279-11e7-8e4a-ac9be52d13b1.png)

- After
![screen shot 2017-10-16 at 1 53 06 pm](https://user-images.githubusercontent.com/5789411/31627092-03e31872-b27a-11e7-82a8-8e92dca03af2.png)
