### PR TITLE
DP-5768 add description to download links, create link listing page

### DIFF
--- a/styleguide/source/_patterns/02-molecules/download-link-with-description.md
+++ b/styleguide/source/_patterns/02-molecules/download-link-with-description.md
@@ -1,0 +1,5 @@
+### Description
+This is a variant of the [Download Link](./?p=molecules-download-link) pattern showing an example link with description text.
+
+### How to generate
+* populate the `description` variable with the data structure for `richText`

--- a/styleguide/source/_patterns/02-molecules/download-link.md
+++ b/styleguide/source/_patterns/02-molecules/download-link.md
@@ -6,6 +6,7 @@ This pattern is a link to a file or online form.
 
 ### Pattern Contains
 * Decorative Link
+* Rich Text
 
 ### Variant options
 * You can use [small](./?p=molecules-download-link-with-small-icon) icons
@@ -27,5 +28,7 @@ downloadLink: {
     type: string (filesize) / optional
   format:  
     type: string (fileformat or 'form') / optional
+  description:
+    type: rich text / optional
 }
 ~~~

--- a/styleguide/source/_patterns/02-molecules/download-link.twig
+++ b/styleguide/source/_patterns/02-molecules/download-link.twig
@@ -11,7 +11,7 @@
       {% set decorativeLink = downloadLink.decorativeLink %}
       {% include "@atoms/decorative-link.twig" %}
     {% else %}
-      <a 
+      <a
         class="ma__download-link__file-link"
         href="{{ downloadLink.decorativeLink.href}}">
         <span class="visually-hidden">Open {{ downloadLink.format }} file{% if downloadLink.size %}, {{ downloadLink.size }},{% endif %} for</span>
@@ -22,4 +22,10 @@
       {% endif %}
     {% endif %}
   </div>
+  {% if downloadLink.description %}
+    {% set richText = downloadLink.description %}
+    <div class="ma__download-link__description">
+      {% include "@organisms/by-author/rich-text.twig" %}
+    </div>
+  {% endif %}
 </div>

--- a/styleguide/source/_patterns/02-molecules/download-link~with-description.json
+++ b/styleguide/source/_patterns/02-molecules/download-link~with-description.json
@@ -1,0 +1,23 @@
+{
+  "downloadLink": {
+    "iconSize": "",
+    "icon": "@atoms/05-icons/svg-doc-docx.twig",
+    "decorativeLink": {
+      "text": "Link to a file for download",
+      "href": "#",
+      "info": ""
+    },
+    "size": "40kb",
+    "format": "DOCX",
+    "description": {
+      "rteElements": [{
+        "path": "@atoms/11-text/paragraph.twig",
+        "data": {
+          "paragraph" : {
+            "text": "I am a description. I am limited to 155 characters. I am a description. I am limited to 155 characters. I am a description. I am limited to 155 characters."
+          }
+        }
+      }]
+    }
+  }
+}

--- a/styleguide/source/_patterns/03-organisms/by-author/form-downloads-as-listing.md
+++ b/styleguide/source/_patterns/03-organisms/by-author/form-downloads-as-listing.md
@@ -1,0 +1,5 @@
+### Description
+This is a variant of the [Form Downloads](./?p=organism-form-downloads) pattern showing a layout for listing pages.
+
+### How to generate
+Set the `listing` variable to `true`

--- a/styleguide/source/_patterns/03-organisms/by-author/form-downloads.md
+++ b/styleguide/source/_patterns/03-organisms/by-author/form-downloads.md
@@ -12,6 +12,8 @@ This pattern shows a list of links to downloadable files and online forms.  You 
 ### Variables
 ~~~
 formDownloads: {
+  listing: 
+    type: boolean / optional (defaults to false)
   compHeading: {
     type: compHeading / optional
   },

--- a/styleguide/source/_patterns/03-organisms/by-author/form-downloads.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/form-downloads.twig
@@ -1,4 +1,5 @@
-<section class="ma__form-downloads">
+{% set listingClass = formDownloads.listing ? ' ma__form-downloads--listing' : '' %}
+<section class="ma__form-downloads{{ listingClass }}">
   {% if formDownloads.compHeading %}
     {% set compHeading = formDownloads.compHeading %}
     {% include "@atoms/04-headings/comp-heading.twig" %}

--- a/styleguide/source/_patterns/03-organisms/by-author/form-downloads~as-listing.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/form-downloads~as-listing.json
@@ -1,0 +1,101 @@
+{
+  "formDownloads": {
+    "listing": true,
+    "compHeading": {
+      "title": "Forms",
+      "sub": false
+    },
+    "downloadLinks": [{
+      "downloadLink": {
+        "iconSize": "",
+        "icon": "@atoms/05-icons/svg-doc-pdf.twig",
+        "decorativeLink": {
+          "text": "PDF download item",
+          "href": "#",
+          "info": "",
+          "property": ""
+        },
+        "size": "30kb",
+        "format": "PDF",
+        "description": {
+          "rteElements": [{
+            "path": "@atoms/11-text/paragraph.twig",
+            "data": {
+              "paragraph" : {
+                "text": "I am a description. I am limited to 155 characters. I am a description. I am limited to 155 characters. I am a description. I am limited to 155 characters."
+              }
+            }
+          }]
+        }
+      }
+    },{
+      "downloadLink": {
+        "iconSize": "",
+        "icon": "@atoms/05-icons/svg-doc-docx.twig",
+        "decorativeLink": {
+          "text": "Word download item",
+          "href": "#",
+          "info": "",
+          "property": ""
+        },
+        "size": "40kb",
+        "format": "DOCX"
+      }
+    },{
+      "downloadLink": {
+        "iconSize": "",
+        "icon": "@atoms/05-icons/svg-doc-generic.twig",
+        "decorativeLink": {
+          "text": "Generic type of download",
+          "href": "#",
+          "info": "",
+          "property": ""
+        },
+        "size": "40kb",
+        "format": "???"
+      }
+    },{
+      "downloadLink": {
+        "iconSize": "",
+        "icon": "@atoms/05-icons/svg-laptop.twig",
+        "decorativeLink": {
+          "text": "Link to an online form",
+          "href": "#",
+          "info": "",
+          "property": ""
+        },
+        "size": "",
+        "format": "form"
+      }
+    },{
+      "downloadLink": {
+        "iconSize": "",
+        "icon": "",
+        "decorativeLink": {
+          "text": "Link to another page",
+          "href": "#",
+          "info": "",
+          "property": ""
+        },
+        "size": "",
+        "format": "form",
+        "description": {
+          "rteElements": [{
+            "path": "@atoms/11-text/paragraph.twig",
+            "data": {
+              "paragraph" : {
+                "text": "I am a description. I am limited to 155 characters. I am a description. I am limited to 155 characters. I am a description. I am limited to 155 characters."
+              }
+            }
+          }]
+        }
+      }
+    }],
+    "more": {
+      "href": "#",
+      "text": "See all 10 additional resources",
+      "chevron": true,
+      "label": "See all of the resources for Executive Office of Health and Human Services"
+    }
+  }
+}

--- a/styleguide/source/_patterns/03-organisms/by-author/stacked-row-section.md
+++ b/styleguide/source/_patterns/03-organisms/by-author/stacked-row-section.md
@@ -16,10 +16,13 @@ This is a row of content used in the Stacked Row Template
 
 ### Usage Guidelines
 * The ID value is used as an anchor tag when the Jump Links pattern is added as a table of contents (see guide pages)
+* Set `borderless` to true to remove the top border when there are multiple stacked rows.
 
 ### Variables
 ~~~
 stackedRowSection: {
+  borderless: 
+    type: boolean / optional (defaults to false),
   title:
     type: string / optional,
   id: 

--- a/styleguide/source/_patterns/03-organisms/by-author/stacked-row-section.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/stacked-row-section.twig
@@ -1,6 +1,7 @@
-{% set stackRowRestriction = stackedRowSection.sideBar|length ? '' : 'ma__stacked-row-section--restricted' %}
+{% set stackRowRestriction = stackedRowSection.sideBar|length ? '' : ' ma__stacked-row-section--restricted' %}
+{% set stackRowBorderless = stackedRow.borderless ? ' ma__stacked-row__section--borderless' : ''  %}
 
-<section class="ma__stacked-row-section {{ stackRowRestriction }}">
+<section class="ma__stacked-row-section{{ stackRowBorderless }}{{ stackRowRestriction }}">
   {% if stackedRowSection.title %}
     <div class="ma__stacked-row-section__container">
       <div class="ma__stacked-row-section__title">
@@ -14,7 +15,7 @@
         {% include "@atoms/04-headings/comp-heading.twig" %}
       </div>
     </div>
-  {% endif %}    
+  {% endif %}
   <div class="main-content {{ stackedRowSection.sideBar|length ? 'main-content--two' : 'main-content--full' }}">
     <div class="page-content">
       {% for content in stackedRowSection.pageContent %}

--- a/styleguide/source/_patterns/04-templates/stacked-row-template.md
+++ b/styleguide/source/_patterns/04-templates/stacked-row-template.md
@@ -26,6 +26,8 @@ This template allows you to have rows of content that are either full width or w
 ### Variables
 ~~~
 stackedRows: [{
+  borderless:
+    type: boolean / optional (defaults to false),
   title:
     type: string / optional,
   id: 

--- a/styleguide/source/_patterns/04-templates/stacked-row-template.twig
+++ b/styleguide/source/_patterns/04-templates/stacked-row-template.twig
@@ -19,16 +19,16 @@
           {% include "@organisms/by-template/jump-links.twig" %}
         </div>
       {% endif %}
-      
+
       {# backward compatible with v 5.6 - stackedRowSections becomes stackedRows #}
       {% if stackedRowSections %}
         {% set stackedRows = stackedRowSections %}
       {% endif %}
 
       {% for stackedRow in stackedRows %}
-        {% set stackedRowRestriction = stackedRow.sideBar|length ? '' : 'ma__stacked-row--restricted' %}
-
-        <section class="ma__stacked-row__section {{ stackedRowRestriction }}">
+        {% set stackedRowRestriction = stackedRow.sideBar|length ? '' : ' ma__stacked-row--restricted' %}
+        {% set stackRowBorderless = stackedRow.borderless ? ' ma__stacked-row__section--borderless' : ''  %}
+        <section class="ma__stacked-row__section{{ stackRowBorderless }}{{ stackedRowRestriction }}">
           {% if stackedRow.title %}
             <div class="ma__stacked-row__container">
               <div class="ma__stacked-row__title">
@@ -42,7 +42,7 @@
                 {% include "@atoms/04-headings/comp-heading.twig" %}
               </div>
             </div>
-          {% endif %}    
+          {% endif %}
           <div class="main-content {{ stackedRow.sideBar|length ? 'main-content--two' : 'main-content--full' }}">
             <div class="page-content">
               {% for content in stackedRow.pageContent %}

--- a/styleguide/source/_patterns/05-pages/listing-links.json
+++ b/styleguide/source/_patterns/05-pages/listing-links.json
@@ -1,0 +1,354 @@
+{
+  "pageHeader": {
+    "category": "",
+    "divider": false,
+    "title": "Link listing page",
+    "subTitle": "",
+    "headerTags": {
+      "label": "Related to:",
+      "taxonomyTerms": [{
+        "href": "#",
+        "text": "Parent Page"
+      },{
+        "href": "#",
+        "text": "Another Parent Page"
+      }]
+    },
+    "optionalContents": [{
+      "path": "@organisms/by-author/rich-text.twig",
+      "data": {
+        "richText": {
+          "property": "",
+          "rteElements": [{
+            "path": "@atoms/11-text/paragraph.twig",
+            "data": {
+              "paragraph" : {
+                "text": "This is a page which implements the stacked row template.  It can be used to create a curated list of links to other pages, web forms, and various document downloads."
+              }
+            }
+          }]
+        }
+      }
+    }],
+    "widgets": null
+  },
+
+  "jumpLinks": {
+    "title": "In this List",
+    "links": [{
+      "text": "List One",
+      "href": "list-one"
+    },{
+      "text": "List Two",
+      "href": "list-two"
+    },{
+      "text": "List Three",
+      "href": "list-three"
+    }]
+  },
+
+  "stackedRows": [{
+    "borderless": true,
+    "title": "List One",
+    "id": "list-one",
+    "pageContent": [{
+      "path": "@organisms/by-author/form-downloads.twig",
+      "data": {
+        "formDownloads": {
+          "listing": true,
+          "compHeading": null,
+          "downloadLinks": [{
+            "downloadLink": {
+              "iconSize": "",
+              "icon": "@atoms/05-icons/svg-doc-pdf.twig",
+              "decorativeLink": {
+                "text": "PDF download item",
+                "href": "#",
+                "info": "",
+                "property": ""
+              },
+              "size": "30kb",
+              "format": "PDF",
+              "description": {
+                "rteElements": [{
+                  "path": "@atoms/11-text/paragraph.twig",
+                  "data": {
+                    "paragraph" : {
+                      "text": "I am a description. I am limited to 155 characters. I am a description. I am limited to 155 characters. I am a description. I am limited to 155 characters."
+                    }
+                  }
+                }]
+              }
+            }
+          },{
+            "downloadLink": {
+              "iconSize": "",
+              "icon": "@atoms/05-icons/svg-doc-docx.twig",
+              "decorativeLink": {
+                "text": "Word download item",
+                "href": "#",
+                "info": "",
+                "property": ""
+              },
+              "size": "40kb",
+              "format": "DOCX"
+            }
+          },{
+            "downloadLink": {
+              "iconSize": "",
+              "icon": "@atoms/05-icons/svg-doc-generic.twig",
+              "decorativeLink": {
+                "text": "Generic type of download",
+                "href": "#",
+                "info": "",
+                "property": ""
+              },
+              "size": "40kb",
+              "format": "???"
+            }
+          },{
+            "downloadLink": {
+              "iconSize": "",
+              "icon": "@atoms/05-icons/svg-laptop.twig",
+              "decorativeLink": {
+                "text": "Link to an online form",
+                "href": "#",
+                "info": "",
+                "property": ""
+              },
+              "size": "",
+              "format": "form"
+            }
+          },{
+            "downloadLink": {
+              "iconSize": "",
+              "icon": "",
+              "decorativeLink": {
+                "text": "Link to another page",
+                "href": "#",
+                "info": "",
+                "property": ""
+              },
+              "size": "",
+              "format": "form",
+              "description": {
+                "rteElements": [{
+                  "path": "@atoms/11-text/paragraph.twig",
+                  "data": {
+                    "paragraph" : {
+                      "text": "I am a description. I am limited to 155 characters. I am a description. I am limited to 155 characters. I am a description. I am limited to 155 characters."
+                    }
+                  }
+                }]
+              }
+            }
+          }]
+        }
+      }
+    }],
+
+    "sideBar": []
+  },{
+    "borderless": true,
+    "title": "List Two",
+    "id": "list-two",
+    "pageContent": [{
+      "path": "@organisms/by-author/form-downloads.twig",
+      "data": {
+        "formDownloads": {
+          "listing": true,
+          "compHeading": null,
+          "downloadLinks": [{
+            "downloadLink": {
+              "iconSize": "",
+              "icon": "@atoms/05-icons/svg-doc-pdf.twig",
+              "decorativeLink": {
+                "text": "PDF download item",
+                "href": "#",
+                "info": "",
+                "property": ""
+              },
+              "size": "30kb",
+              "format": "PDF",
+              "description": {
+                "rteElements": [{
+                  "path": "@atoms/11-text/paragraph.twig",
+                  "data": {
+                    "paragraph" : {
+                      "text": "I am a description. I am limited to 155 characters. I am a description. I am limited to 155 characters. I am a description. I am limited to 155 characters."
+                    }
+                  }
+                }]
+              }
+            }
+          },{
+            "downloadLink": {
+              "iconSize": "",
+              "icon": "@atoms/05-icons/svg-doc-docx.twig",
+              "decorativeLink": {
+                "text": "Word download item",
+                "href": "#",
+                "info": "",
+                "property": ""
+              },
+              "size": "40kb",
+              "format": "DOCX"
+            }
+          },{
+            "downloadLink": {
+              "iconSize": "",
+              "icon": "@atoms/05-icons/svg-doc-generic.twig",
+              "decorativeLink": {
+                "text": "Generic type of download",
+                "href": "#",
+                "info": "",
+                "property": ""
+              },
+              "size": "40kb",
+              "format": "???"
+            }
+          },{
+            "downloadLink": {
+              "iconSize": "",
+              "icon": "@atoms/05-icons/svg-laptop.twig",
+              "decorativeLink": {
+                "text": "Link to an online form",
+                "href": "#",
+                "info": "",
+                "property": ""
+              },
+              "size": "",
+              "format": "form"
+            }
+          },{
+            "downloadLink": {
+              "iconSize": "",
+              "icon": "",
+              "decorativeLink": {
+                "text": "Link to another page",
+                "href": "#",
+                "info": "",
+                "property": ""
+              },
+              "size": "",
+              "format": "form",
+              "description": {
+                "rteElements": [{
+                  "path": "@atoms/11-text/paragraph.twig",
+                  "data": {
+                    "paragraph" : {
+                      "text": "I am a description. I am limited to 155 characters. I am a description. I am limited to 155 characters. I am a description. I am limited to 155 characters."
+                    }
+                  }
+                }]
+              }
+            }
+          }]
+        }
+      }
+    }],
+
+    "sideBar": []
+  },{
+    "borderless": true,
+    "title": "List Three",
+    "id": "list-three",
+    "pageContent": [{
+      "path": "@organisms/by-author/form-downloads.twig",
+      "data": {
+        "formDownloads": {
+          "listing": true,
+          "compHeading": null,
+          "downloadLinks": [{
+            "downloadLink": {
+              "iconSize": "",
+              "icon": "@atoms/05-icons/svg-doc-pdf.twig",
+              "decorativeLink": {
+                "text": "PDF download item",
+                "href": "#",
+                "info": "",
+                "property": ""
+              },
+              "size": "30kb",
+              "format": "PDF",
+              "description": {
+                "rteElements": [{
+                  "path": "@atoms/11-text/paragraph.twig",
+                  "data": {
+                    "paragraph" : {
+                      "text": "I am a description. I am limited to 155 characters. I am a description. I am limited to 155 characters. I am a description. I am limited to 155 characters."
+                    }
+                  }
+                }]
+              }
+            }
+          },{
+            "downloadLink": {
+              "iconSize": "",
+              "icon": "@atoms/05-icons/svg-doc-docx.twig",
+              "decorativeLink": {
+                "text": "Word download item",
+                "href": "#",
+                "info": "",
+                "property": ""
+              },
+              "size": "40kb",
+              "format": "DOCX"
+            }
+          },{
+            "downloadLink": {
+              "iconSize": "",
+              "icon": "@atoms/05-icons/svg-doc-generic.twig",
+              "decorativeLink": {
+                "text": "Generic type of download",
+                "href": "#",
+                "info": "",
+                "property": ""
+              },
+              "size": "40kb",
+              "format": "???"
+            }
+          },{
+            "downloadLink": {
+              "iconSize": "",
+              "icon": "@atoms/05-icons/svg-laptop.twig",
+              "decorativeLink": {
+                "text": "Link to an online form",
+                "href": "#",
+                "info": "",
+                "property": ""
+              },
+              "size": "",
+              "format": "form"
+            }
+          },{
+            "downloadLink": {
+              "iconSize": "",
+              "icon": "",
+              "decorativeLink": {
+                "text": "Link to another page",
+                "href": "#",
+                "info": "",
+                "property": ""
+              },
+              "size": "",
+              "format": "form",
+              "description": {
+                "rteElements": [{
+                  "path": "@atoms/11-text/paragraph.twig",
+                  "data": {
+                    "paragraph" : {
+                      "text": "I am a description. I am limited to 155 characters. I am a description. I am limited to 155 characters. I am a description. I am limited to 155 characters."
+                    }
+                  }
+                }]
+              }
+            }
+          }]
+        }
+      }
+    }],
+
+    "sideBar": []
+  }]
+}

--- a/styleguide/source/_patterns/05-pages/listing-links.md
+++ b/styleguide/source/_patterns/05-pages/listing-links.md
@@ -1,0 +1,49 @@
+### Description
+Example of a Mass Gov Link Listing page using the stacked row template
+
+### Status
+* Stable as of 5.0.0
+
+### Pattern Contains
+* Header
+* Footer
+* Page Header
+* Stacked Row (template)
+* Form Downloads (listing variant)
+
+### Usage Guidelines
+* When using the Jump Links option, each Section should have a matching ID value in the compHeading.
+* The Stacked Row Sections are used to populate the Page Content and Right Rail areas shown.
+* The Stacked Row Sections each set their `borderless` variable to `true` to remove the top border between adjacent stacked rows.
+
+### JavaScript Used
+* Jump Links (js/modules/scrollAnchors.js)
+
+### Usage Guidelines
+* The ID value is used as an anchor tag when the Jump Links pattern is added as a table of contents (see guide pages)
+
+### Variables
+~~~
+stackedRows: [{
+  borderless:
+    type: boolean / optional (defaults to false),
+  title:
+    type: string / optional,
+  id: 
+    type: string (unique per page) / optional
+  pageContent: [{
+    path: 
+      type: string / required,
+    data: {
+      type: object / required
+    }
+  }],
+  sideBar: (optional) [{
+    path: 
+      type: string / required,
+    data: {
+      type: object / required
+    }
+  }]
+}]
+~~~

--- a/styleguide/source/_patterns/05-pages/listing-links.twig
+++ b/styleguide/source/_patterns/05-pages/listing-links.twig
@@ -1,0 +1,8 @@
+{% extends '@templates/stacked-row-template.twig' %}
+
+{% block preContent %}
+  {% include "@organisms/by-template/content-eyebrow.twig" %}
+  {% include "@organisms/by-template/page-header.twig" %}
+{% endblock %}
+
+{% block postContent %}{% endblock %}

--- a/styleguide/source/assets/scss/02-molecules/_download-link.scss
+++ b/styleguide/source/assets/scss/02-molecules/_download-link.scss
@@ -1,5 +1,5 @@
 .ma__download-link {
-  @include clearfix;
+  @include clearfix();
 
   & + & {
     padding-top: 25px;
@@ -26,7 +26,7 @@
     height: 25px;
     margin-top: 4px;
     width: 40px;
-    
+
     & > svg {
       height: 25px;
       width: 25px;
@@ -34,7 +34,7 @@
   }
 
   &__title {
-    float: left;
+    display: inline-block;
     font-size: 1.375rem;
     margin-bottom: 0;
     width: calc(100% - 66px);
@@ -50,5 +50,15 @@
     font-size: 1rem;
     line-height: 2.14;
     white-space: nowrap;
+  }
+
+  &__description {
+    font-size: 1.25rem;
+    margin-top: 10px;
+  }
+
+  .ma__form-downloads--listing & {
+    border-bottom: 1px solid;
+    padding-bottom: 25px;
   }
 }

--- a/styleguide/source/assets/scss/03-organisms/_form-downloads.scss
+++ b/styleguide/source/assets/scss/03-organisms/_form-downloads.scss
@@ -3,7 +3,7 @@
   .pre-content > &,
   .post-content > &,
   .main-content--full .page-content > & {
-    @include ma-container;
+    @include ma-container('restricted');
   }
 
   &__see-all {

--- a/styleguide/source/assets/scss/04-templates/_stacked-row.scss
+++ b/styleguide/source/assets/scss/04-templates/_stacked-row.scss
@@ -6,7 +6,7 @@
     @media ($bp-large-max) {
       padding-bottom: 45px;
 
-      & ~ & {
+      & ~ &:not(&__section--borderless) {
         border-top-width: 1px;
         border-top-style: solid;
       }
@@ -26,7 +26,7 @@
     @include ma-container('restricted');
   }
 
-  &__section ~ &__section &__container:before {
+  &__section ~ &__section:not(&__section--borderless) &__container:before {
     content: "";
     display: block;
     padding-top: 45px;

--- a/styleguide/source/assets/scss/06-theme/02-molecules/_download-link.scss
+++ b/styleguide/source/assets/scss/06-theme/02-molecules/_download-link.scss
@@ -13,4 +13,8 @@
   &__file-spec {
     font-weight: 500;
   }
+
+  .ma__form-downloads--listing & {
+    border-color: $c-bd-divider;
+  }
 }


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
This PR creates pattern variants and new patterns to support a link listing page:
- variant of the download link molecule with a short description
- variant of the form downloads organism which uses the variant of the download link with short description + adds some vertical spacing and borders to the list items
- page pattern for the link listing (i.e. mass.gov curated list page)


## Related Issue / Ticket

- [JIRA issue](https://jira.state.ma.us/browse/DP-5768)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. [x] To test the download links "with descriptoin" variant exists and matches the design
    - Browse to: https://jesconstantine.github.io/mayflower/?p=molecules-download-link-with-description&view=c
    - [x] Read the pattern info to confirm it is clear how to implement this pattern variant
1. [x] To test the form downloads "listing" variant exists and matches the design
    - Browse to: https://jesconstantine.github.io/mayflower/?p=organisms-form-downloads-as-listing&view=c
        - [x] Read the pattern info to confirm it is clear how to implement this pattern variant
    - Compare the styling with the listing sections in the invision: https://invis.io/KZCHVVD42#/253708329_Library-Listing-Page
1. [x] To test the "List of links" page exists, illustrates curated list content, and matches the design
    - Browse to: https://jesconstantine.github.io/mayflower/?p=pages-listing-links
        - [x] Read the pattern info to confirm it is clear how to implement this pattern variant
    - Compare the styles with the invision: https://invis.io/KZCHVVD42#/253708329_Library-Listing-Page
1. [x] To test that the original version of form downloads organism is still being used elsewhere on the site
    - Browse to: https://jesconstantine.github.io/mayflower/?p=pages-detail-for-service-howto-location
        - Confirm the "Additional Resources" still render the version of the form downloads without descriptions and borders
    - Browse to: https://jesconstantine.github.io/mayflower/?p=pages-policy-advisory-directive
        - Confirm the "Downloads" still render the version of the form downloads without descriptions and borders
    - Browse to: https://jesconstantine.github.io/mayflower/?p=pages-service
        - Confirm the "Additional Resources" still render the version of the form downloads without descriptions and borders


## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
