### PR TITLE
Release 5.12.0

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -7,7 +7,7 @@ Mayflower release managers with the necessary repo permissions can follow these 
 1. Check out the [massgov/mayflower `dev` branch](https://github.com/massgov/mayflower/commits/dev): `git checkout dev` and pull the latest from upstream `git pull upstream dev`. (This assumes that your massgov/mayflower remote repo is named `upstream`)
 1. Create a release branch `git checkout -b release-#.#.#` where `#.#.#` is the next version (i.e. `5.0.0`).  Read more about [Mayflower and semantic versioning](docs/versioning.md) to ensure that your are creating the right type of version.
 1. Document the new release based on the "Upcoming" queue at the top of [release-notes.md](/release-notes.md), and then commit.
-1. Move into the `stylguide` directory `cd styleguide`
+1. Move into the `stylguide` directory `cd styleguide` (may be a good idea to run `npm install` in case the release includes new packages).
 1. Bump the version on the homepage - `@pages/readme2.json` - by updating the version and date text in `errorPage.type`
 1. Bump the version of the npm package by running `gulp bump -v=#.#.#` where `#.#.#` is the version you are releasing.
 1. Commit your version bump file updates.

--- a/docs/release.md
+++ b/docs/release.md
@@ -17,7 +17,7 @@ Mayflower release managers with the necessary repo permissions can follow these 
 1. Smoke test Mayflower (a quick way to do this is to browse around to some of the different pages in the "pages" menu and do a quick gut check)
 1. Open a Github Pull Request to merge (no squash!) the release branch into the `master` branch.
     1. Add the relevant release notes to the PR notes.
-    1. This is a great time to verify one more time that your release [is following semantic versioning](../docs/versioning.md) properly (i.e. not pushing out breaking changes in a minor release).
+    1. This is a great time to verify one more time that your release [is following semantic versioning](versioning.md) properly (i.e. not pushing out breaking changes in a minor release).
 1. [Create a production release](https://help.github.com/articles/creating-releases/) off the `master` branch in GitHub, remember to add the release notes!
 1. Wait for [the circle builds](https://circleci.com/gh/massgov/mayflower) to pass
 1. Pull down your tag `git pull tags`

--- a/docs/release.md
+++ b/docs/release.md
@@ -4,7 +4,7 @@ Mayflower release managers with the necessary repo permissions can follow these 
 *Note: the following steps assume that your local machine and repository is already set up and functioning according to our [Getting Started docs](../.github/CONTRIBUTING.md#getting-started).*
 
 1. If there is new code to be delivered, notify the team at least two hours ahead of time that a release is coming. Follow the [Communicate Releases](https://wiki.state.ma.us/display/massgovredesign/Communicating+Releases) instructions for Upcoming Deployments.
-1. Check out the [massgov/mayflower `dev` branch](https://github.com/massgov/mayflower/commits/dev): `git checkout dev` and pull the latest from upstream `git pull upstream dev`. (This assumes that your massgov/mass remote repo is named `upstream`)
+1. Check out the [massgov/mayflower `dev` branch](https://github.com/massgov/mayflower/commits/dev): `git checkout dev` and pull the latest from upstream `git pull upstream dev`. (This assumes that your massgov/mayflower remote repo is named `upstream`)
 1. Create a release branch `git checkout -b release-#.#.#` where `#.#.#` is the next version (i.e. `5.0.0`).  Read more about [Mayflower and semantic versioning](docs/versioning.md) to ensure that your are creating the right type of version.
 1. Document the new release based on the "Upcoming" queue at the top of [release-notes.md](/release-notes.md), and then commit.
 1. Move into the `stylguide` directory `cd styleguide`

--- a/docs/release.md
+++ b/docs/release.md
@@ -13,7 +13,7 @@ Mayflower release managers with the necessary repo permissions can follow these 
 1. Commit your version bump file updates.
 1. Push release branch to `massgov/mayflower` (i.e. `git push upstream release-#.#.#`).
 1. Wait for [the circle build](https://circleci.com/gh/massgov/mayflower) to pass, which will deploy your release branch to staging automagically :).
-1. Verify release notes against the site rendered at: `https://mayflower.digital.mass.gov/<your-release-branch>/`.
+1. Verify release notes against the site rendered at: `https://mayflower.digital.mass.gov/<your-release-branch>/index.html`.
 1. Smoke test Mayflower (a quick way to do this is to browse around to some of the different pages in the "pages" menu and do a quick gut check)
 1. Open a Github Pull Request to merge (no squash!) the release branch into the `master` branch.
     1. Add the relevant release notes to the PR notes.
@@ -24,7 +24,7 @@ Mayflower release managers with the necessary repo permissions can follow these 
 1. Make sure you are in `styleguide` (cd `styleguide` if you're not)
 1. Deploy the release (to its three locations: prod `/`, current version `/<your-tag-name>/`, and latest minor `/<current-major-version>/`) and publish the [@massds/mayflower package on NPM](https://www.npmjs.com/package/@massds/mayflower) by running `../scripts/deploy-mayflower.s3 -b <your-tag-name>` and follow the prompts.
     1. Protip: In order to push the Mayflower package to [NPM](https://npmjs.com/@massds/mayflower), you need to be authenticated on NPM, by one of the following:
-        1. Having an `.npmrc` file with credentials for the `@massds` account (or your own NPM account if you're added to the Mayflower package as an owner) in your Mayflower repo root (this file is not and should not be versioned -- ask a team member for credentials)
+        1. Having an `.npmrc` file with credentials for the `@massds` account (or your own NPM account if you're added to the Mayflower package as an owner) in the styleguide directory of your Mayflower repo (this file is not and should not be versioned -- ask a team member for credentials)
             - See [npmjs docs re: .npmrc](https://docs.npmjs.com/files/npmrc#per-project-config-file\n\n2) 
         1. Having an `NPM_TOKEN` environment variable for `@massds`
             - See [npmjs docs re: NPM_TOKEN](http://blog.npmjs.org/post/118393368555/deploying-with-npm-private-modules)

--- a/release-notes.md
+++ b/release-notes.md
@@ -11,7 +11,20 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 **For example**
 - DP-1234: The short description text on a [service detail](http://mayflower.digital.mass.gov/?p=pages-detail-for-service-howto-location) page banner ([@organisms/by-template/page-banner](http://mayflower.digital.mass.gov/?p=organisms-page-banner)) should now render ([PR #493](https://github.com/massgov/mayflower/pull/493))
 
-## 5.10.2 (2/2/2018)
+## 5.12.0 (2/7/2018)
+
+### Changed
+- DP-7718: Adds support for Description text to [@molecules/callout-link](https://mayflower.digital.mass.gov/?p=molecules-callout-link-as-description&view=c) (e.g calls to action on a location page header).
+- D-7725: Adds Support for Blue Variant of [@atoms/colored-heading](https://mayflower.digital.mass.gov/?p=atoms-colored-heading-blue&view=c) (e.g. header in the press filter organism)
+
+## Fixed
+- DP-7359: Make line breaks on word in [richtext](https://mayflower.digital.mass.gov/?p=organisms-rich-text) links compatible with non-chrome browsers.
+- DP-7490: Adjust the [page banner](https://mayflower.digital.mass.gov/?p=organisms-page-banner-as-overlay) and its children for flexble height.
+
+## Added
+- (For Devs): Adds shell scripts and circle config to deploy feature branches and production tags to mayflower.digital.mass.gov [s3 bucket|https://github.com/massgov/mayflower/blob/dev/docs/s3-architecture.md] AND to publish static assets on [NPM|https://www.npmjs.com/package/@massds/mayflower]. See new [release process|https://github.com/massgov/mayflower/blob/dev/docs/release.md]
+
+## 5.11.0 (2/5/2018)
 
 ### Changed
 - DP-7478 - Page based alerts can now span multiple rows as needed.
@@ -19,7 +32,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - DP-7265 - Add new 'Mosaic Grid' organism with 'Featured Item' molecules for use on ['Organization Elected Official' pages](https://mayflower.digital.mass.gov/?p=pages-organization-elected-official).
-
 
 ## 5.10.1 (1/3/2018)
 

--- a/styleguide/package.json
+++ b/styleguide/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@massds/mayflower",
   "description": "Open source UI components and visual style guide for Massachusetts government websites",
-  "version": "5.10.0",
+  "version": "5.12.0",
   "author": "Massachusetts Digital Services (MDS)",
   "repository": {
     "type": "git",

--- a/styleguide/source/_data/data.json
+++ b/styleguide/source/_data/data.json
@@ -1,6 +1,6 @@
 {
   "title" : "Mass Gov",
-  "version": "5.10.1",
+  "version": "5.12.0",
   "htmlClass": "pl",
   "bodyClass": "",
   "directory": "assets",

--- a/styleguide/source/_patterns/05-pages/readme2.json
+++ b/styleguide/source/_patterns/05-pages/readme2.json
@@ -5,7 +5,7 @@
   },
 
   "errorPage": {
-    "type": "v5.11.0 (2/2/2018)",
+    "type": "v5.12.0 (2/8/2018)",
     "title": "Welcome to Mayflower, the Commonwealth's Design System",
     "message": "Use the navigation menu above to browse our pattern library."
   },


### PR DESCRIPTION
## 5.12.0 (2/8/2018)

### Changed
- DP-7718: Adds support for Description text to [@molecules/callout-link](https://mayflower.digital.mass.gov/?p=molecules-callout-link-as-description&view=c) (e.g calls to action on a location page header).
- D-7725: Adds Support for Blue Variant of [@atoms/colored-heading](https://mayflower.digital.mass.gov/?p=atoms-colored-heading-blue&view=c) (e.g. header in the press filter organism)

## Fixed
- DP-7359: Make line breaks on word in [richtext](https://mayflower.digital.mass.gov/?p=organisms-rich-text) links compatible with non-chrome browsers.
- DP-7490: Adjust the [page banner](https://mayflower.digital.mass.gov/?p=organisms-page-banner-as-overlay) and its children for flexble height.

## Added
- (For Devs): Adds shell scripts and circle config to deploy feature branches and production tags to mayflower.digital.mass.gov [s3 bucket|https://github.com/massgov/mayflower/blob/dev/docs/s3-architecture.md] AND to publish static assets on [NPM|https://www.npmjs.com/package/@massds/mayflower]. See new [release process|https://github.com/massgov/mayflower/blob/dev/docs/release.md]