### PR TITLE
DP-7478 -- MF change page based alert to span multiple rows as needed

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-template/header-alert.json
+++ b/styleguide/source/_patterns/03-organisms/by-template/header-alert.json
@@ -2,7 +2,7 @@
   "headerAlert": {
     "id": "GUID09058070135",
     "prefix": "",
-    "text": "Lots of Bears.",
+    "text": "Vivamus suscipit tortor eget felis porttitor volutpat. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus suscipit tortor eget felis porttitor volutpat.",
     "href": "#",
     "info": ""
   }

--- a/styleguide/source/assets/scss/03-organisms/_header-alert.scss
+++ b/styleguide/source/assets/scss/03-organisms/_header-alert.scss
@@ -26,9 +26,7 @@
     display: inline-block;
     overflow: hidden;
     max-width: 100%;
-    text-overflow: ellipsis;
     vertical-align: baseline;
-    white-space: nowrap;
   }
 
   &__label {


### PR DESCRIPTION
## Description
Update the scss to allow for the alerts to wrap inside their container

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Go to /?p=organisms-header-alert
2. You should see that that alert now accepts longer content that wraps inside the component.



## Screenshots
<img width="1186" alt="updated_alert" src="https://user-images.githubusercontent.com/18662734/35228190-19f1ce70-ff5e-11e7-87c4-d5c89ad3cd76.png">

## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* organisms -- header-alert
 
#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
