### PR TITLE
Dp 7725: [Search] Add Support for Blue Variant of Colored Heading

### DIFF
--- a/styleguide/source/_patterns/01-atoms/04-headings/colored-heading-blue.md
+++ b/styleguide/source/_patterns/01-atoms/04-headings/colored-heading-blue.md
@@ -1,0 +1,5 @@
+### Description
+This is a variant of the [Colored Heading](./?p=atoms-colored-heading) pattern showing an example with a blue background.
+
+### How to generate
+* set the `color` variable to 'blue'

--- a/styleguide/source/_patterns/01-atoms/04-headings/colored-heading.md
+++ b/styleguide/source/_patterns/01-atoms/04-headings/colored-heading.md
@@ -13,7 +13,7 @@ An Heading element with a background color
 * Green color would only be used at the top of the Page Content
 * Gray color would be used in the Right Rail
 * When used in the Right Rail the diagonal will automatically appear on the left
-* Bluw color is only used for filter in the search application
+* Blue color is only used for filter in the search application
 
 
 ### Variables

--- a/styleguide/source/_patterns/01-atoms/04-headings/colored-heading.md
+++ b/styleguide/source/_patterns/01-atoms/04-headings/colored-heading.md
@@ -7,11 +7,13 @@ An Heading element with a background color
 ### Variant options
 * With a [green](./?p=atoms-colored-heading-green) background
 * Usage [example](./?p=atoms-colored-heading-usage-example) showing green heading for Page Content and gray for Right Rail
+* With a [blue](./?p=atoms-colored-heading-blue) background
 
 ### Usage Guidelines
 * Green color would only be used at the top of the Page Content
 * Gray color would be used in the Right Rail
 * When used in the Right Rail the diagonal will automatically appear on the left
+* Green color is only used for filter in the search application
 
 
 ### Variables
@@ -22,7 +24,7 @@ coloredHeading {
   titleContext: 
     type: string / optional
   color:
-    type: string ('','green') / optional
+    type: string ('','green','blue') / optional
   level:
     type: number / optional
 }

--- a/styleguide/source/_patterns/01-atoms/04-headings/colored-heading.md
+++ b/styleguide/source/_patterns/01-atoms/04-headings/colored-heading.md
@@ -13,7 +13,7 @@ An Heading element with a background color
 * Green color would only be used at the top of the Page Content
 * Gray color would be used in the Right Rail
 * When used in the Right Rail the diagonal will automatically appear on the left
-* Green color is only used for filter in the search application
+* Bluw color is only used for filter in the search application
 
 
 ### Variables

--- a/styleguide/source/_patterns/01-atoms/04-headings/colored-heading~blue.json
+++ b/styleguide/source/_patterns/01-atoms/04-headings/colored-heading~blue.json
@@ -1,0 +1,6 @@
+{
+  "coloredHeading": {
+    "text": "Colored Heading",
+    "color": "blue"
+  }
+}

--- a/styleguide/source/assets/scss/06-theme/01-atoms/_colored-heading.scss
+++ b/styleguide/source/assets/scss/06-theme/01-atoms/_colored-heading.scss
@@ -4,4 +4,8 @@
   &--green {
     background-color: $c-theme-green;
   }
+
+    &--blue {
+    background-color: $c-theme-blue;
+  }
 }


### PR DESCRIPTION
The search application requires, based on the news tabs filter designs, a variant of the Colored Heading atoms that permits a blue background.

## Description
Adds blue variant support to the Colored Heading atom in Mayflower. The aim of adding this variant is to support the requirements of the search application for the [news filter]
## Related Issue / Ticket

- [DP-7725](https://jira.state.ma.us/browse/DP-7725)

## Steps to Test
1. Compile Mayflower branch and view in browser
2. Check template at Atoms > Headings > Colored Heading Blue
3. Confirm that the heading displays with a blue background. Confirm that the readme links to the Colored Heading atom and provides information on how to create this variant
4. Check template at Atoms > Heading > Colored Heading
5. Confirm that the json variable includes 'blue' as a color option. Confirm that the readme mentions and describe the blue variant variant.
 

## Screenshots
![colored-heading-blue](https://user-images.githubusercontent.com/9359261/35752443-fff9d038-0829-11e8-947a-ba67d777216c.gif)
<img width="261" alt="screen shot 2018-02-02 at 2 56 58 pm" src="https://user-images.githubusercontent.com/9359261/35752448-06829b60-082a-11e8-849c-0c13bd62cf22.png">


## Additional Notes:
 
@jesconstantine can you double check this PR to make sure it is set, my first commit to Mayflower code so want to be sure it looks good and is up to par/standards.

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*
