### PR TITLE
DP-5916 Location page results listing image display

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_image-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_image-promo.scss
@@ -67,9 +67,6 @@ $image-promo-bp-x-large-min: "min-width: 1160px";
 
   &__description {
     font-size: 1.25rem;
-  }
-
-  &__title + &__description {
     margin-top: 10px;
   }
 


### PR DESCRIPTION
## Description
This adjusts the spacing between pieces of content in the Image Promo component. Previously, the description had a 10px margin-top only when it was immediately below the title. DP-5916 requested that a 10px margin be put between the description and phone number. For consistency, the rules have been modified to have a 10px margin above the description at all times, as can be seen in the screenshot below.

## Related Issue / Ticket
https://jira.state.ma.us/browse/DP-5916

## Steps to Test
1. Check out branch locally and compile.
2. View the "Image Promo with Map Link" Molecule and confirm that there is a margin between the phone number and the description.

## Screenshots
![margins](https://user-images.githubusercontent.com/18170074/33088128-b988230a-ceba-11e7-80f5-f91dbeeb05fd.png)


## Additional Notes:
N/A

#### Impacted Areas in Application
* Image Promo organism, which is used in:
    * Image Promos organism, which is used in:
        * Location Listing organism (which is used in Location Listing page)
        * Location General Content page
        * Location Park Content page
    * Personal Message organism, which is used in:
        * Executive Order page
        * Press content type template (which is used in Press Release page)

#### @TODO
N/A

#### Today I learned...
N/A
