### PR TITLE
Release 5.8.2

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -25,18 +25,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ## 5.8.2
 
 ### Added
-- DP-4534 - Add a button to toggle showing more/less "Related To:" items in [@molecules/header-tags](http://mayflower.digital.mass.gov/?p=molecules-header-tags). [PR #594](https://github.com/massgov/mayflower/pull/594)
-- DP-6111 - Add empty state for [event listings](http://mayflower.digital.mass.gov/?p=organisms-event-listing). [PR #617](https://github.com/massgov/mayflower/pull/617)
-- DP-5385 - Add optional more link to [suggested pages](http://mayflower.digital.mass.gov/?p=organisms-suggested-pages). [PR #647](https://github.com/massgov/mayflower/pull/647)
+- DP-4534 - Add a generalized button to toggle showing more/less "Related To:" items in [@molecules/header-tags](http://mayflower.digital.mass.gov/?p=molecules-header-tags). [PR #594](https://github.com/massgov/mayflower/pull/594)
+- DP-6111 - Add empty state for [event listings](http://mayflower.digital.mass.gov/?p=organisms-event-listing) to show when there are no upcoming events. [PR #617](https://github.com/massgov/mayflower/pull/617)
+- DP-5385 - Add optional "see more" link to [suggested pages](http://mayflower.digital.mass.gov/?p=organisms-suggested-pages). [PR #647](https://github.com/massgov/mayflower/pull/647)
 
 ### Changed
-- DP-5858 - Updated print styles to hide feedback and floating button and show expanded accordions content. [PR #625](https://github.com/massgov/mayflower/pull/625)
-- DP-5518 - Fix feedback form wrapper layout at bottom of page to have child content flow properly. [PR #608](https://github.com/massgov/mayflower/pull/608)
+- DP-5858 - Updated print styles to hide feedback and floating button and show expanded content from normally collapsed accordion sections. [PR #625](https://github.com/massgov/mayflower/pull/625)
+- DP-5518 - Fix feedback form wrapper layout at bottom of page to have child content flow properly (i.e textarea is full width). [PR #608](https://github.com/massgov/mayflower/pull/608)
 - DP-5515 - Make service page title & organization title sentence case. [PR #615](https://github.com/massgov/mayflower/pull/615)
-- DP-4572 - Change composition of [Press Release](http://mayflower.digital.mass.gov/?p=pages-press-release) location to be now inline the rich text area. [PPR #599](https://github.com/massgov/mayflower/pull/599)
+- DP-4572 - Change [Press Release](http://mayflower.digital.mass.gov/?p=pages-press-release) location to be inline the rich text area and upper case. [PPR #599](https://github.com/massgov/mayflower/pull/599)
 - DP-5388 - Expand [page banner](http://mayflower.digital.mass.gov/?p=organisms-page-banner) height to provide more ample room for longer titles. [PR #641](https://github.com/massgov/mayflower/pull/641)
-- DP-5523 - Fix action finder background where it is used multiple times like on [service pages](http://mayflower.digital.mass.gov//?p=pages-service). [PR #639](https://github.com/massgov/mayflower/pull/639)
-- DP-3060 - Remove unecessary outline on non-interactive elements. [PR #614](https://github.com/massgov/mayflower/pull/614)
+- DP-5523 - Fix action finder background color overlays where it is used multiple times, like on [service pages](http://mayflower.digital.mass.gov//?p=pages-service). [PR #639](https://github.com/massgov/mayflower/pull/639)
+- DP-3060 - Remove unecessary outline on non-interactive elements when users use the side-navigation on [how-to pages](http://mayflower.digital.mass.gov/?p=pages-howto). [PR #614](https://github.com/massgov/mayflower/pull/614)
 - DP-5636 - On mobile, remove dropshadow between rows on [@organisms/stacked-rows](http://mayflower.digital.mass.gov/?p=organisms-stacked-row-section). [PR #637](https://github.com/massgov/mayflower/pull/637)
 - DP-6106 - Fix [@organisms/page-banner](http://mayflower.digital.mass.gov/?p=organisms-page-banner) padding & margins on mobile. [PR #636](https://github.com/massgov/mayflower/pull/636)
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -18,10 +18,30 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Changed
 
 ### Removed
-- DP-5914 - Remove extra padding on callout links
-- DP-5636 - On mobile, remove dropshadow between rows on stacked row section.
+
 
 ### Migrate Path
+
+## 5.8.2
+
+### Added
+- DP-4534 - Add a button to toggle showing more/less "Related To:" items. [PR #594](https://github.com/massgov/mayflower/pull/594)
+- DP-6111 - Add empty state for event listings. [PR #617](https://github.com/massgov/mayflower/pull/617)
+- DP-5385 - Add optional more link to suggested pages. [PR #647](https://github.com/massgov/mayflower/pull/647)
+
+### Changed
+- DP-5858 - Updated print styles to hide feedback and floating button and show expanded accordions content. [PR #625](https://github.com/massgov/mayflower/pull/625)
+- DP-5518 - Fix feedback form wrapper layout at bottom of page to have child content flow properly. [PR #608](https://github.com/massgov/mayflower/pull/608)
+- DP-5515 - Make service page section & update organization title sentence case. [PR #615](https://github.com/massgov/mayflower/pull/615)
+- DP-4572 - Change composition of Press Release location to be now inline the rich text area. [PPR #599](https://github.com/massgov/mayflower/pull/599)
+- DP-5388 - Expand service page banner height to provide more ample room for longer titles. [PR #641](https://github.com/massgov/mayflower/pull/641)
+- DP-5523 - Fix action finder background. [PR #639](https://github.com/massgov/mayflower/pull/639)
+- DP-3060 - Remove unecessary outline on non-interactive elements. [PR #614](https://github.com/massgov/mayflower/pull/614)
+- DP-5636 - On mobile, remove dropshadow between rows on stacked row section. [PR #637](https://github.com/massgov/mayflower/pull/637)
+- DP-6106 - Fix topic page banner padding & margins on mobile. [PR #636](https://github.com/massgov/mayflower/pull/636)
+
+### Removed
+- DP-5914 - Remove extra padding on callout links. [PR #626](https://github.com/massgov/mayflower/pull/626)
 
 
 ## 5.8.1

--- a/release-notes.md
+++ b/release-notes.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Removed
 - DP-5636 - On mobile, remove dropshadow between rows on stacked row section.
+- DP-5914 - Remove extra padding on callout links
 
 ### Migrate Path
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Removed
 - DP-5914 - Remove extra padding on callout links
+- DP-5636 - On mobile, remove dropshadow between rows on stacked row section.
 
 ### Migrate Path
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -18,7 +18,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Changed
 
 ### Removed
-- DP-5636 - On mobile, remove dropshadow between rows on stacked row section.
 - DP-5914 - Remove extra padding on callout links
 
 ### Migrate Path

--- a/release-notes.md
+++ b/release-notes.md
@@ -25,23 +25,23 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ## 5.8.2
 
 ### Added
-- DP-4534 - Add a button to toggle showing more/less "Related To:" items. [PR #594](https://github.com/massgov/mayflower/pull/594)
-- DP-6111 - Add empty state for event listings. [PR #617](https://github.com/massgov/mayflower/pull/617)
-- DP-5385 - Add optional more link to suggested pages. [PR #647](https://github.com/massgov/mayflower/pull/647)
+- DP-4534 - Add a button to toggle showing more/less "Related To:" items in [@molecules/header-tags](http://mayflower.digital.mass.gov/?p=molecules-header-tags). [PR #594](https://github.com/massgov/mayflower/pull/594)
+- DP-6111 - Add empty state for [event listings](http://mayflower.digital.mass.gov/?p=organisms-event-listing). [PR #617](https://github.com/massgov/mayflower/pull/617)
+- DP-5385 - Add optional more link to [suggested pages](http://mayflower.digital.mass.gov/?p=organisms-suggested-pages). [PR #647](https://github.com/massgov/mayflower/pull/647)
 
 ### Changed
 - DP-5858 - Updated print styles to hide feedback and floating button and show expanded accordions content. [PR #625](https://github.com/massgov/mayflower/pull/625)
 - DP-5518 - Fix feedback form wrapper layout at bottom of page to have child content flow properly. [PR #608](https://github.com/massgov/mayflower/pull/608)
-- DP-5515 - Make service page section & update organization title sentence case. [PR #615](https://github.com/massgov/mayflower/pull/615)
-- DP-4572 - Change composition of Press Release location to be now inline the rich text area. [PPR #599](https://github.com/massgov/mayflower/pull/599)
-- DP-5388 - Expand service page banner height to provide more ample room for longer titles. [PR #641](https://github.com/massgov/mayflower/pull/641)
-- DP-5523 - Fix action finder background. [PR #639](https://github.com/massgov/mayflower/pull/639)
+- DP-5515 - Make service page title & organization title sentence case. [PR #615](https://github.com/massgov/mayflower/pull/615)
+- DP-4572 - Change composition of [Press Release](http://mayflower.digital.mass.gov/?p=pages-press-release) location to be now inline the rich text area. [PPR #599](https://github.com/massgov/mayflower/pull/599)
+- DP-5388 - Expand [page banner](http://mayflower.digital.mass.gov/?p=organisms-page-banner) height to provide more ample room for longer titles. [PR #641](https://github.com/massgov/mayflower/pull/641)
+- DP-5523 - Fix action finder background where it is used multiple times like on [service pages](http://mayflower.digital.mass.gov//?p=pages-service). [PR #639](https://github.com/massgov/mayflower/pull/639)
 - DP-3060 - Remove unecessary outline on non-interactive elements. [PR #614](https://github.com/massgov/mayflower/pull/614)
-- DP-5636 - On mobile, remove dropshadow between rows on stacked row section. [PR #637](https://github.com/massgov/mayflower/pull/637)
-- DP-6106 - Fix topic page banner padding & margins on mobile. [PR #636](https://github.com/massgov/mayflower/pull/636)
+- DP-5636 - On mobile, remove dropshadow between rows on [@organisms/stacked-rows](http://mayflower.digital.mass.gov/?p=organisms-stacked-row-section). [PR #637](https://github.com/massgov/mayflower/pull/637)
+- DP-6106 - Fix [@organisms/page-banner](http://mayflower.digital.mass.gov/?p=organisms-page-banner) padding & margins on mobile. [PR #636](https://github.com/massgov/mayflower/pull/636)
 
 ### Removed
-- DP-5914 - Remove extra padding on callout links. [PR #626](https://github.com/massgov/mayflower/pull/626)
+- DP-5914 - Remove extra padding on [@molecules/section-links](http://mayflower.digital.mass.gov/?p=molecules-section-links). [PR #626](https://github.com/massgov/mayflower/pull/626)
 
 
 ## 5.8.1

--- a/release-notes.md
+++ b/release-notes.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Changed
 
 ### Removed
+- DP-5636 - On mobile, remove dropshadow between rows on stacked row section.
 
 ### Migrate Path
 

--- a/styleguide/source/_patterns/02-molecules/header-tags.json
+++ b/styleguide/source/_patterns/02-molecules/header-tags.json
@@ -1,5 +1,8 @@
 {
   "headerTags": {
+    "id": "terms",
+    "moreLabel": "show more",
+    "lessLabel": "show less",
     "label": "More about:",
     "taxonomyTerms": [{
       "href": "#",
@@ -13,6 +16,12 @@
     },{
       "href": "#",
       "text": "Term 4"
+    },{
+      "href": "#",
+      "text": "Term 5"
+    },{
+      "href": "#",
+      "text": "Term 6"
     }]
   }
 }

--- a/styleguide/source/_patterns/02-molecules/header-tags.twig
+++ b/styleguide/source/_patterns/02-molecules/header-tags.twig
@@ -1,10 +1,16 @@
+{% set moreLabel = headerTags.moreLabel ?: "show more" %}
+{% set lessLabel = headerTags.lessLabel ?: "show less" %}
+
 <div class="ma__header-tags">
   {% if headerTags.label %}
     <span>{{ headerTags.label }}</span>
   {% endif %}
-  <div class="ma__header-tags__terms">
+  <div id="{{ headerTags.id }}" class="ma__header-tags__terms js-header-tag-link">
     {% for item in headerTags.taxonomyTerms %}
       <a href="{{ item.href }}">{{ item.text }}</a>
     {% endfor %}
+    <button type="button" class="js-header-tag-button" aria-expanded="false" aria-controls="{{ headerTags.id }}">
+      <span>{{ headerTags.moreLabel }}</span><span>{{ headerTags.lessLabel }}</span>
+    </button>
   </div>
 </div>

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing-as-grid.md
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing-as-grid.md
@@ -1,5 +1,5 @@
 ### Description
-This is a variant of the [Event Listing](./?p=organisms-event-listing) pattern showing how it can be renedered as a grid.
+This is a variant of the [Event Listing](./?p=organisms-event-listing) pattern showing how it can be rendered as a grid.
 
 ### How to generate
 * set the `grid` variable to true

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing-past-as-grid.md
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing-past-as-grid.md
@@ -1,0 +1,6 @@
+### Description
+This is a variant of the [Event Listing](./?p=organisms-event-listing) pattern showing how it can be renedered as a grid when there are no upcoming events but there are past events.
+
+### How to generate
+* set the `grid` variable to true
+* set the "emptyText" and "pastMore" variables to the eventListing array.

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing-past-as-sidebar.md
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing-past-as-sidebar.md
@@ -1,0 +1,5 @@
+### Description
+This is a variant of the [Event Listing](./?p=organisms-event-listing) pattern showing how it should be rendered in the Right Rail when there are no upcoming events but there are past events.
+
+### How to generate
+* set the "emptyText" and "pastMore" variables to the eventListing array.

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing.md
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing.md
@@ -24,10 +24,16 @@ eventListing: {
   sidebarHeading:{
     type: compHeading / optional
   },
+  emptyText: {
+    type: string / optional
+  }
   events:[{
     type: eventTeaser / required
   }],
   more:{
+    type: link / optional
+  }
+  pastMore:{
     type: link / optional
   }
 }

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing.twig
@@ -13,14 +13,27 @@
       {% include "@atoms/04-headings/sidebar-heading.twig" %}
       {% set teaserHeading = (sidebarHeading.level ? : teaserHeading) + 1 %}
     {% endif %}
-    <ul class="ma__event-listing__items js-event-listing-items">
-      {% for eventTeaser in eventListing.events %}
-        {% set eventTeaser = eventTeaser|merge({"level":teaserHeading}) %}
-        <li class="ma__event-listing__item js-event-listing-item">
-          {% include "@molecules/event-teaser.twig" %}
-        </li>
-      {% endfor %}
-    </ul>
+    {% if eventListing.events %}
+      <ul class="ma__event-listing__items js-event-listing-items">
+        {% for eventTeaser in eventListing.events %}
+          {% set eventTeaser = eventTeaser|merge({"level":teaserHeading}) %}
+          <li class="ma__event-listing__item js-event-listing-item">
+            {% include "@molecules/event-teaser.twig" %}
+          </li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+    {% if eventListing.emptyText %}
+      <div class="ma__event-listing__empty">
+        {{ eventListing.emptyText }}
+      </div>
+    {% endif %}
+    {% if eventListing.pastMore %}
+      <div class="ma__event-listing__past">
+        {% set link = eventListing.pastMore %}
+        {% include "@atoms/11-text/link.twig" %}
+      </div>
+    {% endif %}
     {% if eventListing.more %}
       <div class="ma__event-listing__more">
         {% set link = eventListing.more %}

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing~past-as-grid.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing~past-as-grid.json
@@ -1,0 +1,17 @@
+{
+  "eventListing": {
+    "grid": true,
+    "compHeading":{
+      "title": "Upcoming Events"
+    },
+    "emptyText": "No upcoming events scheduled",
+    "events": null,
+    "pastMore":{
+      "href": "#",
+      "text": "See past events",
+      "info": "view all past events for this location",
+      "chevron": true
+    }
+  }
+}
+ 

--- a/styleguide/source/_patterns/03-organisms/by-author/event-listing~past-as-sidebar.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/event-listing~past-as-sidebar.json
@@ -1,0 +1,17 @@
+{
+  "eventListing": {
+    "compHeading" : null,
+    "sidebarHeading":{
+      "title": "Upcoming Events"
+    },
+    "emptyText": "No upcoming events scheduled",
+    "events": null,
+    "pastMore":{
+      "href": "#",
+      "text": "See past events",
+      "info": "View all past events for this location",
+      "chevron": true
+    }
+  }
+}
+ 

--- a/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.json
@@ -54,6 +54,12 @@
         "text": "Title Link IV",
         "info": ""
       }
-    }]
+    }],
+    "more":{
+      "href": "#",
+      "text": "See all related pages",
+      "info": "",
+      "chevron": true
+    }
   }
 }

--- a/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.md
+++ b/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.md
@@ -8,6 +8,7 @@ This Pattern shows a collection of images and links to other pages on the site.
 * Illustrated link
 * Decorative Link
 * Image
+* Link
 
 ### Variant options
 * The pattern can be shown with [Illustrated Links](./?p=organisms-suggested-pages-guide)
@@ -30,5 +31,8 @@ This Pattern shows a collection of images and links to other pages on the site.
       type: decorativeLink / required
     }
   }]
+  "more": {
+    type: link / optional
+  }
 }
 ~~~

--- a/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.twig
@@ -27,5 +27,11 @@
         {% endfor %}
       {% endif %}
     </div>
+    {% if suggestedPages.more %}
+      <div class="ma__suggested-pages__more">
+        {% set link = suggestedPages.more %}
+        {% include "@atoms/11-text/link.twig" %}
+      </div>
+    {% endif %}
   </div>
 </section>

--- a/styleguide/source/_patterns/04-templates/01-content-types/press.twig
+++ b/styleguide/source/_patterns/04-templates/01-content-types/press.twig
@@ -28,10 +28,6 @@
         {% set video = pageContent.video %}
         {% include "@atoms/09-media/video.twig" %}
       {% endif %}
-      
-      {% if pageContent.location %}
-        <p class="ma__press__location-label"><b>{{ pageContent.location }}</b>&nbsp;&mdash;&nbsp;</p>
-      {% endif %}
 
       {% set richText = pageContent.richText %}
       {% include "@organisms/by-author/rich-text.twig" %}

--- a/styleguide/source/_patterns/05-pages/guide.json
+++ b/styleguide/source/_patterns/05-pages/guide.json
@@ -48,6 +48,9 @@
   "contentEyebrow": {
     "hideBorder": true,
     "headerTags": {
+      "id": "terms",
+      "moreLabel": "more",
+      "lessLabel": "less",
       "label": "More about:",
       "taxonomyTerms": [{
         "href": "#",

--- a/styleguide/source/_patterns/05-pages/howto.json
+++ b/styleguide/source/_patterns/05-pages/howto.json
@@ -8,10 +8,25 @@
     "title": "Apply for unemployment benefits",
     "subTitle": "Have you lost your job?  You may qualify for temporary income to support you while you look for a new one.",
     "headerTags": {
+      "id": "how-to-tags",
       "label": "More about:",
+      "moreLabel": "show more",
+      "lessLabel": "show less",
       "taxonomyTerms": [{
         "href": "#",
-        "text": "Unemployment Benefits"
+        "text": "Header tag 1"
+      },{
+        "href": "#",
+        "text": "Header tag 2"
+      },{
+        "href": "#",
+        "text": "Header tag 3"
+      },{
+        "href": "#",
+        "text": "Header tag 4"
+      },{
+        "href": "#",
+        "text": "Header tag 5"
       }]
     },
     "socialLinks": {

--- a/styleguide/source/_patterns/05-pages/location-general-content.json
+++ b/styleguide/source/_patterns/05-pages/location-general-content.json
@@ -767,38 +767,13 @@
       "sidebarHeading":{
         "title": "Upcoming Events"
       },
-      "events":[{
-        "title": {
-          "href": "#",
-          "text": "Winter Birding Event",
-          "info": "",
-          "property": ""
-        },
-        "location": "Lanesborough, MA",
-        "date": {
-          "summary": "March 30, 2017" 
-        },
-        "time": "12 p.m. - 2 p.m.",
-        "description": "Event description. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Magnam tempora itaque fuga quasi vero sint, sapiente soluta sit molestias architecto deleniti sunt eum incidunt laboriosam quos repudiandae nesciunt eligendi? Aliquid."
-      },{
-        "title": {
-          "href": "#",
-          "text": "First Day Hike",
-          "info": "",
-          "property": ""
-        },
-        "location": "Lanesborough, MA",
-        "date": {
-          "summary": "March 30, 2017 - April 10, 2017"
-        },
-        "time": "12 p.m. - 2 p.m.",
-        "description": ""
-      }],
-      "more":{
+      "emptyText": "No upcoming events scheduled",
+      "events": null,
+      "pastMore":{
         "href": "#",
-        "text": "view all events at this location",
-        "chevron": true,
-        "label": ""
+        "text": "See past events",
+        "info": "view all past events for this location",
+        "chevron": true
       }
     }
   }

--- a/styleguide/source/_patterns/05-pages/organization.json
+++ b/styleguide/source/_patterns/05-pages/organization.json
@@ -150,7 +150,7 @@
           "id": "GUID831741781374893",
           "bgWide":"../../assets/images/placeholder/1600x600-lighthouse-blur.jpg",
           "bgNarrow":"../../assets/images/placeholder/800x800.png",
-          "title": "What Would You Like to Do?",
+          "title": "What do you need help with?",
           "featuredHeading":"Featured Services",
           "generalHeading":"More Services",
 

--- a/styleguide/source/_patterns/05-pages/organization.json
+++ b/styleguide/source/_patterns/05-pages/organization.json
@@ -532,6 +532,7 @@
       "data": {
         "eventListing": {
           "grid": true,
+          "emptyText": "No upcoming events scheduled",
           "compHeading":{
             "title": "Upcoming Events",
             "sub": "",
@@ -539,46 +540,12 @@
             "id": "",
             "centered": ""
           },
-          "events":[{
-            "title": {
-              "href": "#",
-              "text": "Winter Birding Event",
-              "info": "",
-              "property": ""
-            },
-            "location": "Lanesborough, MA",
-            "date": {
-              "summary": "March 30, 2017",
-              "startMonth": "Mar",
-              "startDay": "30",
-              "endMonth": "",
-              "endDay": ""
-            },
-            "time": "12 p.m. - 2 p.m.",
-            "description": "Event description. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Magnam tempora itaque fuga quasi vero sint, sapiente soluta sit molestias architecto deleniti sunt eum incidunt laboriosam quos repudiandae nesciunt eligendi? Aliquid."
-          },{
-            "title": {
-              "href": "#",
-              "text": "First Day Hike",
-              "info": "",
-              "property": ""
-            },
-            "location": "Lanesborough, MA",
-            "date": {
-              "summary": "March 30, 2017 - April 10, 2017",
-              "startMonth": "Mar",
-              "startDay": "30",
-              "endMonth": "Apr",
-              "endDay": "10"
-            },
-            "time": "12 p.m. - 2 p.m.",
-            "description": ""
-          }],
-          "more":{
+          "events": null,
+          "pastMore":{
             "href": "#",
-            "text": "See all events",
-            "chevron": true,
-            "label": "See all events for Executive Office of Health and Human Services"
+            "text": "See past events",
+            "info": "view all past events for Executive Office of Health and Human Services",
+            "chevron": true
           }
         }
       }

--- a/styleguide/source/_patterns/05-pages/press-release.json
+++ b/styleguide/source/_patterns/05-pages/press-release.json
@@ -58,7 +58,7 @@
         "path": "@atoms/11-text/paragraph.twig",
         "data": {
           "paragraph" : {
-            "text": "Today, Governor Charlie Baker delivers his first State of the Commonwealth address from the House Chamber of the Massachusetts State House. Remarks as prepared for delivery:"
+            "text": "<span class=\"ma__rich-text__flame\">Boston</span> &mdash; Today, Governor Charlie Baker delivers his first State of the Commonwealth address from the House Chamber of the Massachusetts State House. Remarks as prepared for delivery:"
           }
         }
       },{

--- a/styleguide/source/_patterns/05-pages/readme2.json
+++ b/styleguide/source/_patterns/05-pages/readme2.json
@@ -5,7 +5,7 @@
   },
 
   "errorPage": {
-    "type": "v5.8.1 (10/16/2017)",
+    "type": "v5.8.2 (11/26/2017)",
     "title": "Welcome to Mayflower, the Commonwealth's Design System",
     "message": "Use the navigation menu above to browse our patterns."
   },

--- a/styleguide/source/_patterns/05-pages/service.json
+++ b/styleguide/source/_patterns/05-pages/service.json
@@ -133,7 +133,7 @@
       "id": "GUID90357801731903501238",
       "bgWide":"",
       "bgNarrow":"",
-      "title": "What Would You Like to Do?",
+      "title": "What would you like to do?",
       "featuredHeading":"Featured:",
       "generalHeading":"All How-Tos:",
       "hideFilter": true,

--- a/styleguide/source/assets/js/index.js
+++ b/styleguide/source/assets/js/index.js
@@ -9,6 +9,7 @@ import eventFilters               from "./modules/eventFilters";
 import eventListingInteractive    from "./modules/eventListingInteractive";
 import footnote                   from "./modules/footnote.js";
 import formValidation             from "./modules/formValidation.js";
+import headerTags                 from "./modules/headerTags.js";
 import hideAlert                  from "./modules/hideAlert.js";
 import keywordSearch              from "./modules/keywordSearch.js";
 import locationFilters            from "./modules/locationFilters.js";

--- a/styleguide/source/assets/js/modules/headerTags.js
+++ b/styleguide/source/assets/js/modules/headerTags.js
@@ -1,0 +1,30 @@
+export default function (window,document,$,undefined) {
+  "use strict";
+  $('.js-header-tag-link').each(function() {
+
+    let $showHideButton = $('.js-header-tag-link .js-header-tag-button'),
+        $relatedItems = $('.js-header-tag-link a:nth-child(n+4)'),
+        $parent = $showHideButton.parent();
+
+      // Hide items after 3 items.
+      if ($relatedItems.length) {
+        // Show our see button if we have more than three items.
+        $showHideButton.show();
+      }
+
+      $showHideButton.on('click', function(e) {
+        e.preventDefault();
+        $parent.toggleClass('is-open');
+
+        if ($parent.hasClass('is-open')) {
+          $showHideButton.attr('aria-expanded', 'true');
+          $relatedItems.show();
+        }
+        else {
+          $showHideButton.attr('aria-expanded', 'false');
+          $relatedItems.hide();
+        }
+      });
+
+  });
+}(window,document,jQuery);

--- a/styleguide/source/assets/js/templates/googleMapInfo.html
+++ b/styleguide/source/assets/js/templates/googleMapInfo.html
@@ -17,7 +17,7 @@
   {{/if}}
   {{#if email}}
     <div class="ma__info-window__email">
-      <span class="ma__info-window__label">Online:</span>
+      <span class="ma__info-window__label">Email:</span>
       <a class="ma__info-window__email-link" href="mailto:{{email}}">{{email}}</a>
     </div>
   {{/if}}

--- a/styleguide/source/assets/js/templates/googleMapInfo.html
+++ b/styleguide/source/assets/js/templates/googleMapInfo.html
@@ -17,7 +17,7 @@
   {{/if}}
   {{#if email}}
     <div class="ma__info-window__email">
-      <span class="ma__info-window__label">Email:</span>
+      <span class="ma__info-window__label">Online:</span>
       <a class="ma__info-window__email-link" href="mailto:{{email}}">{{email}}</a>
     </div>
   {{/if}}

--- a/styleguide/source/assets/scss/01-atoms/_textarea.scss
+++ b/styleguide/source/assets/scss/01-atoms/_textarea.scss
@@ -1,7 +1,6 @@
 .ma__textarea {
 
   &__wrapper {
-    display: inline-block;
     position: relative;
 
     &:after {

--- a/styleguide/source/assets/scss/01-atoms/global/_elements.scss
+++ b/styleguide/source/assets/scss/01-atoms/global/_elements.scss
@@ -89,3 +89,14 @@ h6 {
   @include ma-visually-hidden;
 }
 
+h1,
+h2,
+h3,
+h4,
+p,
+main,
+div {
+  &[tabindex="-1"]:focus {
+    outline: none;
+  }
+}

--- a/styleguide/source/assets/scss/02-molecules/_header-tags.scss
+++ b/styleguide/source/assets/scss/02-molecules/_header-tags.scss
@@ -2,6 +2,15 @@
   font-size: 16px;
   letter-spacing: .1em;
   text-transform: uppercase;
+  max-width: $l-max-content-width;
+
+  > span {
+    white-space: nowrap;
+  }
+
+  @media ($bp-medium-min) {
+    display: inline-flex;
+  }
 
   &__terms {
     display: inline;
@@ -26,6 +35,68 @@
 
       &:last-child {
         margin-right: 0;
+      }
+
+      &:nth-child(n+4) {
+        display: none;
+      }
+
+      @media ($bp-x-small-max) {
+        // On small screens each tag is full width.
+        display: block;
+      }
+    }
+
+    &.is-open {
+      a {
+        display: inline-block;
+
+        @media ($bp-x-small-max) {
+          // On small screens each tag is full width.
+          display: block;
+        }
+      }
+
+      > button {
+        &:after {
+          transform: translateY(-55%) rotate(-135deg);
+        }
+        span:first-child {
+          display: none;
+        }
+        span:nth-child(2) {
+          display: inline;
+        }
+      }
+    }
+
+    > button {
+      @include ma-button-reset;
+      @include ma-link-underline;
+      @include ma-chevron;
+      padding-left: 10px;
+      font-size: 19px;
+      display: none;
+
+      &:after {
+        opacity: .5;
+        margin-left: 0;
+        border-width: 3px;
+        height: 8px;
+        width: 8px;
+        transform: translateY(-45%) rotate(45deg);
+      }
+
+      span:first-child {
+        display: inline;
+      }
+
+      span:nth-child(2) {
+        display: none;
+      }
+
+      @media ($bp-x-small-max) {
+        display: block;
       }
     }
   }

--- a/styleguide/source/assets/scss/02-molecules/_section-links.scss
+++ b/styleguide/source/assets/scss/02-molecules/_section-links.scss
@@ -92,9 +92,12 @@
 
   &__title {
     @include ma-h3;
-    margin-bottom: 15px;
+    margin-bottom: .5em;
+    @media ($bp-small-min){
+      margin-bottom: .5em;
+    }
     align-self: stretch;
-
+    
     a {
       border: none;
     }
@@ -166,6 +169,7 @@
     @include ma-reset-list;
   }
 
+
   // skip the first item
   &__item + &__item {
     margin-top: 1em;
@@ -173,13 +177,14 @@
 
   // Make child content callout links full width
   &__item > .ma__callout-link {
-    @include ma-container();
     display: block;
     width: 100%;
   }
 
   &__item > .ma__decorative-link {
+    &__item > .ma__decorative-link {
     font-size: 1.625rem;
     line-height: 1.3;
+  }
   }
 }

--- a/styleguide/source/assets/scss/03-organisms/_event-listing.scss
+++ b/styleguide/source/assets/scss/03-organisms/_event-listing.scss
@@ -15,6 +15,15 @@ $event-listing-bp-show-grid: $bp-medium-min;
     @include ma-component-spacing;
   }
 
+  &__empty {
+    font-size: 1.5rem;
+    margin-bottom: .25em;
+
+    .ma__page-header & {
+      font-size: 1.813rem;
+    }
+  }
+
   &--grid &__container {
     
     @media ($event-listing-bp-show-grid) {
@@ -135,11 +144,20 @@ $event-listing-bp-show-grid: $bp-medium-min;
   }
 
 
-  &__more {
-    margin-top: 30px;
+  &__more,
+  &__past {
+    margin-top: 20px;
 
     @media ($bp-large-min) {
-      margin-top: 45px;
+      margin-top: 35px;
+    }
+
+    .sidebar & {
+      margin-top: 15px;
+
+      @media ($bp-large-min) {
+        margin-top: 25px;
+      }
     }
   }
 

--- a/styleguide/source/assets/scss/03-organisms/_page-banner.scss
+++ b/styleguide/source/assets/scss/03-organisms/_page-banner.scss
@@ -22,7 +22,7 @@ $page-banner-icon-width: $column + $gutter;
 
   &--overlay {
     @media ($bp-large-min) {
-      height: 300px;
+      height: 400px;
     }
   }
 

--- a/styleguide/source/assets/scss/03-organisms/_page-banner.scss
+++ b/styleguide/source/assets/scss/03-organisms/_page-banner.scss
@@ -1,9 +1,10 @@
 $page-banner-icon-width: $column + $gutter;
+$page-banner-height: 330px;
 
 .ma__page-banner {
   background-size: cover;
   background-position: center center;
-  height: 400px;
+  height: $page-banner-height;
   margin-bottom: 20px;
   overflow: hidden;
   position: relative;
@@ -49,6 +50,7 @@ $page-banner-icon-width: $column + $gutter;
     @include clearfix;
     height: auto;
     min-height: 450px;
+    padding-right: 0px; //fix gap on mobile
   }
 
   &--overlay &__container {
@@ -64,6 +66,9 @@ $page-banner-icon-width: $column + $gutter;
   }
 
   &__content {
+    display: flex;
+      align-items: center;
+      flex-wrap: wrap;
     font-size: 1rem;
     max-width: 1050px;
     padding: 30px 25px 45px 0;
@@ -73,9 +78,6 @@ $page-banner-icon-width: $column + $gutter;
     z-index: 1;
 
     @media ($bp-x-small-min) {
-      display: flex;
-        align-items: center;
-        flex-wrap: wrap;
       margin-right: 70px;
       padding-top: 50px;
       padding-right: 80px;
@@ -133,10 +135,10 @@ $page-banner-icon-width: $column + $gutter;
   }
 
   &--columns &__content {
-    height: 400px;
+    height: $page-banner-height;
     max-width: 640px;
     position: relative;
-      top: 200px;
+      top: calc(#{$page-banner-height}/2);
 
     @media ($bp-medium-min) {
       height: 100%;
@@ -149,6 +151,7 @@ $page-banner-icon-width: $column + $gutter;
   &__icon {
     padding-right: 30px;
     width: 75px;
+    display: none;
 
     @media ($bp-x-small-min) {
       transform: skew(30deg);
@@ -156,6 +159,7 @@ $page-banner-icon-width: $column + $gutter;
 
     @media ($bp-medium-min) {
       width: $page-banner-icon-width;
+      display: inline-block;
     }
 
     & > svg {
@@ -310,7 +314,7 @@ $page-banner-icon-width: $column + $gutter;
   &--columns &__image {
     background-position: 50% 50%;
     background-size: cover;
-    height: 400px;
+    height: $page-banner-height;
     position: absolute;
       right: 0;
       top: 0;

--- a/styleguide/source/assets/scss/03-organisms/_page-header.scss
+++ b/styleguide/source/assets/scss/03-organisms/_page-header.scss
@@ -13,6 +13,9 @@ $page-header-widget-width: 350px;
     overflow: hidden;
     margin-bottom: -20px;
     padding-top: 18px;
+    border-bottom-width: 1px;
+    border-bottom-style: solid;
+    margin-bottom: 20px;
 
     .ma__header-tags,
     .ma__social-links {
@@ -21,11 +24,17 @@ $page-header-widget-width: 350px;
       min-height: 48px;
       position: relative;
         top: 1px;
+      @media ($bp-medium-min) {
+        border: 0;
+      }
     }
 
     .ma__header-tags {
       flex-grow: 1;
       margin-bottom: 30px;
+      @media ($bp-medium-min) {
+        margin-bottom: 10px;
+      }
     }
 
     .ma__social-links {
@@ -34,6 +43,9 @@ $page-header-widget-width: 350px;
       @media ($bp-small-max) {
         width: 100%;
       }
+    }
+    @media ($bp-medium-max) {
+      border: 0;
     }
   }
 

--- a/styleguide/source/assets/scss/03-organisms/_rich-text.scss
+++ b/styleguide/source/assets/scss/03-organisms/_rich-text.scss
@@ -4,6 +4,10 @@ $rich-text-spacing-mobile: 1.5rem;
 .ma__rich-text {
   @include clearfix;
 
+  &__flame {
+    text-transform: uppercase;
+  }
+
   &--description {
     margin-bottom: 1rem;
   }

--- a/styleguide/source/assets/scss/03-organisms/_stacked-row-section.scss
+++ b/styleguide/source/assets/scss/03-organisms/_stacked-row-section.scss
@@ -1,11 +1,11 @@
 .ma__stacked-row-section {
 
   @media ($bp-large-max) {
-    box-shadow: 0 0.5rem 0.5rem -0.25rem rgba(1, 1, 1, 0.25);
     padding-bottom: 45px;
 
-    &:last-child {
-      box-shadow: none;
+    & ~ & {
+      border-top-width: 1px;
+      border-top-style: solid;
     }
   }
 
@@ -38,7 +38,7 @@
   &--restricted &__title {
     max-width: 820px;
   }
-  
+
   .main-content {
 
     @media ($bp-large-max) {

--- a/styleguide/source/assets/scss/03-organisms/_stacked-row-section.scss
+++ b/styleguide/source/assets/scss/03-organisms/_stacked-row-section.scss
@@ -1,11 +1,12 @@
 .ma__stacked-row-section {
 
   @media ($bp-large-max) {
-    box-shadow: 0 0.5rem 0.5rem -0.25rem rgba(1, 1, 1, 0.25);
+    box-shadow: none;
     padding-bottom: 45px;
 
-    &:last-child {
-      box-shadow: none;
+    & + & {
+      border-top-width: 1px;
+      border-top-style: solid;
     }
   }
 
@@ -38,7 +39,7 @@
   &--restricted &__title {
     max-width: 820px;
   }
-  
+
   .main-content {
 
     @media ($bp-large-max) {

--- a/styleguide/source/assets/scss/03-organisms/_stacked-row-section.scss
+++ b/styleguide/source/assets/scss/03-organisms/_stacked-row-section.scss
@@ -1,12 +1,11 @@
 .ma__stacked-row-section {
 
   @media ($bp-large-max) {
-    box-shadow: none;
+    box-shadow: 0 0.5rem 0.5rem -0.25rem rgba(1, 1, 1, 0.25);
     padding-bottom: 45px;
 
-    & + & {
-      border-top-width: 1px;
-      border-top-style: solid;
+    &:last-child {
+      box-shadow: none;
     }
   }
 
@@ -39,7 +38,7 @@
   &--restricted &__title {
     max-width: 820px;
   }
-
+  
   .main-content {
 
     @media ($bp-large-max) {

--- a/styleguide/source/assets/scss/04-templates/_press.scss
+++ b/styleguide/source/assets/scss/04-templates/_press.scss
@@ -11,14 +11,6 @@
     }
   }
 
-  &__location-label {
-    float: left;
-    line-height: 1em;
-    margin-bottom: 0;
-    padding-top: .25em;
-    text-transform: uppercase;
-  }
-
   &__sidebar {
     .ma__contact-list {
 

--- a/styleguide/source/assets/scss/04-templates/_stacked-row.scss
+++ b/styleguide/source/assets/scss/04-templates/_stacked-row.scss
@@ -4,11 +4,11 @@
   &__section {
 
     @media ($bp-large-max) {
-      box-shadow: 0 0.5rem 0.5rem -0.25rem rgba(1, 1, 1, 0.25);
       padding-bottom: 45px;
 
-      &:last-child {
-        box-shadow: none;
+      & ~ & {
+        border-top-width: 1px;
+        border-top-style: solid;
       }
     }
 

--- a/styleguide/source/assets/scss/04-templates/_stacked-row.scss
+++ b/styleguide/source/assets/scss/04-templates/_stacked-row.scss
@@ -4,11 +4,12 @@
   &__section {
 
     @media ($bp-large-max) {
-      box-shadow: 0 0.5rem 0.5rem -0.25rem rgba(1, 1, 1, 0.25);
+      box-shadow: none;
       padding-bottom: 45px;
 
-      &:last-child {
-        box-shadow: none;
+      & + & {
+        border-top-width: 1px;
+        border-top-style: solid;
       }
     }
 

--- a/styleguide/source/assets/scss/04-templates/_stacked-row.scss
+++ b/styleguide/source/assets/scss/04-templates/_stacked-row.scss
@@ -4,12 +4,11 @@
   &__section {
 
     @media ($bp-large-max) {
-      box-shadow: none;
+      box-shadow: 0 0.5rem 0.5rem -0.25rem rgba(1, 1, 1, 0.25);
       padding-bottom: 45px;
 
-      & + & {
-        border-top-width: 1px;
-        border-top-style: solid;
+      &:last-child {
+        box-shadow: none;
       }
     }
 

--- a/styleguide/source/assets/scss/06-theme/01-atoms/_table.scss
+++ b/styleguide/source/assets/scss/06-theme/01-atoms/_table.scss
@@ -18,7 +18,7 @@
 }
 
 .ma__table {
-  
+
   @media ($bp-small-max) {
     thead + tbody,
     tbody:first-child {
@@ -26,7 +26,7 @@
     }
 
     td {
-      
+
       &:before {
         color: $c-font-heading;
         font-weight: 500;
@@ -41,7 +41,7 @@
 }
 
 .ma__table--wide {
-  
+
   @media ($bp-medium-max) {
     thead + tbody,
     tbody:first-child {
@@ -49,7 +49,7 @@
     }
 
     td {
-      
+
       &:before {
         color: $c-font-heading;
         font-weight: 500;

--- a/styleguide/source/assets/scss/06-theme/02-molecules/_header-tags.scss
+++ b/styleguide/source/assets/scss/06-theme/02-molecules/_header-tags.scss
@@ -11,5 +11,10 @@
         border-color: $c-font-link;
       }
     }
+
+    > button {
+      color: $c-theme-primary;
+      font-weight: 500;
+    }
   }
 }

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_action-finder.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_action-finder.scss
@@ -2,7 +2,7 @@ $action-finder-bg-color: tint($c-theme-primary,89%);
 $action-finder-border-color: tint($c-theme-primary,50%);
 
 .ma__action-finder {
-  
+
   &:after {
     background-image: linear-gradient(180deg, rgba(#000,.6), transparent 90%, transparent);
   }
@@ -10,12 +10,6 @@ $action-finder-border-color: tint($c-theme-primary,50%);
   &--no-background {
     background-image: linear-gradient(180deg, $c-white 50px, $c-bg-section 51px);
   }
-
-  &--no-background + &--no-background {
-    background-image: none;
-    background-color: $c-bg-section;
-  }
-
 
   &--no-background &__header {
     background-color: $c-theme-primary;
@@ -54,7 +48,7 @@ $action-finder-border-color: tint($c-theme-primary,50%);
   }
 
   &__items--all {
-    
+
     .ma__callout-link {
       background-color: $c-white;
       box-shadow: none;

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_event-listing.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_event-listing.scss
@@ -1,5 +1,10 @@
 .ma__event-listing {
 
+  &__empty {
+    font-style: italic;
+    font-weight: 500;
+  }
+
   &--grid &__item {
     border-color: $c-bd-divider;
 

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_page-header.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_page-header.scss
@@ -1,7 +1,9 @@
 .ma__page-header {
 
   &__tags {
-
+    @media ($bp-medium-min) {
+      border-color: $c-bd-divider;
+    }
     .ma__header-tags,
     .ma__social-links {
       border-color: $c-bd-divider;

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_rich-text.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_rich-text.scss
@@ -1,4 +1,8 @@
 .ma__rich-text {
+
+  &__flame {
+    font-weight: bold;
+  }
   
   &__footnote {
     border-color: rgba($c-font-link,.5);

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_stacked-row-section.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_stacked-row-section.scss
@@ -1,6 +1,6 @@
 .ma__stacked-row-section {
 
-  & ~ & &__container:before {
+  &, & ~ & &__container:before {
     border-color: $c-bd-divider;
   }
 }

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_stacked-row-section.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_stacked-row-section.scss
@@ -1,6 +1,6 @@
 .ma__stacked-row-section {
 
-  &, & ~ & &__container:before {
+  & ~ & &__container:before {
     border-color: $c-bd-divider;
   }
 }

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_stacked-row-section.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_stacked-row-section.scss
@@ -1,6 +1,10 @@
 .ma__stacked-row-section {
 
-  & ~ & &__container:before {
+  & ~ & {
     border-color: $c-bd-divider;
+    
+    &__container:before {
+      border-color: $c-bd-divider;
+    }
   }
 }

--- a/styleguide/source/assets/scss/06-theme/04-templates/_stacked-row.scss
+++ b/styleguide/source/assets/scss/06-theme/04-templates/_stacked-row.scss
@@ -1,6 +1,6 @@
 .ma__stacked-row {
 
-  &__section ~ &__section &__container:before {
+  &__section, &__section ~ &__section &__container:before {
     border-color: $c-bd-divider;
   }
 }

--- a/styleguide/source/assets/scss/06-theme/04-templates/_stacked-row.scss
+++ b/styleguide/source/assets/scss/06-theme/04-templates/_stacked-row.scss
@@ -1,6 +1,10 @@
 .ma__stacked-row {
 
-  &__section ~ &__section &__container:before {
+  &__section ~ &__section {
     border-color: $c-bd-divider;
+    
+    &__container:before {
+      border-color: $c-bd-divider;
+    }
   }
 }

--- a/styleguide/source/assets/scss/06-theme/04-templates/_stacked-row.scss
+++ b/styleguide/source/assets/scss/06-theme/04-templates/_stacked-row.scss
@@ -1,6 +1,6 @@
 .ma__stacked-row {
 
-  &__section, &__section ~ &__section &__container:before {
+  &__section ~ &__section &__container:before {
     border-color: $c-bd-divider;
   }
 }

--- a/styleguide/source/assets/scss/08-print/_print.scss
+++ b/styleguide/source/assets/scss/08-print/_print.scss
@@ -49,7 +49,9 @@ h1,
 .ma__banner-carousel,
 .ma__quick-actions,
 .ma__wait-time,
-.fluid-width-video-wrapper {
+.fluid-width-video-wrapper,
+#feedback,
+.ma__floating-action {
   display: none !important;
 }
 
@@ -552,6 +554,9 @@ h4 {
   column-count: 1;
 }
 
-
-
+  // Opens accordions when printing.
+  .ma__action-step--accordion .ma__action-step__content,
+  .ma__contact-us--accordion .ma__contact-us__content  {
+    display: block !important;
+  }
 }


### PR DESCRIPTION
## 5.8.2

### Added
- DP-4534 - Add a generalized button to toggle showing more/less "Related To:" items in [@molecules/header-tags](http://mayflower.digital.mass.gov/?p=molecules-header-tags). [PR #594](https://github.com/massgov/mayflower/pull/594)
- DP-6111 - Add empty state for [event listings](http://mayflower.digital.mass.gov/?p=organisms-event-listing) to show when there are no upcoming events. [PR #617](https://github.com/massgov/mayflower/pull/617)
- DP-5385 - Add optional "see more" link to [suggested pages](http://mayflower.digital.mass.gov/?p=organisms-suggested-pages). [PR #647](https://github.com/massgov/mayflower/pull/647)

### Changed
- DP-5858 - Updated print styles to hide feedback and floating button and show expanded content from normally collapsed accordion sections. [PR #625](https://github.com/massgov/mayflower/pull/625)
- DP-5518 - Fix feedback form wrapper layout at bottom of page to have child content flow properly (i.e textarea is full width). [PR #608](https://github.com/massgov/mayflower/pull/608)
- DP-5515 - Make service page title & organization title sentence case. [PR #615](https://github.com/massgov/mayflower/pull/615)
- DP-4572 - Change [Press Release](http://mayflower.digital.mass.gov/?p=pages-press-release) location to be inline the rich text area and upper case. [PPR #599](https://github.com/massgov/mayflower/pull/599)
- DP-5388 - Expand [page banner](http://mayflower.digital.mass.gov/?p=organisms-page-banner) height to provide more ample room for longer titles. [PR #641](https://github.com/massgov/mayflower/pull/641)
- DP-5523 - Fix action finder background color overlays where it is used multiple times, like on [service pages](http://mayflower.digital.mass.gov//?p=pages-service). [PR #639](https://github.com/massgov/mayflower/pull/639)
- DP-3060 - Remove unecessary outline on non-interactive elements when users use the side-navigation on [how-to pages](http://mayflower.digital.mass.gov/?p=pages-howto). [PR #614](https://github.com/massgov/mayflower/pull/614)
- DP-5636 - On mobile, remove dropshadow between rows on [@organisms/stacked-rows](http://mayflower.digital.mass.gov/?p=organisms-stacked-row-section). [PR #637](https://github.com/massgov/mayflower/pull/637)
- DP-6106 - Fix [@organisms/page-banner](http://mayflower.digital.mass.gov/?p=organisms-page-banner) padding & margins on mobile. [PR #636](https://github.com/massgov/mayflower/pull/636)

### Removed
- DP-5914 - Remove extra padding on [@molecules/section-links](http://mayflower.digital.mass.gov/?p=molecules-section-links). [PR #626](https://github.com/massgov/mayflower/pull/626)

 		 