### PR TITLE
DP-6712 Fix the Video Dimensions on the Service Detail Page

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_iframe.scss
+++ b/styleguide/source/assets/scss/01-atoms/_iframe.scss
@@ -1,13 +1,13 @@
 .ma__iframe {
   @include clearfix;
-  
+
   &__container {
     font-size: 0;
     padding: 13px;
   }
 
   @media ($bp-small-min) {
-  
+
     &--right &__container {
       float: right;
       margin-left: 1em;
@@ -17,9 +17,9 @@
   }
 
   .main-content--full .page-content > & {
-    @include ma-container();
+    @include ma-container('restricted');
   }
-  
+
   &__link {
     margin-top: 12px;
   }

--- a/styleguide/source/assets/scss/01-atoms/_iframe.scss
+++ b/styleguide/source/assets/scss/01-atoms/_iframe.scss
@@ -17,7 +17,7 @@
   }
 
   .main-content--full .page-content > & {
-    @include ma-container();
+    @include ma-container('restricted');
   }
 
   &__link {

--- a/styleguide/source/assets/scss/01-atoms/_iframe.scss
+++ b/styleguide/source/assets/scss/01-atoms/_iframe.scss
@@ -17,7 +17,7 @@
   }
 
   .main-content--full .page-content > & {
-    @include ma-container('restricted');
+    @include ma-container();
   }
 
   &__link {

--- a/styleguide/source/assets/scss/01-atoms/_video.scss
+++ b/styleguide/source/assets/scss/01-atoms/_video.scss
@@ -17,7 +17,7 @@
 
   // Backward Compatible - had to add the --new as a variant for the new styling
   .main-content--full .page-content > & {
-    @include ma-container;
+    @include ma-container('restricted');
   }
 
   &__link {


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
The container for video, `.ma__video`, and iframe, `.ma__iframe`, didn't have the styles which other content container in the main column have:
```
    margin-left: auto;
    margin-right: auto;
    padding-right: 500px;
```
This was causing to iframe and video to stretch to fill its parent container when the side column content is not available.

Those missing styles are added to `.ma__video` and `.ma__iframe` to maintain the same width as other content in the main column.

## Related Issue / Ticket

- [DP-6712 Fix the Video Dimensions on the Service Detail Page](https://jira.state.ma.us/browse/DP-6712)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

Note:  Even the change is made in Mayflower, you don't see it in the sample pages set up in Mayflower.  You need to test it in Drupal.
1. Build the site with the tag, `5.10.1-alpha-67124`.
2. Create a service detail page with video, iframe and some sections.  Do not add any side content.  You can use 'mass.local/service-details/massachusetts-traffic-map/' as a sample and add video.
3. Go to the generated page and see the video and iframe have the same width as other section content.  In another words, they are lined up on the right side along with other section content, no sticking out.  See below screenshot, After.
4. When you inspect `.ma__iframe`, you'll find the following styles:
```
.main-content--full .page-content > .ma__iframe {
    margin-left: auto;
    margin-right: auto;
    padding-right: 500px;
}
```
<img width="692" alt="dp-7490_iframe-css" src="https://user-images.githubusercontent.com/9633303/35301211-eb4ab18a-0058-11e8-9148-65bea5f6677b.png">

5. When you inspect `.ma__video`, you'll find the following styles:
```
.main-content--full .page-content > .ma__video {
    margin-left: auto;
    margin-right: auto;
    padding-right: 500px;
}
```
<img width="669" alt="dp-7490_video-css" src="https://user-images.githubusercontent.com/9633303/35301246-08e2defc-0059-11e8-96f5-3ec86c30be0c.png">


**Note:**
Videos are adjusted to fit in the given space for their widths and heights, but iframe are not. When the linked content (the page in the iframe) is bigger than the .ma__iframe (= iframe size), users need to use iframe's scroll bars to see overflow content. This is the same condition seen in mobile in the current production.


## Screenshots
Before
<img width="647" alt="dp-7490_before" src="https://user-images.githubusercontent.com/9633303/35301266-144ee1a0-0059-11e8-8ea8-c2ddbb06f552.png">

After
<img width="615" alt="massachusetts_traffic_map___mass_gov" src="https://user-images.githubusercontent.com/9633303/35301278-1d0c8ba8-0059-11e8-9a54-d2ee305e8e40.png">


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
