### PR TITLE
DP-3222-3914 [a11y] heading levels adjustment for imagePromo items

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-author/image-promos.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/image-promos.twig
@@ -12,6 +12,7 @@
     {% set promoHeading = (sidebarHeading.level ? : promoHeading) + 1 %}
   {% endif %}
 
+  {% set promoHeading = compHeading.level ? (compHeading.level + 1) : promoHeading %}
   <div>
     {% for imagePromo in imagePromos.items %}
       {% set imagePromo = imagePromo|merge({"level": promoHeading}) %}


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
In the template `@organizms/image-promos.twig`, the heading number for each image promo item is supposed to have a value of the [heading number for `imagePromos.compHeading` + 1], but in the original template, it was assigned to the template's default value `promoHeading = 2` instead.

This was causing put a semantically incorrect heading number to imagePromo items in Location page. Also, to optimize [DP-3222-3914 [a11y] heading levels adjustment #1387](https://github.com/massgov/mass/pull/1387), a heading number value should passed on from its parent heading by increasing its value by 1 from its parent value and avoid using default value, which is static value.

A variable for the image promo item heading number is set up.  It checks for a value of `compHeading.level`, which is the heading number value for its parent heading, and if the value exist, use the value increasing by 1, if not, use the default value set by `promoHeading`.

## Related Issue / Ticket

- [DP-3914 \[a11y\] The headings are not semantically correct](https://jira.state.ma.us/browse/DP-3914) 
- [DP-3222 A11y Heading Levels used incorrectly](https://jira.state.ma.us/browse/DP-3222)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

Testing needs to be done in Drupal with `5.10.1-alpha-3222`, which includes this change.

1. Go to a location page with an "Actions" section which has image promo content.  Sample page: /locations/wells-state-park  

2. Check the heading for "Actions" and image promo item's heading titles for their heading numbers.
- The heading number for Action (`compHeading`) matches to other `compHeading`'s in the main content column such as Overview, Hours, Accessibilities, and etc.  In this case, **3**.
- The heading number for the image promo items is the heading number for `compHeading` + 1, which is **4**, not the template default value of 2.

## Screenshots
<img width="628" alt="dp-3222_image-promo-item" src="https://user-images.githubusercontent.com/9633303/35642138-2a362144-0690-11e8-975e-ffc3fa2903db.png">


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
