### PR TITLE
Fix border color on stacked row pages (i.e. Guide)

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_stacked-row-section.scss
+++ b/styleguide/source/assets/scss/03-organisms/_stacked-row-section.scss
@@ -7,6 +7,10 @@
       border-top-width: 1px;
       border-top-style: solid;
     }
+
+    & ~ &--borderless {
+      border-top-width: 0;
+    }
   }
 
   @media print {
@@ -32,6 +36,12 @@
       border-top-width: 1px;
       border-top-style: solid;
       padding-top: 90px;
+    }
+  }
+
+  & ~ &--borderless &__container:before {
+    @media print, ($bp-large-min) {
+      border-top-width: 0;
     }
   }
 

--- a/styleguide/source/assets/scss/04-templates/_stacked-row.scss
+++ b/styleguide/source/assets/scss/04-templates/_stacked-row.scss
@@ -6,9 +6,13 @@
     @media ($bp-large-max) {
       padding-bottom: 45px;
 
-      & ~ &:not(&__section--borderless) {
+      & ~ & {
         border-top-width: 1px;
         border-top-style: solid;
+      }
+
+      & ~ &--borderless {
+        border-top-width: 0;
       }
     }
 
@@ -26,7 +30,7 @@
     @include ma-container('restricted');
   }
 
-  &__section ~ &__section:not(&__section--borderless) &__container:before {
+  &__section ~ &__section &__container:before {
     content: "";
     display: block;
     padding-top: 45px;
@@ -35,6 +39,12 @@
       border-top-width: 1px;
       border-top-style: solid;
       padding-top: 90px;
+    }
+  }
+
+  &__section ~ &__section--borderless &__container:before {
+    @media print, ($bp-large-min) {
+      border-top-width: 0;
     }
   }
 

--- a/styleguide/source/assets/scss/06-theme/04-templates/_stacked-row.scss
+++ b/styleguide/source/assets/scss/06-theme/04-templates/_stacked-row.scss
@@ -2,9 +2,9 @@
 
   &__section ~ &__section {
     border-color: $c-bd-divider;
-    
-    &__container:before {
-      border-color: $c-bd-divider;
-    }
+  }
+
+  &__section ~ &__section &__container:before {
+    border-color: $c-bd-divider;
   }
 }


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
This PR patches the stacked row/section styles to make the section divider borders gray again (they were inadvertently made black in #653 ).

## Related Issue / Ticket

n/a

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Pull this branch down and build
1. Browse to pages > guide
1. Verify that the divider borders in between the stacked row sections are gray, not black (see before/after screenshots for context)
1. Browse to pages > listing links
1. Verify that there are still not borders in between the stacked row sections (i.e. the lists)

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

### Divider border colors

#### BEFORE (black divider borders)
<img width="1440" alt="screen shot 2017-12-20 at 7 03 39 am" src="https://user-images.githubusercontent.com/3279883/34206540-e73162c0-e554-11e7-9533-c49964a8d293.png">

#### AFTER (gray divider borders)
<img width="1440" alt="screen shot 2017-12-20 at 6 47 55 am" src="https://user-images.githubusercontent.com/3279883/34206551-eea8386c-e554-11e7-8ee2-24476db8e588.png">

### Link listing page - no borders (confirms no visual regression)

#### BEFORE (no borders)
<img width="1440" alt="screen shot 2017-12-20 at 6 48 48 am" src="https://user-images.githubusercontent.com/3279883/34206569-04d9dcd0-e555-11e7-8ca0-7844a72a8636.png">

#### AFTER (no borders)
<img width="1440" alt="screen shot 2017-12-20 at 7 00 57 am" src="https://user-images.githubusercontent.com/3279883/34206570-0695177e-e555-11e7-9868-b6a35a27e330.png">


## Additional Notes:

Anything else to add?

- Verify that this is a non-breaking css change

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* Stacked row section organism, template, and pages (homepage, guide, listing links)


#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
