### PR TITLE
clear utility menus when mobile nav is toggled

### DIFF
--- a/styleguide/source/assets/js/modules/utilNav.js
+++ b/styleguide/source/assets/js/modules/utilNav.js
@@ -21,8 +21,8 @@ export default function (window,document,$,undefined) {
 
       // hide other content
       hide($openContent);
-      
-      if(open) { 
+
+      if(open) {
         return;
       }
       // add open class to this item
@@ -44,7 +44,7 @@ export default function (window,document,$,undefined) {
       hide( $(this).closest('.js-util-nav-content') );
     });
 
-    $('.js-close-sub-nav').on('click', function(){
+    $('.js-header-menu-button, .js-close-sub-nav').on('click', function(){
       let $openContent = $parent.find('.js-util-nav-content.' + openClass);
       hide($openContent);
     });


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
Clear utility menus (blue overlay) when mobile nav menu is toggled, so no overlay is present when mobile nav is re-opened.

## Related Issue / Ticket

- [JIRA issue](https://jira.state.ma.us/browse/DP-5951)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Resize browser to mobile
2. Open main navigation
3. Open 'State Organizations'
4. Close main navigation
5. Open main navigation
6. Ensure state organization menu isn't present & main menu is visible 

## Screenshots
![utility-clear](https://user-images.githubusercontent.com/1397914/33726582-6a95fd54-db43-11e7-9898-846f754273e3.gif)


## Additional Notes:


#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* utilNav.js

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
