### PR TITLE
DP-3198 a11y Keyboard focus indicator usability for main menus

### DIFF
--- a/styleguide/source/_patterns/02-molecules/main-nav.twig
+++ b/styleguide/source/_patterns/02-molecules/main-nav.twig
@@ -5,7 +5,7 @@
       {% set menuId =  'menu' ~ loop.index %}
       <li class="ma__main-nav__item {{ nav.active ? 'is-active' : '' }} {{ nav.subNav ? 'has-subnav js-main-nav-toggle' : 'js-main-nav-top-link' }}">
         {% if nav.subNav %}
-          <button id="{{ buttonId }}" class="ma__main-nav__top-link" aria-haspopup="true" aria-expanded="false" aria-controls="{{ menuId }}" tabindex="{{ loop.first? 0 : -1 }}">{{ nav.text }}</button>
+          <button id="{{ buttonId }}" class="ma__main-nav__top-link" aria-haspopup="true" aria-expanded="false" tabindex="{{ loop.first? 0 : -1 }}">{{ nav.text }}</button>
           <div class="ma__main-nav__subitems js-main-nav-content is-closed">
             <ul id="{{ menuId }}" role="menu" aria-labelledby="{{ buttonId }}" class="ma__main-nav__container">
               <li role="menuitem" class="ma__main-nav__subitem"><a href="{{ nav.href }}" class="ma__main-nav__link" tabindex="-1">{{ nav.text }}</a></li>


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Removed the poor supported `aria-controles` from the main navigation tabs to remove the non-functional keyboard instruction in JAWS with Firefox.

## Related Issue / Ticket

- [DP-3198 a11y Keyboard focus indicator usability for main menus](https://jira.state.ma.us/browse/DP-3198?jql=labels%20%3D%20PSFrontend)

No Drupal change is involved.

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->
**Test in Mayflower**
1.  In Mayflower, go to any page with the main navigation.
2.  Look into the source code for the main navigation.
3. Find `button.ma__main-nav__top-link` has no `aria-controls` attribute. (See the screenshots **Before** and **After** below.)
4. Find the value of `id` for `button.ma__main-nav__top-link` matches the value of `aria-labelledby` for its corresponding `ul.ma__main-nav__container`. (See the screenshot **After** below.)
5. [optional] Browse the navigation with JAWS in Firefox to see if it still announces the keyboard instruction or not. 
6. You may check Steps. 3 - 5 with some more tabs.

**Test in Drupal**
1.  To test in Drupal, use Use the tag, `5.10.1-alpha-3198`.
2. Follow the steps 2-6 above.

## Screenshots
**Before**
![dp-3198_before](https://user-images.githubusercontent.com/9633303/35348239-7e075f58-0105-11e8-94ef-8412975f072c.png)

**After**
![dp-3198_after](https://user-images.githubusercontent.com/9633303/35348245-834c162a-0105-11e8-9575-9b9b715cb00e.png)

## Additional Notes:

n/a

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* Main Navigation

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

n/a

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
