### PR TITLE
Release 5.9.0

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 **For example**
 - DP-1234: The short description text on a [service detail](http://mayflower.digital.mass.gov/?p=pages-detail-for-service-howto-location) page banner ([@organisms/by-template/page-banner](http://mayflower.digital.mass.gov/?p=organisms-page-banner)) should now render ([PR #493](https://github.com/massgov/mayflower/pull/493))
 
-## 5.9.0
+## 5.9.0 (11/27/2017)
 
 ### Added
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 **For example**
 - DP-1234: The short description text on a [service detail](http://mayflower.digital.mass.gov/?p=pages-detail-for-service-howto-location) page banner ([@organisms/by-template/page-banner](http://mayflower.digital.mass.gov/?p=organisms-page-banner)) should now render ([PR #493](https://github.com/massgov/mayflower/pull/493))
 
-## Upcoming (add in progress changes here)
+## 5.9.0
 
 ### Added
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Removed
 - DP-5636 - On mobile, remove dropshadow between rows on stacked row section.
+- DP-5914 - Remove extra padding on callout links
 
 ### Migrate Path
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -14,15 +14,29 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ## 5.9.0 (11/27/2017)
 
 ### Added
+- DP-5385 - The [Suggested Pages](http://mayflower.digital.mass.gov/?p=organisms-suggested-pages) pattern (i.e. Related Locations) now includes an optional more link so that it can be implemented to only render 3 entries and link to the rest.
+- DP-5858 - Styles have been added which hide the "Tell us what you think" button and ensure that contact accordions are expanded when a page is printed.
+- DP-6111 - Event teaser listings now have a ["no event" state](http://mayflower.digital.mass.gov/?p=organisms-event-listing-past-as-grid) which will render when the pattern is included on a page but no future events are provided.
 
 ### Changed
+- DP-4534 - The [header tags](http://mayflower.digital.mass.gov/?p=molecules-header-tags) molecule (i.e. relationship indicators) has been updated to support 3+ tags by adding a show/hide button to collapse and expand the tags.
+- DP-4572 - The dateline (i.e. BOSTON -) style on a press release page has been updated to be bold with an emdash appended.
+- DP-5388 - The page banner on a Service Page will now fit longer text content (i.e. up to 400px in height).
+- DP-5515 - [Service](http://mayflower.digital.mass.gov/?p=pages-service) and [Org](http://mayflower.digital.mass.gov/?p=pages-organization) page "action finder" titles (i.e. What would you like to do?) have been updated to sentence case.
+- DP-5518 - The style for the feedback form (i.e. Did you find what you're looking for) textarea is more consistent when a user clicks yes / no.
+- DP-5523 - When appearing consecutively (i.e. on a [Service Page](http://mayflower.digital.mass.gov/?p=pages-service) the grey background of the second "action finder" (i.e. What you need to know) will line up more consistently with the first.
+- DP-5914 - The spacing has been fixed on [Topic page Section links](http://mayflower.digital.mass.gov/?p=pages-topic) (i.e. Topic cards) which display Callout links (i.e. links to Services).
+- DP-6106 - The mobile styling for the banner on [Topic pages](http://mayflower.digital.mass.gov/?p=pages-topic&w=350px) has been made more consistent to other page banners: the height is flexible, the content is vertically centered, the icon removed, and the colored background fills the width of the screen.
 
 ### Removed
+- DP-3060 - The outline has been removed from the Heading which appeared when a [How-To](http://mayflower.digital.mass.gov/?p=pages-howto) subnav anchor link (i.e. "Next Steps") is clicked.
 - DP-5914 - Remove extra padding on callout links
-- DP-5636 - On mobile, remove dropshadow between rows on stacked row section.
 
 ### Migrate Path
-
+- DP-5385 - To use the new more link for Suggested Pages, populate the optional `suggestPages.more` property with the data for a Link pattern. 
+- DP-4572 - To apply this style fix, wrap your press release dateline (i.e. BOSTON) text in `span.ma__rich-text__flame`. (See [massgov/mass PR #1304](https://github.com/massgov/mass/pull/1304/files))
+- DP-5515 - The title text for "action finders" (i.e. What you need to know) are configurable, so just update your implementation to use sentence case to meet our styleguide standards!
+- DP-6111 - To use the new "no events" state for a listing of Event Teasers (i.e. on Org pages), populate the `eventListing.emptyText` and `eventListing.pastMore` properties and leave `eventListing.events` array empty. (See [massgov/mass PR #1443](https://github.com/massgov/mass/pull/1443/files)) 
 
 ## 5.8.1
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 **For example**
 - DP-1234: The short description text on a [service detail](http://mayflower.digital.mass.gov/?p=pages-detail-for-service-howto-location) page banner ([@organisms/by-template/page-banner](http://mayflower.digital.mass.gov/?p=organisms-page-banner)) should now render ([PR #493](https://github.com/massgov/mayflower/pull/493))
 
-## 5.9.0 (11/27/2017)
+## 5.9.0 (11/27/2017) RP
 
 ### Added
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Removed
 - DP-5914 - Remove extra padding on callout links
+- DP-5636 - On mobile, remove dropshadow between rows on stacked row section.
 
 ### Migrate Path
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -18,7 +18,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Changed
 
 ### Removed
-- DP-5636 - On mobile, remove dropshadow between rows on stacked row section.
 - DP-5914 - Remove extra padding on callout links
 
 ### Migrate Path

--- a/release-notes.md
+++ b/release-notes.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Changed
 
 ### Removed
+- DP-5636 - On mobile, remove dropshadow between rows on stacked row section.
 
 ### Migrate Path
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 **For example**
 - DP-1234: The short description text on a [service detail](http://mayflower.digital.mass.gov/?p=pages-detail-for-service-howto-location) page banner ([@organisms/by-template/page-banner](http://mayflower.digital.mass.gov/?p=organisms-page-banner)) should now render ([PR #493](https://github.com/massgov/mayflower/pull/493))
 
-## 5.9.0 (11/27/2017) RP
+## 5.9.0 (11/27/2017)
 
 ### Added
 - DP-5385 - The [Suggested Pages](http://mayflower.digital.mass.gov/?p=organisms-suggested-pages) pattern (i.e. Related Locations) now includes an optional more link so that it can be implemented to only render 3 entries and link to the rest.

--- a/styleguide/source/_patterns/02-molecules/header-tags.json
+++ b/styleguide/source/_patterns/02-molecules/header-tags.json
@@ -1,8 +1,5 @@
 {
   "headerTags": {
-    "id": "terms",
-    "moreLabel": "show more",
-    "lessLabel": "show less",
     "label": "More about:",
     "taxonomyTerms": [{
       "href": "#",

--- a/styleguide/source/_patterns/02-molecules/header-tags.json
+++ b/styleguide/source/_patterns/02-molecules/header-tags.json
@@ -1,5 +1,8 @@
 {
   "headerTags": {
+    "id": "terms",
+    "moreLabel": "show more",
+    "lessLabel": "show less",
     "label": "More about:",
     "taxonomyTerms": [{
       "href": "#",
@@ -13,6 +16,12 @@
     },{
       "href": "#",
       "text": "Term 4"
+    },{
+      "href": "#",
+      "text": "Term 5"
+    },{
+      "href": "#",
+      "text": "Term 6"
     }]
   }
 }

--- a/styleguide/source/_patterns/02-molecules/header-tags.twig
+++ b/styleguide/source/_patterns/02-molecules/header-tags.twig
@@ -10,7 +10,7 @@
       <a href="{{ item.href }}">{{ item.text }}</a>
     {% endfor %}
     <button type="button" class="js-header-tag-button" aria-expanded="false" aria-controls="{{ headerTags.id }}">
-      <span>{{ headerTags.moreLabel }}</span><span>{{ headerTags.lessLabel }}</span>
+      <span>{{ moreLabel }}</span><span>{{ lessLabel }}</span>
     </button>
   </div>
 </div>

--- a/styleguide/source/_patterns/02-molecules/header-tags.twig
+++ b/styleguide/source/_patterns/02-molecules/header-tags.twig
@@ -1,15 +1,17 @@
 {% set moreLabel = headerTags.moreLabel ?: "show more" %}
 {% set lessLabel = headerTags.lessLabel ?: "show less" %}
+{# Use passed id if it exists, otherwise leave blank to have js assign. #}
+{% set id = headerTags.id ?: '' %}
 
 <div class="ma__header-tags">
   {% if headerTags.label %}
     <span>{{ headerTags.label }}</span>
   {% endif %}
-  <div id="{{ headerTags.id }}" class="ma__header-tags__terms js-header-tag-link">
+  <div id="{{ id }}" class="ma__header-tags__terms js-header-tag-link">
     {% for item in headerTags.taxonomyTerms %}
       <a href="{{ item.href }}">{{ item.text }}</a>
     {% endfor %}
-    <button type="button" class="js-header-tag-button" aria-expanded="false" aria-controls="{{ headerTags.id }}">
+    <button type="button" class="js-header-tag-button">
       <span>{{ moreLabel }}</span><span>{{ lessLabel }}</span>
     </button>
   </div>

--- a/styleguide/source/_patterns/02-molecules/header-tags.twig
+++ b/styleguide/source/_patterns/02-molecules/header-tags.twig
@@ -1,10 +1,16 @@
+{% set moreLabel = headerTags.moreLabel ?: "show more" %}
+{% set lessLabel = headerTags.lessLabel ?: "show less" %}
+
 <div class="ma__header-tags">
   {% if headerTags.label %}
     <span>{{ headerTags.label }}</span>
   {% endif %}
-  <div class="ma__header-tags__terms">
+  <div id="{{ headerTags.id }}" class="ma__header-tags__terms js-header-tag-link">
     {% for item in headerTags.taxonomyTerms %}
       <a href="{{ item.href }}">{{ item.text }}</a>
     {% endfor %}
+    <button type="button" class="js-header-tag-button" aria-expanded="false" aria-controls="{{ headerTags.id }}">
+      <span>{{ headerTags.moreLabel }}</span><span>{{ headerTags.lessLabel }}</span>
+    </button>
   </div>
 </div>

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing-as-grid.md
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing-as-grid.md
@@ -1,5 +1,5 @@
 ### Description
-This is a variant of the [Event Listing](./?p=organisms-event-listing) pattern showing how it can be renedered as a grid.
+This is a variant of the [Event Listing](./?p=organisms-event-listing) pattern showing how it can be rendered as a grid.
 
 ### How to generate
 * set the `grid` variable to true

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing-past-as-grid.md
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing-past-as-grid.md
@@ -1,0 +1,6 @@
+### Description
+This is a variant of the [Event Listing](./?p=organisms-event-listing) pattern showing how it can be renedered as a grid when there are no upcoming events but there are past events.
+
+### How to generate
+* set the `grid` variable to true
+* set the "emptyText" and "pastMore" variables to the eventListing array.

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing-past-as-sidebar.md
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing-past-as-sidebar.md
@@ -1,0 +1,5 @@
+### Description
+This is a variant of the [Event Listing](./?p=organisms-event-listing) pattern showing how it should be rendered in the Right Rail when there are no upcoming events but there are past events.
+
+### How to generate
+* set the "emptyText" and "pastMore" variables to the eventListing array.

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing.md
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing.md
@@ -24,10 +24,16 @@ eventListing: {
   sidebarHeading:{
     type: compHeading / optional
   },
+  emptyText: {
+    type: string / optional
+  }
   events:[{
     type: eventTeaser / required
   }],
   more:{
+    type: link / optional
+  }
+  pastMore:{
     type: link / optional
   }
 }

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing.twig
@@ -13,14 +13,27 @@
       {% include "@atoms/04-headings/sidebar-heading.twig" %}
       {% set teaserHeading = (sidebarHeading.level ? : teaserHeading) + 1 %}
     {% endif %}
-    <ul class="ma__event-listing__items js-event-listing-items">
-      {% for eventTeaser in eventListing.events %}
-        {% set eventTeaser = eventTeaser|merge({"level":teaserHeading}) %}
-        <li class="ma__event-listing__item js-event-listing-item">
-          {% include "@molecules/event-teaser.twig" %}
-        </li>
-      {% endfor %}
-    </ul>
+    {% if eventListing.events %}
+      <ul class="ma__event-listing__items js-event-listing-items">
+        {% for eventTeaser in eventListing.events %}
+          {% set eventTeaser = eventTeaser|merge({"level":teaserHeading}) %}
+          <li class="ma__event-listing__item js-event-listing-item">
+            {% include "@molecules/event-teaser.twig" %}
+          </li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+    {% if eventListing.emptyText %}
+      <div class="ma__event-listing__empty">
+        {{ eventListing.emptyText }}
+      </div>
+    {% endif %}
+    {% if eventListing.pastMore %}
+      <div class="ma__event-listing__past">
+        {% set link = eventListing.pastMore %}
+        {% include "@atoms/11-text/link.twig" %}
+      </div>
+    {% endif %}
     {% if eventListing.more %}
       <div class="ma__event-listing__more">
         {% set link = eventListing.more %}

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing~past-as-grid.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing~past-as-grid.json
@@ -1,0 +1,17 @@
+{
+  "eventListing": {
+    "grid": true,
+    "compHeading":{
+      "title": "Upcoming Events"
+    },
+    "emptyText": "No upcoming events scheduled",
+    "events": null,
+    "pastMore":{
+      "href": "#",
+      "text": "See past events",
+      "info": "view all past events for this location",
+      "chevron": true
+    }
+  }
+}
+ 

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing~past-as-sidebar.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing~past-as-sidebar.json
@@ -1,0 +1,17 @@
+{
+  "eventListing": {
+    "compHeading" : null,
+    "sidebarHeading":{
+      "title": "Upcoming Events"
+    },
+    "emptyText": "No upcoming events scheduled",
+    "events": null,
+    "pastMore":{
+      "href": "#",
+      "text": "See past events",
+      "info": "View all past events for this location",
+      "chevron": true
+    }
+  }
+}
+ 

--- a/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.json
@@ -54,6 +54,12 @@
         "text": "Title Link IV",
         "info": ""
       }
-    }]
+    }],
+    "more":{
+      "href": "#",
+      "text": "See all related pages",
+      "info": "",
+      "chevron": true
+    }
   }
 }

--- a/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.md
+++ b/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.md
@@ -8,6 +8,7 @@ This Pattern shows a collection of images and links to other pages on the site.
 * Illustrated link
 * Decorative Link
 * Image
+* Link
 
 ### Variant options
 * The pattern can be shown with [Illustrated Links](./?p=organisms-suggested-pages-guide)
@@ -30,5 +31,8 @@ This Pattern shows a collection of images and links to other pages on the site.
       type: decorativeLink / required
     }
   }]
+  "more": {
+    type: link / optional
+  }
 }
 ~~~

--- a/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.twig
@@ -27,5 +27,11 @@
         {% endfor %}
       {% endif %}
     </div>
+    {% if suggestedPages.more %}
+      <div class="ma__suggested-pages__more">
+        {% set link = suggestedPages.more %}
+        {% include "@atoms/11-text/link.twig" %}
+      </div>
+    {% endif %}
   </div>
 </section>

--- a/styleguide/source/_patterns/04-templates/01-content-types/press.twig
+++ b/styleguide/source/_patterns/04-templates/01-content-types/press.twig
@@ -28,10 +28,6 @@
         {% set video = pageContent.video %}
         {% include "@atoms/09-media/video.twig" %}
       {% endif %}
-      
-      {% if pageContent.location %}
-        <p class="ma__press__location-label"><b>{{ pageContent.location }}</b>&nbsp;&mdash;&nbsp;</p>
-      {% endif %}
 
       {% set richText = pageContent.richText %}
       {% include "@organisms/by-author/rich-text.twig" %}

--- a/styleguide/source/_patterns/05-pages/guide.json
+++ b/styleguide/source/_patterns/05-pages/guide.json
@@ -48,6 +48,9 @@
   "contentEyebrow": {
     "hideBorder": true,
     "headerTags": {
+      "id": "terms",
+      "moreLabel": "more",
+      "lessLabel": "less",
       "label": "More about:",
       "taxonomyTerms": [{
         "href": "#",

--- a/styleguide/source/_patterns/05-pages/guide.json
+++ b/styleguide/source/_patterns/05-pages/guide.json
@@ -48,9 +48,6 @@
   "contentEyebrow": {
     "hideBorder": true,
     "headerTags": {
-      "id": "terms",
-      "moreLabel": "more",
-      "lessLabel": "less",
       "label": "More about:",
       "taxonomyTerms": [{
         "href": "#",
@@ -64,6 +61,12 @@
       },{
         "href": "#",
         "text": "Term 4"
+      },{
+        "href": "#",
+        "text": "Term 5"
+      },{
+        "href": "#",
+        "text": "Term 6"
       }]
     }
   },
@@ -95,9 +98,9 @@
       "widgets": null
     }
   },
-  
+
   "COMMENT":"****PAGE CONTENT COMPONENTS****",
-  
+
   "jumpLinks": {
     "title": "In this guide",
     "links": [{
@@ -144,14 +147,14 @@
           },{
             "path": "@atoms/08-lists/unordered-list.twig",
             "data": {
-              "unorderedList": [{ 
-                "text": "Protection from unlawful discrimination" 
-              },{ 
-                "text": "Rental agreements for leases and tenancy-at-will" 
-              },{ 
-                "text": "Rent withholding and deductions for repairs" 
-              },{ 
-                "text": "Lease termination, eviction, and moving out" 
+              "unorderedList": [{
+                "text": "Protection from unlawful discrimination"
+              },{
+                "text": "Rental agreements for leases and tenancy-at-will"
+              },{
+                "text": "Rent withholding and deductions for repairs"
+              },{
+                "text": "Lease termination, eviction, and moving out"
               }]
             }
           },{
@@ -342,11 +345,11 @@
           },{
             "path": "@atoms/06-rich-text/icon-list.twig",
             "data": {
-              "iconList": [{ 
+              "iconList": [{
                 "text": "The <a href=\"#\">Executive Office of Energy and Environmental Affairs (EEA)</a> recommends <a href=\"#\">selecting a reputable mover</a>."
-              },{ 
+              },{
                 "text": "Make sure that any in-state moving company you use is properly licensed with the <a href=\"http://www.mass.gov\">Massachusetts Department of Public Utilities (DPU)</a>."
-              },{ 
+              },{
                 "text": "Follow the <a href=\"#\">Federal Motor Carrier Safety Administration (FMCSA)</a> guidelines to protect yourself from moving fraud."
               }]
             }
@@ -360,9 +363,9 @@
           },{
             "path": "@atoms/06-rich-text/icon-list.twig",
             "data": {
-              "iconList": [{ 
+              "iconList": [{
                 "text": "Research <a href=\"#\">parking restrictions</a> before moving to find out where you are allowed to unload vehicles."
-              },{ 
+              },{
                 "text": "<a href=\"http://www.mass.gov\">Contact your city or town</a> for information on obtaining a moving permit, or talk to your landlord or property owner."
               }]
             }
@@ -475,15 +478,15 @@
           },{
             "path": "@atoms/06-rich-text/icon-list.twig",
             "data": {
-              "iconList": [{ 
+              "iconList": [{
                 "text": "<a href=\"#\">Contact your town or city</a> for information on local protocols, such as pet licensing. <a href=\"http://www.mass.gov\">Dog licenses are required by state law</a>."
-              },{ 
+              },{
                 "text": "<a href=\"#\">Observe Centers for Disease Control and Prevention (CDC)</a> restrictions when <a href=\"http://www.mass.gov\">moving pets to the United States from a different country</a>."
-              },{ 
+              },{
                 "text": "Make sure your pet is comfortable during the move, and that you use the right size kennel or crate."
-              },{ 
+              },{
                 "text": "Ensure your pet’s vaccines are up to date. <a href=\"#\">Dogs, cats, and ferrets must be vaccinated against rabies in Massachusetts.</a>"
-              },{ 
+              },{
                 "text": "Dogs should have secure identification tags or a microchip installed - <a href=\"http://www.mass.gov\">contact a local veterinarian’s office for more information</a>."
               }]
             }
@@ -616,8 +619,8 @@
             "data": {
               "figure": {
                 "align": "",
-                "image": { 
-                  "alt": "alt text", 
+                "image": {
+                  "alt": "alt text",
                   "src": "../../assets/images/placeholder/800x400.png",
                   "height": "",
                   "width": ""
@@ -707,8 +710,8 @@
             "data": {
               "figure": {
                 "align": "align-right",
-                "image": { 
-                  "alt": "alt text", 
+                "image": {
+                  "alt": "alt text",
                   "src": "../../assets/images/placeholder/400x300.png",
                   "height": "",
                   "width": ""
@@ -837,12 +840,12 @@
                   },{
                     "path": "@atoms/08-lists/unordered-list.twig",
                     "data": {
-                      "unorderedList": [{ 
-                        "text": "Bulleted item" 
-                      },{ 
-                        "text": "Bulleted item" 
-                      },{ 
-                        "text": "Bulleted item" 
+                      "unorderedList": [{
+                        "text": "Bulleted item"
+                      },{
+                        "text": "Bulleted item"
+                      },{
+                        "text": "Bulleted item"
                       }]
                     }
                   }]
@@ -907,7 +910,7 @@
     },
     "pages": [{
       "image": {
-        "alt": "Place Holder Image", 
+        "alt": "Place Holder Image",
         "src": "../../assets/images/placeholder/130x160.png",
         "height": "160",
         "width": "130"
@@ -920,7 +923,7 @@
       }
     },{
       "image": {
-        "alt": "Place Holder Image", 
+        "alt": "Place Holder Image",
         "src": "../../assets/images/placeholder/130x160.png",
         "height": "160",
         "width": "130"
@@ -933,7 +936,7 @@
       }
     },{
       "image": {
-        "alt": "Place Holder Image", 
+        "alt": "Place Holder Image",
         "src": "../../assets/images/placeholder/130x160.png",
         "height": "160",
         "width": "130"

--- a/styleguide/source/_patterns/05-pages/howto.json
+++ b/styleguide/source/_patterns/05-pages/howto.json
@@ -8,10 +8,25 @@
     "title": "Apply for unemployment benefits",
     "subTitle": "Have you lost your job?  You may qualify for temporary income to support you while you look for a new one.",
     "headerTags": {
+      "id": "how-to-tags",
       "label": "More about:",
+      "moreLabel": "show more",
+      "lessLabel": "show less",
       "taxonomyTerms": [{
         "href": "#",
-        "text": "Unemployment Benefits"
+        "text": "Header tag 1"
+      },{
+        "href": "#",
+        "text": "Header tag 2"
+      },{
+        "href": "#",
+        "text": "Header tag 3"
+      },{
+        "href": "#",
+        "text": "Header tag 4"
+      },{
+        "href": "#",
+        "text": "Header tag 5"
       }]
     },
     "socialLinks": {

--- a/styleguide/source/_patterns/05-pages/howto.json
+++ b/styleguide/source/_patterns/05-pages/howto.json
@@ -8,10 +8,7 @@
     "title": "Apply for unemployment benefits",
     "subTitle": "Have you lost your job?  You may qualify for temporary income to support you while you look for a new one.",
     "headerTags": {
-      "id": "how-to-tags",
       "label": "More about:",
-      "moreLabel": "show more",
-      "lessLabel": "show less",
       "taxonomyTerms": [{
         "href": "#",
         "text": "Header tag 1"

--- a/styleguide/source/_patterns/05-pages/location-general-content.json
+++ b/styleguide/source/_patterns/05-pages/location-general-content.json
@@ -767,38 +767,13 @@
       "sidebarHeading":{
         "title": "Upcoming Events"
       },
-      "events":[{
-        "title": {
-          "href": "#",
-          "text": "Winter Birding Event",
-          "info": "",
-          "property": ""
-        },
-        "location": "Lanesborough, MA",
-        "date": {
-          "summary": "March 30, 2017" 
-        },
-        "time": "12 p.m. - 2 p.m.",
-        "description": "Event description. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Magnam tempora itaque fuga quasi vero sint, sapiente soluta sit molestias architecto deleniti sunt eum incidunt laboriosam quos repudiandae nesciunt eligendi? Aliquid."
-      },{
-        "title": {
-          "href": "#",
-          "text": "First Day Hike",
-          "info": "",
-          "property": ""
-        },
-        "location": "Lanesborough, MA",
-        "date": {
-          "summary": "March 30, 2017 - April 10, 2017"
-        },
-        "time": "12 p.m. - 2 p.m.",
-        "description": ""
-      }],
-      "more":{
+      "emptyText": "No upcoming events scheduled",
+      "events": null,
+      "pastMore":{
         "href": "#",
-        "text": "view all events at this location",
-        "chevron": true,
-        "label": ""
+        "text": "See past events",
+        "info": "view all past events for this location",
+        "chevron": true
       }
     }
   }

--- a/styleguide/source/_patterns/05-pages/organization.json
+++ b/styleguide/source/_patterns/05-pages/organization.json
@@ -150,7 +150,7 @@
           "id": "GUID831741781374893",
           "bgWide":"../../assets/images/placeholder/1600x600-lighthouse-blur.jpg",
           "bgNarrow":"../../assets/images/placeholder/800x800.png",
-          "title": "What Would You Like to Do?",
+          "title": "What do you need help with?",
           "featuredHeading":"Featured Services",
           "generalHeading":"More Services",
 

--- a/styleguide/source/_patterns/05-pages/organization.json
+++ b/styleguide/source/_patterns/05-pages/organization.json
@@ -532,6 +532,7 @@
       "data": {
         "eventListing": {
           "grid": true,
+          "emptyText": "No upcoming events scheduled",
           "compHeading":{
             "title": "Upcoming Events",
             "sub": "",
@@ -539,46 +540,12 @@
             "id": "",
             "centered": ""
           },
-          "events":[{
-            "title": {
-              "href": "#",
-              "text": "Winter Birding Event",
-              "info": "",
-              "property": ""
-            },
-            "location": "Lanesborough, MA",
-            "date": {
-              "summary": "March 30, 2017",
-              "startMonth": "Mar",
-              "startDay": "30",
-              "endMonth": "",
-              "endDay": ""
-            },
-            "time": "12 p.m. - 2 p.m.",
-            "description": "Event description. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Magnam tempora itaque fuga quasi vero sint, sapiente soluta sit molestias architecto deleniti sunt eum incidunt laboriosam quos repudiandae nesciunt eligendi? Aliquid."
-          },{
-            "title": {
-              "href": "#",
-              "text": "First Day Hike",
-              "info": "",
-              "property": ""
-            },
-            "location": "Lanesborough, MA",
-            "date": {
-              "summary": "March 30, 2017 - April 10, 2017",
-              "startMonth": "Mar",
-              "startDay": "30",
-              "endMonth": "Apr",
-              "endDay": "10"
-            },
-            "time": "12 p.m. - 2 p.m.",
-            "description": ""
-          }],
-          "more":{
+          "events": null,
+          "pastMore":{
             "href": "#",
-            "text": "See all events",
-            "chevron": true,
-            "label": "See all events for Executive Office of Health and Human Services"
+            "text": "See past events",
+            "info": "view all past events for Executive Office of Health and Human Services",
+            "chevron": true
           }
         }
       }

--- a/styleguide/source/_patterns/05-pages/press-release.json
+++ b/styleguide/source/_patterns/05-pages/press-release.json
@@ -58,7 +58,7 @@
         "path": "@atoms/11-text/paragraph.twig",
         "data": {
           "paragraph" : {
-            "text": "Today, Governor Charlie Baker delivers his first State of the Commonwealth address from the House Chamber of the Massachusetts State House. Remarks as prepared for delivery:"
+            "text": "<span class=\"ma__rich-text__flame\">Boston</span> &mdash; Today, Governor Charlie Baker delivers his first State of the Commonwealth address from the House Chamber of the Massachusetts State House. Remarks as prepared for delivery:"
           }
         }
       },{

--- a/styleguide/source/_patterns/05-pages/readme2.json
+++ b/styleguide/source/_patterns/05-pages/readme2.json
@@ -5,7 +5,7 @@
   },
 
   "errorPage": {
-    "type": "v5.8.1 (10/16/2017)",
+    "type": "v5.9.0 (11/27/2017)",
     "title": "Welcome to Mayflower, the Commonwealth's Design System",
     "message": "Use the navigation menu above to browse our patterns."
   },

--- a/styleguide/source/_patterns/05-pages/service.json
+++ b/styleguide/source/_patterns/05-pages/service.json
@@ -133,7 +133,7 @@
       "id": "GUID90357801731903501238",
       "bgWide":"",
       "bgNarrow":"",
-      "title": "What Would You Like to Do?",
+      "title": "What would you like to do?",
       "featuredHeading":"Featured:",
       "generalHeading":"All How-Tos:",
       "hideFilter": true,

--- a/styleguide/source/assets/js/index.js
+++ b/styleguide/source/assets/js/index.js
@@ -9,6 +9,7 @@ import eventFilters               from "./modules/eventFilters";
 import eventListingInteractive    from "./modules/eventListingInteractive";
 import footnote                   from "./modules/footnote.js";
 import formValidation             from "./modules/formValidation.js";
+import headerTags                 from "./modules/headerTags.js";
 import hideAlert                  from "./modules/hideAlert.js";
 import keywordSearch              from "./modules/keywordSearch.js";
 import locationFilters            from "./modules/locationFilters.js";

--- a/styleguide/source/assets/js/modules/headerTags.js
+++ b/styleguide/source/assets/js/modules/headerTags.js
@@ -1,0 +1,30 @@
+export default function (window,document,$,undefined) {
+  "use strict";
+  $('.js-header-tag-link').each(function() {
+
+    let $showHideButton = $('.js-header-tag-link .js-header-tag-button'),
+        $relatedItems = $('.js-header-tag-link a:nth-child(n+4)'),
+        $parent = $showHideButton.parent();
+
+      // Hide items after 3 items.
+      if ($relatedItems.length) {
+        // Show our see button if we have more than three items.
+        $showHideButton.show();
+      }
+
+      $showHideButton.on('click', function(e) {
+        e.preventDefault();
+        $parent.toggleClass('is-open');
+
+        if ($parent.hasClass('is-open')) {
+          $showHideButton.attr('aria-expanded', 'true');
+          $relatedItems.show();
+        }
+        else {
+          $showHideButton.attr('aria-expanded', 'false');
+          $relatedItems.hide();
+        }
+      });
+
+  });
+}(window,document,jQuery);

--- a/styleguide/source/assets/js/modules/headerTags.js
+++ b/styleguide/source/assets/js/modules/headerTags.js
@@ -1,14 +1,19 @@
 export default function (window,document,$,undefined) {
   "use strict";
-  $('.js-header-tag-link').each(function() {
+  $('.js-header-tag-link').each(function(index) {
 
     let $showHideButton = $('.js-header-tag-link .js-header-tag-button'),
-        $relatedItems = $('.js-header-tag-link a:nth-child(n+4)'),
-        $parent = $showHideButton.parent();
+        $dynamicItems = $('.js-header-tag-link a:nth-child(n+4)'),
+        $parent = $showHideButton.parent(),
+        id = $parent.attr('id') || 'headerTags' + (index + 1),
+        open = $parent.hasClass('is-open');
 
-      // Hide items after 3 items.
-      if ($relatedItems.length) {
+      // Set the id attribute (respects default if set).
+      $parent.attr('id', id);
+
+      if ($dynamicItems.length) {
         // Show our see button if we have more than three items.
+        $showHideButton.attr('aria-expanded',open).attr('aria-controls', id);
         $showHideButton.show();
       }
 
@@ -18,11 +23,11 @@ export default function (window,document,$,undefined) {
 
         if ($parent.hasClass('is-open')) {
           $showHideButton.attr('aria-expanded', 'true');
-          $relatedItems.show();
+          $dynamicItems.show();
         }
         else {
           $showHideButton.attr('aria-expanded', 'false');
-          $relatedItems.hide();
+          $dynamicItems.hide();
         }
       });
 

--- a/styleguide/source/assets/js/templates/googleMapInfo.html
+++ b/styleguide/source/assets/js/templates/googleMapInfo.html
@@ -17,7 +17,7 @@
   {{/if}}
   {{#if email}}
     <div class="ma__info-window__email">
-      <span class="ma__info-window__label">Online:</span>
+      <span class="ma__info-window__label">Email:</span>
       <a class="ma__info-window__email-link" href="mailto:{{email}}">{{email}}</a>
     </div>
   {{/if}}

--- a/styleguide/source/assets/js/templates/googleMapInfo.html
+++ b/styleguide/source/assets/js/templates/googleMapInfo.html
@@ -17,7 +17,7 @@
   {{/if}}
   {{#if email}}
     <div class="ma__info-window__email">
-      <span class="ma__info-window__label">Email:</span>
+      <span class="ma__info-window__label">Online:</span>
       <a class="ma__info-window__email-link" href="mailto:{{email}}">{{email}}</a>
     </div>
   {{/if}}

--- a/styleguide/source/assets/scss/01-atoms/_textarea.scss
+++ b/styleguide/source/assets/scss/01-atoms/_textarea.scss
@@ -1,7 +1,6 @@
 .ma__textarea {
 
   &__wrapper {
-    display: inline-block;
     position: relative;
 
     &:after {

--- a/styleguide/source/assets/scss/01-atoms/global/_elements.scss
+++ b/styleguide/source/assets/scss/01-atoms/global/_elements.scss
@@ -89,3 +89,14 @@ h6 {
   @include ma-visually-hidden;
 }
 
+h1,
+h2,
+h3,
+h4,
+p,
+main,
+div {
+  &[tabindex="-1"]:focus {
+    outline: none;
+  }
+}

--- a/styleguide/source/assets/scss/02-molecules/_header-tags.scss
+++ b/styleguide/source/assets/scss/02-molecules/_header-tags.scss
@@ -2,6 +2,15 @@
   font-size: 16px;
   letter-spacing: .1em;
   text-transform: uppercase;
+  max-width: $l-max-content-width;
+
+  > span {
+    white-space: nowrap;
+  }
+
+  @media ($bp-medium-min) {
+    display: inline-flex;
+  }
 
   &__terms {
     display: inline;
@@ -26,6 +35,68 @@
 
       &:last-child {
         margin-right: 0;
+      }
+
+      &:nth-child(n+4) {
+        display: none;
+      }
+
+      @media ($bp-x-small-max) {
+        // On small screens each tag is full width.
+        display: block;
+      }
+    }
+
+    &.is-open {
+      a {
+        display: inline-block;
+
+        @media ($bp-x-small-max) {
+          // On small screens each tag is full width.
+          display: block;
+        }
+      }
+
+      > button {
+        &:after {
+          transform: translateY(-55%) rotate(-135deg);
+        }
+        span:first-child {
+          display: none;
+        }
+        span:nth-child(2) {
+          display: inline;
+        }
+      }
+    }
+
+    > button {
+      @include ma-button-reset;
+      @include ma-link-underline;
+      @include ma-chevron;
+      padding-left: 10px;
+      font-size: 19px;
+      display: none;
+
+      &:after {
+        opacity: .5;
+        margin-left: 0;
+        border-width: 3px;
+        height: 8px;
+        width: 8px;
+        transform: translateY(-45%) rotate(45deg);
+      }
+
+      span:first-child {
+        display: inline;
+      }
+
+      span:nth-child(2) {
+        display: none;
+      }
+
+      @media ($bp-x-small-max) {
+        display: block;
       }
     }
   }

--- a/styleguide/source/assets/scss/02-molecules/_section-links.scss
+++ b/styleguide/source/assets/scss/02-molecules/_section-links.scss
@@ -92,9 +92,12 @@
 
   &__title {
     @include ma-h3;
-    margin-bottom: 15px;
+    margin-bottom: .5em;
+    @media ($bp-small-min){
+      margin-bottom: .5em;
+    }
     align-self: stretch;
-
+    
     a {
       border: none;
     }
@@ -166,6 +169,7 @@
     @include ma-reset-list;
   }
 
+
   // skip the first item
   &__item + &__item {
     margin-top: 1em;
@@ -173,13 +177,14 @@
 
   // Make child content callout links full width
   &__item > .ma__callout-link {
-    @include ma-container();
     display: block;
     width: 100%;
   }
 
   &__item > .ma__decorative-link {
+    &__item > .ma__decorative-link {
     font-size: 1.625rem;
     line-height: 1.3;
+  }
   }
 }

--- a/styleguide/source/assets/scss/03-organisms/_event-listing.scss
+++ b/styleguide/source/assets/scss/03-organisms/_event-listing.scss
@@ -15,6 +15,15 @@ $event-listing-bp-show-grid: $bp-medium-min;
     @include ma-component-spacing;
   }
 
+  &__empty {
+    font-size: 1.5rem;
+    margin-bottom: .25em;
+
+    .ma__page-header & {
+      font-size: 1.813rem;
+    }
+  }
+
   &--grid &__container {
     
     @media ($event-listing-bp-show-grid) {
@@ -135,11 +144,20 @@ $event-listing-bp-show-grid: $bp-medium-min;
   }
 
 
-  &__more {
-    margin-top: 30px;
+  &__more,
+  &__past {
+    margin-top: 20px;
 
     @media ($bp-large-min) {
-      margin-top: 45px;
+      margin-top: 35px;
+    }
+
+    .sidebar & {
+      margin-top: 15px;
+
+      @media ($bp-large-min) {
+        margin-top: 25px;
+      }
     }
   }
 

--- a/styleguide/source/assets/scss/03-organisms/_page-banner.scss
+++ b/styleguide/source/assets/scss/03-organisms/_page-banner.scss
@@ -22,7 +22,7 @@ $page-banner-icon-width: $column + $gutter;
 
   &--overlay {
     @media ($bp-large-min) {
-      height: 300px;
+      height: 400px;
     }
   }
 

--- a/styleguide/source/assets/scss/03-organisms/_page-banner.scss
+++ b/styleguide/source/assets/scss/03-organisms/_page-banner.scss
@@ -1,9 +1,10 @@
 $page-banner-icon-width: $column + $gutter;
+$page-banner-height: 330px;
 
 .ma__page-banner {
   background-size: cover;
   background-position: center center;
-  height: 400px;
+  height: $page-banner-height;
   margin-bottom: 20px;
   overflow: hidden;
   position: relative;
@@ -49,6 +50,7 @@ $page-banner-icon-width: $column + $gutter;
     @include clearfix;
     height: auto;
     min-height: 450px;
+    padding-right: 0px; //fix gap on mobile
   }
 
   &--overlay &__container {
@@ -64,6 +66,9 @@ $page-banner-icon-width: $column + $gutter;
   }
 
   &__content {
+    display: flex;
+      align-items: center;
+      flex-wrap: wrap;
     font-size: 1rem;
     max-width: 1050px;
     padding: 30px 25px 45px 0;
@@ -73,9 +78,6 @@ $page-banner-icon-width: $column + $gutter;
     z-index: 1;
 
     @media ($bp-x-small-min) {
-      display: flex;
-        align-items: center;
-        flex-wrap: wrap;
       margin-right: 70px;
       padding-top: 50px;
       padding-right: 80px;
@@ -133,10 +135,10 @@ $page-banner-icon-width: $column + $gutter;
   }
 
   &--columns &__content {
-    height: 400px;
+    height: $page-banner-height;
     max-width: 640px;
     position: relative;
-      top: 200px;
+      top: calc(#{$page-banner-height}/2);
 
     @media ($bp-medium-min) {
       height: 100%;
@@ -149,6 +151,7 @@ $page-banner-icon-width: $column + $gutter;
   &__icon {
     padding-right: 30px;
     width: 75px;
+    display: none;
 
     @media ($bp-x-small-min) {
       transform: skew(30deg);
@@ -156,6 +159,7 @@ $page-banner-icon-width: $column + $gutter;
 
     @media ($bp-medium-min) {
       width: $page-banner-icon-width;
+      display: inline-block;
     }
 
     & > svg {
@@ -310,7 +314,7 @@ $page-banner-icon-width: $column + $gutter;
   &--columns &__image {
     background-position: 50% 50%;
     background-size: cover;
-    height: 400px;
+    height: $page-banner-height;
     position: absolute;
       right: 0;
       top: 0;

--- a/styleguide/source/assets/scss/03-organisms/_page-header.scss
+++ b/styleguide/source/assets/scss/03-organisms/_page-header.scss
@@ -13,6 +13,9 @@ $page-header-widget-width: 350px;
     overflow: hidden;
     margin-bottom: -20px;
     padding-top: 18px;
+    border-bottom-width: 1px;
+    border-bottom-style: solid;
+    margin-bottom: 20px;
 
     .ma__header-tags,
     .ma__social-links {
@@ -21,11 +24,17 @@ $page-header-widget-width: 350px;
       min-height: 48px;
       position: relative;
         top: 1px;
+      @media ($bp-medium-min) {
+        border: 0;
+      }
     }
 
     .ma__header-tags {
       flex-grow: 1;
       margin-bottom: 30px;
+      @media ($bp-medium-min) {
+        margin-bottom: 10px;
+      }
     }
 
     .ma__social-links {
@@ -34,6 +43,9 @@ $page-header-widget-width: 350px;
       @media ($bp-small-max) {
         width: 100%;
       }
+    }
+    @media ($bp-medium-max) {
+      border: 0;
     }
   }
 

--- a/styleguide/source/assets/scss/03-organisms/_rich-text.scss
+++ b/styleguide/source/assets/scss/03-organisms/_rich-text.scss
@@ -4,6 +4,10 @@ $rich-text-spacing-mobile: 1.5rem;
 .ma__rich-text {
   @include clearfix;
 
+  &__flame {
+    text-transform: uppercase;
+  }
+
   &--description {
     margin-bottom: 1rem;
   }

--- a/styleguide/source/assets/scss/03-organisms/_stacked-row-section.scss
+++ b/styleguide/source/assets/scss/03-organisms/_stacked-row-section.scss
@@ -1,11 +1,11 @@
 .ma__stacked-row-section {
 
   @media ($bp-large-max) {
-    box-shadow: 0 0.5rem 0.5rem -0.25rem rgba(1, 1, 1, 0.25);
     padding-bottom: 45px;
 
-    &:last-child {
-      box-shadow: none;
+    & ~ & {
+      border-top-width: 1px;
+      border-top-style: solid;
     }
   }
 
@@ -38,7 +38,7 @@
   &--restricted &__title {
     max-width: 820px;
   }
-  
+
   .main-content {
 
     @media ($bp-large-max) {

--- a/styleguide/source/assets/scss/03-organisms/_stacked-row-section.scss
+++ b/styleguide/source/assets/scss/03-organisms/_stacked-row-section.scss
@@ -1,11 +1,12 @@
 .ma__stacked-row-section {
 
   @media ($bp-large-max) {
-    box-shadow: 0 0.5rem 0.5rem -0.25rem rgba(1, 1, 1, 0.25);
+    box-shadow: none;
     padding-bottom: 45px;
 
-    &:last-child {
-      box-shadow: none;
+    & + & {
+      border-top-width: 1px;
+      border-top-style: solid;
     }
   }
 
@@ -38,7 +39,7 @@
   &--restricted &__title {
     max-width: 820px;
   }
-  
+
   .main-content {
 
     @media ($bp-large-max) {

--- a/styleguide/source/assets/scss/03-organisms/_stacked-row-section.scss
+++ b/styleguide/source/assets/scss/03-organisms/_stacked-row-section.scss
@@ -1,12 +1,11 @@
 .ma__stacked-row-section {
 
   @media ($bp-large-max) {
-    box-shadow: none;
+    box-shadow: 0 0.5rem 0.5rem -0.25rem rgba(1, 1, 1, 0.25);
     padding-bottom: 45px;
 
-    & + & {
-      border-top-width: 1px;
-      border-top-style: solid;
+    &:last-child {
+      box-shadow: none;
     }
   }
 
@@ -39,7 +38,7 @@
   &--restricted &__title {
     max-width: 820px;
   }
-
+  
   .main-content {
 
     @media ($bp-large-max) {

--- a/styleguide/source/assets/scss/04-templates/_press.scss
+++ b/styleguide/source/assets/scss/04-templates/_press.scss
@@ -11,14 +11,6 @@
     }
   }
 
-  &__location-label {
-    float: left;
-    line-height: 1em;
-    margin-bottom: 0;
-    padding-top: .25em;
-    text-transform: uppercase;
-  }
-
   &__sidebar {
     .ma__contact-list {
 

--- a/styleguide/source/assets/scss/04-templates/_stacked-row.scss
+++ b/styleguide/source/assets/scss/04-templates/_stacked-row.scss
@@ -4,11 +4,11 @@
   &__section {
 
     @media ($bp-large-max) {
-      box-shadow: 0 0.5rem 0.5rem -0.25rem rgba(1, 1, 1, 0.25);
       padding-bottom: 45px;
 
-      &:last-child {
-        box-shadow: none;
+      & ~ & {
+        border-top-width: 1px;
+        border-top-style: solid;
       }
     }
 

--- a/styleguide/source/assets/scss/04-templates/_stacked-row.scss
+++ b/styleguide/source/assets/scss/04-templates/_stacked-row.scss
@@ -4,11 +4,12 @@
   &__section {
 
     @media ($bp-large-max) {
-      box-shadow: 0 0.5rem 0.5rem -0.25rem rgba(1, 1, 1, 0.25);
+      box-shadow: none;
       padding-bottom: 45px;
 
-      &:last-child {
-        box-shadow: none;
+      & + & {
+        border-top-width: 1px;
+        border-top-style: solid;
       }
     }
 

--- a/styleguide/source/assets/scss/04-templates/_stacked-row.scss
+++ b/styleguide/source/assets/scss/04-templates/_stacked-row.scss
@@ -4,12 +4,11 @@
   &__section {
 
     @media ($bp-large-max) {
-      box-shadow: none;
+      box-shadow: 0 0.5rem 0.5rem -0.25rem rgba(1, 1, 1, 0.25);
       padding-bottom: 45px;
 
-      & + & {
-        border-top-width: 1px;
-        border-top-style: solid;
+      &:last-child {
+        box-shadow: none;
       }
     }
 

--- a/styleguide/source/assets/scss/06-theme/01-atoms/_table.scss
+++ b/styleguide/source/assets/scss/06-theme/01-atoms/_table.scss
@@ -18,7 +18,7 @@
 }
 
 .ma__table {
-  
+
   @media ($bp-small-max) {
     thead + tbody,
     tbody:first-child {
@@ -26,7 +26,7 @@
     }
 
     td {
-      
+
       &:before {
         color: $c-font-heading;
         font-weight: 500;
@@ -41,7 +41,7 @@
 }
 
 .ma__table--wide {
-  
+
   @media ($bp-medium-max) {
     thead + tbody,
     tbody:first-child {
@@ -49,7 +49,7 @@
     }
 
     td {
-      
+
       &:before {
         color: $c-font-heading;
         font-weight: 500;

--- a/styleguide/source/assets/scss/06-theme/02-molecules/_header-tags.scss
+++ b/styleguide/source/assets/scss/06-theme/02-molecules/_header-tags.scss
@@ -11,5 +11,10 @@
         border-color: $c-font-link;
       }
     }
+
+    > button {
+      color: $c-theme-primary;
+      font-weight: 500;
+    }
   }
 }

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_action-finder.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_action-finder.scss
@@ -2,7 +2,7 @@ $action-finder-bg-color: tint($c-theme-primary,89%);
 $action-finder-border-color: tint($c-theme-primary,50%);
 
 .ma__action-finder {
-  
+
   &:after {
     background-image: linear-gradient(180deg, rgba(#000,.6), transparent 90%, transparent);
   }
@@ -10,12 +10,6 @@ $action-finder-border-color: tint($c-theme-primary,50%);
   &--no-background {
     background-image: linear-gradient(180deg, $c-white 50px, $c-bg-section 51px);
   }
-
-  &--no-background + &--no-background {
-    background-image: none;
-    background-color: $c-bg-section;
-  }
-
 
   &--no-background &__header {
     background-color: $c-theme-primary;
@@ -54,7 +48,7 @@ $action-finder-border-color: tint($c-theme-primary,50%);
   }
 
   &__items--all {
-    
+
     .ma__callout-link {
       background-color: $c-white;
       box-shadow: none;

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_event-listing.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_event-listing.scss
@@ -1,5 +1,10 @@
 .ma__event-listing {
 
+  &__empty {
+    font-style: italic;
+    font-weight: 500;
+  }
+
   &--grid &__item {
     border-color: $c-bd-divider;
 

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_page-header.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_page-header.scss
@@ -1,7 +1,9 @@
 .ma__page-header {
 
   &__tags {
-
+    @media ($bp-medium-min) {
+      border-color: $c-bd-divider;
+    }
     .ma__header-tags,
     .ma__social-links {
       border-color: $c-bd-divider;

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_rich-text.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_rich-text.scss
@@ -1,4 +1,8 @@
 .ma__rich-text {
+
+  &__flame {
+    font-weight: bold;
+  }
   
   &__footnote {
     border-color: rgba($c-font-link,.5);

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_stacked-row-section.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_stacked-row-section.scss
@@ -1,6 +1,6 @@
 .ma__stacked-row-section {
 
-  & ~ & &__container:before {
+  &, & ~ & &__container:before {
     border-color: $c-bd-divider;
   }
 }

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_stacked-row-section.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_stacked-row-section.scss
@@ -1,6 +1,6 @@
 .ma__stacked-row-section {
 
-  &, & ~ & &__container:before {
+  & ~ & &__container:before {
     border-color: $c-bd-divider;
   }
 }

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_stacked-row-section.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_stacked-row-section.scss
@@ -1,6 +1,10 @@
 .ma__stacked-row-section {
 
-  & ~ & &__container:before {
+  & ~ & {
     border-color: $c-bd-divider;
+    
+    &__container:before {
+      border-color: $c-bd-divider;
+    }
   }
 }

--- a/styleguide/source/assets/scss/06-theme/04-templates/_stacked-row.scss
+++ b/styleguide/source/assets/scss/06-theme/04-templates/_stacked-row.scss
@@ -1,6 +1,6 @@
 .ma__stacked-row {
 
-  &__section ~ &__section &__container:before {
+  &__section, &__section ~ &__section &__container:before {
     border-color: $c-bd-divider;
   }
 }

--- a/styleguide/source/assets/scss/06-theme/04-templates/_stacked-row.scss
+++ b/styleguide/source/assets/scss/06-theme/04-templates/_stacked-row.scss
@@ -1,6 +1,10 @@
 .ma__stacked-row {
 
-  &__section ~ &__section &__container:before {
+  &__section ~ &__section {
     border-color: $c-bd-divider;
+    
+    &__container:before {
+      border-color: $c-bd-divider;
+    }
   }
 }

--- a/styleguide/source/assets/scss/06-theme/04-templates/_stacked-row.scss
+++ b/styleguide/source/assets/scss/06-theme/04-templates/_stacked-row.scss
@@ -1,6 +1,6 @@
 .ma__stacked-row {
 
-  &__section, &__section ~ &__section &__container:before {
+  &__section ~ &__section &__container:before {
     border-color: $c-bd-divider;
   }
 }

--- a/styleguide/source/assets/scss/08-print/_print.scss
+++ b/styleguide/source/assets/scss/08-print/_print.scss
@@ -49,7 +49,9 @@ h1,
 .ma__banner-carousel,
 .ma__quick-actions,
 .ma__wait-time,
-.fluid-width-video-wrapper {
+.fluid-width-video-wrapper,
+#feedback,
+.ma__floating-action {
   display: none !important;
 }
 
@@ -552,6 +554,9 @@ h4 {
   column-count: 1;
 }
 
-
-
+  // Opens accordions when printing.
+  .ma__action-step--accordion .ma__action-step__content,
+  .ma__contact-us--accordion .ma__contact-us__content  {
+    display: block !important;
+  }
 }


### PR DESCRIPTION
## 5.9.0 (11/27/2017)

### Added
- DP-5385 - The [Suggested Pages](http://mayflower.digital.mass.gov/?p=organisms-suggested-pages) pattern (i.e. Related Locations) now includes an optional more link so that it can be implemented to only render 3 entries and link to the rest.
- DP-5858 - Styles have been added which hide the "Tell us what you think" button and ensure that contact accordions are expanded when a page is printed.
- DP-6111 - Event teaser listings now have a ["no event" state](http://mayflower.digital.mass.gov/?p=organisms-event-listing-past-as-grid) which will render when the pattern is included on a page but no future events are provided.

### Changed
- DP-4534 - The [header tags](http://mayflower.digital.mass.gov/?p=molecules-header-tags) molecule (i.e. relationship indicators) has been updated to support 3+ tags by adding a show/hide button to collapse and expand the tags.
- DP-4572 - The dateline (i.e. BOSTON -) style on a press release page has been updated to be bold with an emdash appended.
- DP-5388 - The page banner on a Service Page will now fit longer text content (i.e. up to 400px in height).
- DP-5515 - [Service](http://mayflower.digital.mass.gov/?p=pages-service) and [Org](http://mayflower.digital.mass.gov/?p=pages-organization) page "action finder" titles (i.e. What would you like to do?) have been updated to sentence case.
- DP-5518 - The style for the feedback form (i.e. Did you find what you're looking for) textarea is more consistent when a user clicks yes / no.
- DP-5523 - When appearing consecutively (i.e. on a [Service Page](http://mayflower.digital.mass.gov/?p=pages-service) the grey background of the second "action finder" (i.e. What you need to know) will line up more consistently with the first.
- DP-5914 - The spacing has been fixed on [Topic page Section links](http://mayflower.digital.mass.gov/?p=pages-topic) (i.e. Topic cards) which display Callout links (i.e. links to Services).
- DP-6106 - The mobile styling for the banner on [Topic pages](http://mayflower.digital.mass.gov/?p=pages-topic&w=350px) has been made more consistent to other page banners: the height is flexible, the content is vertically centered, the icon removed, and the colored background fills the width of the screen.

### Removed
- DP-3060 - The outline has been removed from the Heading which appeared when a [How-To](http://mayflower.digital.mass.gov/?p=pages-howto) subnav anchor link (i.e. "Next Steps") is clicked.
- DP-5914 - Remove extra padding on callout links

### Migrate Path
- DP-5385 - To use the new more link for Suggested Pages, populate the optional `suggestPages.more` property with the data for a Link pattern. 
- DP-4572 - To apply this style fix, wrap your press release dateline (i.e. BOSTON) text in `span.ma__rich-text__flame`. (See [massgov/mass PR #1304](https://github.com/massgov/mass/pull/1304/files))
- DP-5515 - The title text for "action finders" (i.e. What you need to know) are configurable, so just update your implementation to use sentence case to meet our styleguide standards!
- DP-6111 - To use the new "no events" state for a listing of Event Teasers (i.e. on Org pages), populate the `eventListing.emptyText` and `eventListing.pastMore` properties and leave `eventListing.events` array empty. (See [massgov/mass PR #1443](https://github.com/massgov/mass/pull/1443/files)) 
