### PR TITLE
DP-2082 [a11y] Add intuitive infor to the + symbols for accordion buttons

### DIFF
--- a/styleguide/source/_patterns/02-molecules/contact-us.twig
+++ b/styleguide/source/_patterns/02-molecules/contact-us.twig
@@ -21,7 +21,7 @@
       {% set columnHeading = contactUs.subTitle|merge({"level": contactUs.level}) %}
       {% include "@atoms/04-headings/column-heading.twig" %}
 
-      <span aria-label="click to open">+</span>
+      <span class="ma__contact-us--accordion__status js-accordion-status" aria-label="click to show info">+</span>
     {% if outerAccordion %}
       </button>
     {% endif %}

--- a/styleguide/source/_patterns/02-molecules/contact-us.twig
+++ b/styleguide/source/_patterns/02-molecules/contact-us.twig
@@ -20,6 +20,8 @@
     {% endif %}
       {% set columnHeading = contactUs.subTitle|merge({"level": contactUs.level}) %}
       {% include "@atoms/04-headings/column-heading.twig" %}
+
+      <span aria-label="click to open">+</span>
     {% if outerAccordion %}
       </button>
     {% endif %}

--- a/styleguide/source/assets/js/modules/accordions.js
+++ b/styleguide/source/assets/js/modules/accordions.js
@@ -22,6 +22,7 @@ export default function (window,document,$,undefined) {
     let $el = $(this),
         $link = $el.find('.js-accordion-link'),
         $content = $el.find('.js-accordion-content'),
+        $status = $el.find('.js-accordion-status'),
         id = $content.attr('id') || 'accordion' + (index + 1),
         active = checkActive($el),
         open = $el.hasClass('is-open');
@@ -40,8 +41,10 @@ export default function (window,document,$,undefined) {
         open = $el.hasClass('is-open');
         if(open){
           $content.stop(true,true).slideUp();
+          $status.attr('aria-label', 'click to show info');
         } else {
           $content.stop(true,true).slideDown();
+          $status.attr('aria-label', 'click to hide info');
         }
         $link.attr('aria-expanded',!open);
         $el.toggleClass('is-open');

--- a/styleguide/source/assets/scss/02-molecules/_contact-us.scss
+++ b/styleguide/source/assets/scss/02-molecules/_contact-us.scss
@@ -42,24 +42,24 @@
       padding: 20px 30px;
     }
 
-    span {
-      display: block;
-      font-size: 2.5rem;
-      line-height: .65em;
-      overflow: hidden;
-      position: absolute;
-        right: 15px;
-        top: 25px;
-      transform-origin: center center;
-      transition: transform .2s ease;
-    }
-
     .ma__column-heading {
       margin-bottom: 0;
     }
   }
 
-  &--accordion.is-open &__header span {
+  &--accordion__status {
+    display: block;
+    font-size: 2.5rem;
+    line-height: .65em;
+    overflow: hidden;
+    position: absolute;
+      right: 15px;
+      top: 25px;
+    transform-origin: center center;
+    transition: transform .2s ease;
+  }
+
+  &--accordion.is-open &__header &--accordion__status {
     transform: rotate(135deg);
   }
 
@@ -141,7 +141,7 @@
       font-size: 1.375rem;
       padding-right: 10px;
 
-      span {
+      &--accordion__status {
         margin-left: 0;
         transform: translateY(-45%) rotate(45deg);
 

--- a/styleguide/source/assets/scss/02-molecules/_contact-us.scss
+++ b/styleguide/source/assets/scss/02-molecules/_contact-us.scss
@@ -42,9 +42,9 @@
       padding: 20px 30px;
     }
 
-    &:after {
+    span {
+      display: block;
       font-size: 2.5rem;
-      content: "+";
       line-height: .65em;
       overflow: hidden;
       position: absolute;
@@ -59,7 +59,7 @@
     }
   }
 
-  &--accordion.is-open &__header:after {
+  &--accordion.is-open &__header span {
     transform: rotate(135deg);
   }
 
@@ -141,7 +141,7 @@
       font-size: 1.375rem;
       padding-right: 10px;
 
-      &:after {
+      span {
         margin-left: 0;
         transform: translateY(-45%) rotate(45deg);
 

--- a/styleguide/source/assets/scss/06-theme/02-molecules/_contact-us.scss
+++ b/styleguide/source/assets/scss/06-theme/02-molecules/_contact-us.scss
@@ -17,7 +17,7 @@
   }
 
   &--accordion &__header:after,
-  &--accordion &__header span {
+  &--accordion &__header &--accordion__status {
     color: $c-theme-secondary;
   }
 

--- a/styleguide/source/assets/scss/06-theme/02-molecules/_contact-us.scss
+++ b/styleguide/source/assets/scss/06-theme/02-molecules/_contact-us.scss
@@ -16,7 +16,8 @@
     background-color: transparent;
   }
 
-  &--accordion &__header:after {
+  &--accordion &__header:after,
+  &--accordion &__header span {
     color: $c-theme-secondary;
   }
 


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
**Issue:**
Some screen readers read content inserted by CSS (= value of content property) now.  Contact List accordion button has the + symbol added by this method, which is currently announced as "plus" without any intuitive information.

**Solution:**

- Remove the css `content` property.
- Add the + symbol with `span.ma__contact-us--accordion__status`.
- Add `aria-label` to replace the + symbol for screen readers.  Screen readers announce the value of `aria-label` instead of the content in the `span` tag. 
-  The class `js-accordion-status` also added to the `span` to manipulate the `aria-label` value.  When the accordion is close, it's set to "click to show info".  When the accordion in open, it's set to "click to hide info".

## Related Issue / Ticket

- [DP-2082 Plus Links should be relabeled for screenreaders (site wide)]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Open any pages with contact list accordion in a browser.  Ex. http://localhost:3000/?p=pages-location-park-content
2. With Mac, activate VoiceOver (System Preferences/Accessibility/VoiceOver.  Check "Enable VoiceOver".
3. Let VoiceOver read through the accordion button, and find:
       - It doesn't announce the + symbol in the accordion button as "plus".
       - When the accordion is close, the symbol is announced as "click to show info".  When the accordion in open, it's set to "click to hide info".


## Screenshots
Accordion Close
<img width="438" alt="dp-2082_close" src="https://user-images.githubusercontent.com/9633303/35812467-04aedb14-0a5f-11e8-9d7c-34a38eaedf08.png">

Accordion Open
<img width="442" alt="dp-2082_open" src="https://user-images.githubusercontent.com/9633303/35812474-09932bb2-0a5f-11e8-8f0f-bbb3e29eedb8.png">

## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
