### PR TITLE
DP-6916 Prevent hyphen in "learn more about this organization" link in contact group

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_contact-group.scss
+++ b/styleguide/source/assets/scss/02-molecules/_contact-group.scss
@@ -63,7 +63,6 @@
     display: inline-block;
 
     a {
-      hyphens: auto;
       overflow-wrap: break-word;
       -ms-word-break: break-all;
       word-break: break-all;


### PR DESCRIPTION
## Description
The contact group's link hyphenation rule was removed to prevent auto-hyphenation. As no other hyphenation rule applies to the link by default, simple removal of the rule was adequate to fix this behavior.

## Related Issue / Ticket
https://jira.state.ma.us/browse/DP-6916

## Steps to Test

1. Check out branch locally and compile.
2. Visit http://localhost:3000/?p=pages-howto
3. Use inspector to modify the web link under the Contact sidebar block. It should be changed to "Learn more about this great organization".
4. Confirm that the link does not break on the word "organization".

## Screenshots
![hyphens](https://user-images.githubusercontent.com/18170074/33100085-24ef695c-cee1-11e7-86cf-1822ec3e12b7.png)

## Additional Notes:

N/A

#### Impacted Areas in Application
* A subset of the Contact Group molecules where link text is present and long enough to wrap onto multiple lines

#### @TODO
N/A

#### Today I learned...
N/A