### PR TITLE
DP-5385 Adds optional More link to Suggested Pages

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.json
@@ -57,7 +57,7 @@
     }],
     "more":{
       "href": "#",
-      "text": "See all related locations",
+      "text": "See all related pages",
       "info": "",
       "chevron": true
     }

--- a/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.json
@@ -54,6 +54,12 @@
         "text": "Title Link IV",
         "info": ""
       }
-    }]
+    }],
+    "more":{
+      "href": "#",
+      "text": "See all related locations",
+      "info": "",
+      "chevron": true
+    }
   }
 }

--- a/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.md
+++ b/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.md
@@ -8,6 +8,7 @@ This Pattern shows a collection of images and links to other pages on the site.
 * Illustrated link
 * Decorative Link
 * Image
+* Link
 
 ### Variant options
 * The pattern can be shown with [Illustrated Links](./?p=organisms-suggested-pages-guide)
@@ -30,5 +31,8 @@ This Pattern shows a collection of images and links to other pages on the site.
       type: decorativeLink / required
     }
   }]
+  "more": {
+    type: link / optional
+  }
 }
 ~~~

--- a/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.twig
@@ -27,5 +27,11 @@
         {% endfor %}
       {% endif %}
     </div>
+    {% if suggestedPages.more %}
+      <div class="ma__suggested-pages__more">
+        {% set link = suggestedPages.more %}
+        {% include "@atoms/11-text/link.twig" %}
+      </div>
+    {% endif %}
   </div>
 </section>


### PR DESCRIPTION
## Description
To allow Related Locations on Locations pages to link to location listing pages, a "More" link has to be added to the Suggested Pages organism. This is consistent with how it is handled for Event Listing and Press Listing organisms.

## Related Issue / Ticket
https://jira.state.ma.us/browse/DP-5385

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Check out branch locally and compile Mayflower.
2. Visit http://localhost:3000/?p=organisms-suggested-pages
3. Confirm that there is a "See all related locations" link below the pages and that it [looks like the design](https://projects.invisionapp.com/share/JZD9VUBKC#/screens/251141687_Mass-gov_Locationpage-Related-Seemore1) (with the understanding that the text can be customized to match the design as needed).

## Screenshots
![see all](https://user-images.githubusercontent.com/18170074/33134226-27e8d544-cf6d-11e7-8a45-de169ab1a3b7.png)

## Additional Notes:

#### Impacted Areas in Application
* Guide page
* Location Park Content page

#### @TODO
* Continue work on DP-5385 to use the new 'more' link