### PR TITLE
bump up page banner height on larger screens

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_page-banner.scss
+++ b/styleguide/source/assets/scss/03-organisms/_page-banner.scss
@@ -22,7 +22,7 @@ $page-banner-icon-width: $column + $gutter;
 
   &--overlay {
     @media ($bp-large-min) {
-      height: 300px;
+      height: 400px;
     }
   }
 


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
Increase height of service page banner on desktop to account for longer page titles.

## Related Issue / Ticket

- [DP-5388](https://jira.state.ma.us/browse/DP-5388)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. View service page: `http://localhost:3000/?p=pages-service` 
2. Height of banner on desktop should be 400px instead of 300px. 

## Screenshots
<img width="973" alt="screen shot 2017-11-07 at 12 59 01 pm" src="https://user-images.githubusercontent.com/1397914/32509493-7500028e-c3bb-11e7-8c3b-b1546645c47d.png">



## Additional Notes:

This seems like a band-aid solution to some degree, since longer content will always overflow, and a flexible height banner with consistent padding _may_ make more sense? But, I'm not sure we want or pragmatically care about a flexible height banner given the actual nature of the current content. 

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* Page Banner on desktop

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
