### PR TITLE
DP-7252 hotfix ajax pattern cache

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -11,6 +11,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 **For example**
 - DP-1234: The short description text on a [service detail](http://mayflower.digital.mass.gov/?p=pages-detail-for-service-howto-location) page banner ([@organisms/by-template/page-banner](http://mayflower.digital.mass.gov/?p=organisms-page-banner)) should now render ([PR #493](https://github.com/massgov/mayflower/pull/493))
 
+## 5.10.1 (1/3/2018)
+
+### Changed
+- We've made the ajax pattern respect cache (i.e. the get request no longer appends a cache busting querystring "_=<timestamp> parameter).
+
 ## 5.10.0 (12/13/2017)
 
 ### Added

--- a/styleguide/source/_patterns/05-pages/readme2.json
+++ b/styleguide/source/_patterns/05-pages/readme2.json
@@ -5,7 +5,7 @@
   },
 
   "errorPage": {
-    "type": "v5.10.0 (12/13/2017)",
+    "type": "v5.10.1 (1/3/2018)",
     "title": "Welcome to Mayflower, the Commonwealth's Design System",
     "message": "Use the navigation menu above to browse our patterns."
   },

--- a/styleguide/source/assets/js/helpers/jQueryExtend_ajaxPattern.js
+++ b/styleguide/source/assets/js/helpers/jQueryExtend_ajaxPattern.js
@@ -110,7 +110,7 @@ export default function (window,document,$,undefined) {
       $.ajax({
         type: 'GET',
         url: endpoint,
-        cache: false,
+        cache: true,
         dataType: 'json'
       }).done(function(data){
         // @todo validate data against schema


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
This PR makes the ajax pattern get request honor cache by removing the query string param `_=<timestamp>` which was being appended.

The problem we are solving is that in mass.gov production, ajax pattern get requests to the alert jsonapi endpoint had `_=<timestamp>` cache busting querystring param appended, causing our mass.gov cache stack to be bypassed, causing production issues with acquia.

## Related Issue / Ticket

- [JIRA issue](https://jira.state.ma.us/browse/DP-7252)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Tested in mayflower local by building this branch and verify the querystring param was removed
1. Tested mass.local by pulling in alpha tag  10.0.1-alpha-7252 and verifying the querystring param was removed

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

### Fixed state

## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* Any page which implements ajax pattern

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->

  
  