### PR TITLE
DP-6352 [a11y] change tell us what you think button on all pages to be last item to get keyboard focus

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-template/footer.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/footer.twig
@@ -1,6 +1,3 @@
-{% if floatingAction %}
-  {% include "@molecules/floating-action.twig" %}
-{% endif %}
 <footer class="ma__footer js-footer" id="footer">
   <div class="ma__footer__container">
     <div class="ma__footer__nav">
@@ -28,6 +25,9 @@
     </button>
   {% endif %}
 </footer>
+{% if floatingAction %}
+  {% include "@molecules/floating-action.twig" %}
+{% endif %}
 
 {% if googleLanguages %}
   <script>


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Move the location of the "Tell us what you think" button component, which originally located  above the footer, to below the footer.

## Related Issue / Ticket

- [DP-6352 \[a11y\] - change tell us what you think button on all pages to be last item to get keyboard focus](https://jira.state.ma.us/browse/DP-6352)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. In any sample page with the "Tell us what you think" button, tab through the page.
2. Find the button is the last item to get focus.

## Screenshots
n/a

## Additional Notes:
No visual change.
No Drupal side change involved.

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
