### PR TITLE
DP-7359 Rich text tables rendering differently in Chrome vs IE

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_rich-text.scss
+++ b/styleguide/source/assets/scss/03-organisms/_rich-text.scss
@@ -192,7 +192,7 @@ $heading-indent: $gutter;
     overflow-wrap: break-word;
     transition: border .3s;
     word-wrap: break-word;
-    word-break: break-word;
+    word-break: normal;
   }
 
   // end link styles


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Change the `word-break` value for links in rich text, `.ma__rich-text a`,  to be consistent to all browsers instead of Chrome specific.  The original value `word-break: break-word;` only applies to WebKit/Blink. 

All browsers wrap a word in links from rich text instead of breaking down to characters in Chrome.  The change only applies to WebKit/Blink based browsers. No changes to other browsers since their style is set to what's expected.

## Related Issue / Ticket

- [DP-7359 Rich text tables rendering differently in Chrome vs IE](https://jira.state.ma.us/browse/DP-7359)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

Note:  You can test in Mayflower by editing one of rich text output in sample pages.  I don't find any link samples in rich text section in Mayflower.  Or, use the tag, `5.10.1-alpha-7359`, to test in Drupal. If you test in Drupal, you can use the exiting page which already has a link in a table cell in rich text field, /service-details/dor-legal-library.

Test items:
- a link in rich text section, `.ma__rich-text a`
- a link in a table cell in rich text section, `.ma__rich-text table th a` and `.ma__rich-text table td a`    

1. Check the style change.  In **Inspect** or **Firebug**, find `word-break: normal;` for the test item, `.ma__rich-text a` and  `.ma__rich-text table th a` or `.ma__rich-text table td a` in any browsers as shown in the screenshot **After** below.

2. Check visual.  To check visual, the link needs to be displayed in the smaller parent container than the longest word in the link. It is easier/quicker to test with the sample page mentioned above in Drupal.  You could also set up your sample to meet the condition.  In Chrome, find the test item is display a whole word without breaking down.
Note: Make sure you test in Chrome, which shows breaking down words in the current production environment as shown in the screenshot **Before** below.  Other browsers in the current production environment show the test item like the screenshot **After**.

## Screenshots
**Before**
<img width="809" alt="dp-7359_before" src="https://user-images.githubusercontent.com/9633303/35404615-9902d054-01d1-11e8-91ac-b5b25eaf83e6.png">

**After**
<img width="823" alt="dp-7359_after" src="https://user-images.githubusercontent.com/9633303/35404629-a2d59f62-01d1-11e8-94df-941e8ea45dbe.png">


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
