### PR TITLE
Remove centering override for single event item

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_event-listing.scss
+++ b/styleguide/source/assets/scss/03-organisms/_event-listing.scss
@@ -25,7 +25,7 @@ $event-listing-bp-show-grid: $bp-medium-min;
   }
 
   &--grid &__container {
-    
+
     @media ($event-listing-bp-show-grid) {
       overflow: hidden;
     }
@@ -36,7 +36,7 @@ $event-listing-bp-show-grid: $bp-medium-min;
   }
 
   &--grid &__items {
-    
+
     @media ($event-listing-bp-show-grid) {
       display: flex;
         flex-wrap: wrap;
@@ -66,7 +66,7 @@ $event-listing-bp-show-grid: $bp-medium-min;
       &:first-child,
       &:nth-child(2) {
         margin-top: 0;
-        
+
         &:before {
           display: none;
         }
@@ -74,16 +74,11 @@ $event-listing-bp-show-grid: $bp-medium-min;
 
       &:last-child,
       &:nth-last-child(2):nth-child(odd) {
-        
+
         &:after {
           display: none;
         }
       }
-    }
-
-    &:only-of-type {
-      margin: 0 auto;
-      max-width: 780px;
     }
 
     &:not(:only-of-type) {


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
Remove centering override for single event items

## Related Issue / Ticket

- [JIRA issue](https://jira.state.ma.us/browse/DP-6085)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Look at events listing grid http://localhost:3000/?p=organisms-event-listing-as-grid
2. In the browser dev tools, remove all but one `li.ma__event-listing__item` 
3. Confirm that a single event is left aligned. 

## Screenshots
![screen shot 2017-12-07 at 3 34 33 pm](https://user-images.githubusercontent.com/1397914/33737461-2bbaaf46-db64-11e7-836f-2b707751339b.png)



## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* `@organism/event-listing`

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
