### PR TITLE
Add new gulp-copy dependency to fix npm-install + gulp build

### DIFF
--- a/styleguide/npm-shrinkwrap.json
+++ b/styleguide/npm-shrinkwrap.json
@@ -3593,6 +3593,12 @@
         }
       }
     },
+    "gulp-copy": {
+      "version": "1.0.1",
+      "from": "gulp-copy@latest",
+      "resolved": "https://registry.npmjs.org/gulp-copy/-/gulp-copy-1.0.1.tgz",
+      "dev": true
+    },
     "gulp-debug": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/gulp-debug/-/gulp-debug-2.1.2.tgz",


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
This PR fixes the build issue where gulp-copy is not installed after `npm-install` despite its being required in a new gulp task.

## Related Issue / Ticket

n/a

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Pull this branch down + check it out
1. `cd` into the `styleguide` directory
1. Run `npm install`
1. Run `gulp`
1. Verify that you are able to build Mayflower locally


## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.
Error that was appearing after running `npm install` after  running the command `gulp` would time out after ~19 seconds
![error from mayflower](https://user-images.githubusercontent.com/19477691/33738386-22e9b788-db67-11e7-9ffe-52db9957325f.png)

## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* Build system

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->

If your mayflower work includes installing a new node package, you have to run `npm shrinkwrap --dev` to add your new dependency to the `npm-shrinkwrap.json` file and you have to commit that file (so committing the package.json is not enough).  See: https://docs.npmjs.com/cli/shrinkwrap
