### PR TITLE
DP-6175: Add overview paragraph section to Curated List page.

### DIFF
--- a/styleguide/source/_patterns/05-pages/listing-links.json
+++ b/styleguide/source/_patterns/05-pages/listing-links.json
@@ -3,7 +3,7 @@
     "category": "",
     "divider": false,
     "title": "Link listing page",
-    "subTitle": "",
+    "subTitle": "Subheading",
     "headerTags": {
       "label": "Related to:",
       "taxonomyTerms": [{


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description

There was actually nothing wrong with the overview in mayflower, as it is already displaying.

On the [Listing Links page](https://mayflower.digital.mass.gov/?p=pages-listing-links), the subtitle text is not displaying because it was missing in the example json file. This has been fixed by adding in some text to the subtitle key.

## Related Issue / Ticket

- [JIRA issue](https://jira.state.ma.us/browse/DP-6175)
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Browse to the Listing Links page and confirm the subheading text now appears above the overview text. https://mayflower.digital.mass.gov/?p=pages-listing-links

## Screenshots
Now displaying subtitle text "Subheading":
<img width="751" alt="screen shot 2018-01-04 at 11 01 31 am" src="https://user-images.githubusercontent.com/5257660/34572162-a96c0c1a-f13e-11e7-8d35-2829341f38e5.png">

## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->

  