### PR TITLE
Release 5.12.0

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -342,7 +342,7 @@ This will create the branch on your Mayflower fork. The `-u` flag links this bra
 
 #### Deploying your work
 
-Once your work is complete, deploy your branch to your Mayflower fork's Github Pages, so that its functionality can be tested and reviewed by someone who doesn't have Mayflower running locally.  See [our deployment docs](../docs/deploy.md#developer-deployment) for step by step instructions.
+Once your work is complete, deploy your branch to your Mayflower fork's Github Pages, so that its functionality can be tested and reviewed by someone who doesn't have Mayflower running locally.  See [our deployment docs](../docs/developer-deploy.md) for step by step instructions.
 
 #### Creating a Pull Request
 Pull requests (PRs) let you tell others about changes you've pushed to a repository on GitHub. Once a pull request is opened, you can discuss and review the potential changes with collaborators and add follow-up commits before the changes are merged into the repository.  

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   php:
     version: 5.5.36
+  node:
+    version: 6.11.4
 
 general:
   artifacts:
@@ -8,19 +10,35 @@ general:
   build_dir: styleguide
 
 dependencies:
+  pre:
+    - npm install -g npm
+    - npm install -g gulp
   override:
     - php core/console --generate
     - npm install
+    - npm rebuild node-sass --force
 
 test:
   override:
     - npm run gulp prod
 
 deployment:
-  release:
+  artifacts:
     tag: /\bv?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?:\+[\da-z\-]+(?:\.[\da-z\-]+)*)?\b/
     owner: massgov
     commands:
       - git config --global user.email "devops@palantir.net"
       - git config --global user.name "palantirnet-temp1"
       - vendor/bin/phing deploy
+  cd:
+    branch: /^(?!master).*$/
+    owner: massgov
+    commands:
+      - ../scripts/deploy-s3.sh -b ${CIRCLE_BRANCH}
+#  production:
+#    tag: /^[0-9]+\.+[0-9]+\.+[0-9]+$/
+#    owner: massgov
+#    commands:
+#      - ../scripts/deploy-s3.sh -b ${CIRCLE_TAG}
+#      - ../scripts/deploy-prod-s3.sh -b ${CIRCLE_TAG}
+#      - ../scripts/deploy-latest-minor-s3.sh -b ${CIRCLE_TAG}

--- a/docs/release.md
+++ b/docs/release.md
@@ -7,7 +7,7 @@ Mayflower release managers with the necessary repo permissions can follow these 
 1. Check out the [massgov/mayflower `dev` branch](https://github.com/massgov/mayflower/commits/dev): `git checkout dev` and pull the latest from upstream `git pull upstream dev`. (This assumes that your massgov/mayflower remote repo is named `upstream`)
 1. Create a release branch `git checkout -b release-#.#.#` where `#.#.#` is the next version (i.e. `5.0.0`).  Read more about [Mayflower and semantic versioning](docs/versioning.md) to ensure that your are creating the right type of version.
 1. Document the new release based on the "Upcoming" queue at the top of [release-notes.md](/release-notes.md), and then commit.
-1. Move into the `stylguide` directory `cd styleguide`
+1. Move into the `stylguide` directory `cd styleguide` (may be a good idea to run `npm install` in case the release includes new packages).
 1. Bump the version on the homepage - `@pages/readme2.json` - by updating the version and date text in `errorPage.type`
 1. Bump the version of the npm package by running `gulp bump -v=#.#.#` where `#.#.#` is the version you are releasing.
 1. Commit your version bump file updates.

--- a/docs/release.md
+++ b/docs/release.md
@@ -17,7 +17,7 @@ Mayflower release managers with the necessary repo permissions can follow these 
 1. Smoke test Mayflower (a quick way to do this is to browse around to some of the different pages in the "pages" menu and do a quick gut check)
 1. Open a Github Pull Request to merge (no squash!) the release branch into the `master` branch.
     1. Add the relevant release notes to the PR notes.
-    1. This is a great time to verify one more time that your release [is following semantic versioning](../docs/versioning.md) properly (i.e. not pushing out breaking changes in a minor release).
+    1. This is a great time to verify one more time that your release [is following semantic versioning](versioning.md) properly (i.e. not pushing out breaking changes in a minor release).
 1. [Create a production release](https://help.github.com/articles/creating-releases/) off the `master` branch in GitHub, remember to add the release notes!
 1. Wait for [the circle builds](https://circleci.com/gh/massgov/mayflower) to pass
 1. Pull down your tag `git pull tags`

--- a/docs/release.md
+++ b/docs/release.md
@@ -4,27 +4,35 @@ Mayflower release managers with the necessary repo permissions can follow these 
 *Note: the following steps assume that your local machine and repository is already set up and functioning according to our [Getting Started docs](../.github/CONTRIBUTING.md#getting-started).*
 
 1. If there is new code to be delivered, notify the team at least two hours ahead of time that a release is coming. Follow the [Communicate Releases](https://wiki.state.ma.us/display/massgovredesign/Communicating+Releases) instructions for Upcoming Deployments.
-1. Pull and checkout the [massgov/mayflower `dev` branch](https://github.com/massgov/mayflower/commits/dev): `git fetch upstream && git checkout dev`.
-1. Create a release branch `git checkout -b release-#.#.#` where `#.#.#` is the next version (i.e. `5.0.0`).  Read more about [Mayflower and semantic versioning](docs/versioning.md) to ensure that your are creating the right type of version..
+1. Check out the [massgov/mayflower `dev` branch](https://github.com/massgov/mayflower/commits/dev): `git checkout dev` and pull the latest from upstream `git pull upstream dev`. (This assumes that your massgov/mass remote repo is named `upstream`)
+1. Create a release branch `git checkout -b release-#.#.#` where `#.#.#` is the next version (i.e. `5.0.0`).  Read more about [Mayflower and semantic versioning](docs/versioning.md) to ensure that your are creating the right type of version.
 1. Document the new release based on the "Upcoming" queue at the top of [release-notes.md](/release-notes.md), and then commit.
-1. Bump the version in `@pages/readme2.json` by updating the version and date text in `errorPage.type`, and then commit.
+1. Move into the `stylguide` directory `cd styleguide`
+1. Bump the version on the homepage - `@pages/readme2.json` - by updating the version and date text in `errorPage.type`
+1. Bump the version of the npm package by running `gulp bump -v=#.#.#` where `#.#.#` is the version you are releasing.
+1. Commit your version bump file updates.
 1. Push release branch to `massgov/mayflower` (i.e. `git push upstream release-#.#.#`).
-1. Deploy release branch to *your personal fork's* GH-Pages by running `./scripts/deploy-gh-pages.sh -b <your-release-branch-name> -t <your-github-username>` from the repo root.
-1. Verify release notes against the site rendered on your GH-Pages: `<your-github-username>.github.io/mayflower`.
-1. Smoke test most Mayflower featureset. (*@todo define Mayflower featureset*)
+1. Wait for [the circle build](https://circleci.com/gh/massgov/mayflower) to pass, which will deploy your release branch to staging automagically :).
+1. Verify release notes against the site rendered at: `https://mayflower.digital.mass.gov/<your-release-branch>/`.
+1. Smoke test Mayflower (a quick way to do this is to browse around to some of the different pages in the "pages" menu and do a quick gut check)
 1. Open a Github Pull Request to merge (no squash!) the release branch into the `master` branch.
     1. Add the relevant release notes to the PR notes.
+    1. This is a great time to verify one more time that your release [is following semantic versioning](../docs/versioning.md) properly (i.e. not pushing out breaking changes in a minor release).
 1. [Create a production release](https://help.github.com/articles/creating-releases/) off the `master` branch in GitHub, remember to add the release notes!
-1. Pull down and checkout the your release tag by running `git pull --tags && git checkout <your-release-tag>` (*Note: you should see a message from git that you are in a [detached head state](https://www.git-tower.com/learn/git/faq/detached-head-when-checkout-commit) and that is okay.*)
-1. Deploy release tag to [Prod](http://mayflower.digital.mass.gov) by running `./scripts/deploy-gh-pages.sh -b <your-release-tag> -t massgov -c mayflower.digital.mass.gov` from the repo root, where:
-   - `-b` is the build source (*required*): your git branch or tag name.
-   - `-t` is the target remote repo owner (*required*): `massgov` for prod.
-   - `-c` is the custom cname (domain) for Prod (*required for prod deployment*): `mayflower.digital.mass.gov`
-   1. When prompted, confirm your prod deployment by typing: `y`
+1. Wait for [the circle builds](https://circleci.com/gh/massgov/mayflower) to pass
+1. Pull down your tag `git pull tags`
+1. Make sure you are in `styleguide` (cd `styleguide` if you're not)
+1. Deploy the release (to its three locations: prod `/`, current version `/<your-tag-name>/`, and latest minor `/<current-major-version>/`) and publish the [@massds/mayflower package on NPM](https://www.npmjs.com/package/@massds/mayflower) by running `../scripts/deploy-mayflower.s3 -b <your-tag-name>` and follow the prompts.
+    1. Protip: In order to push the Mayflower package to [NPM](https://npmjs.com/@massds/mayflower), you need to be authenticated on NPM, by one of the following:
+        1. Having an `.npmrc` file with credentials for the `@massds` account (or your own NPM account if you're added to the Mayflower package as an owner) in your Mayflower repo root (this file is not and should not be versioned -- ask a team member for credentials)
+            - See [npmjs docs re: .npmrc](https://docs.npmjs.com/files/npmrc#per-project-config-file\n\n2) 
+        1. Having an `NPM_TOKEN` environment variable for `@massds`
+            - See [npmjs docs re: NPM_TOKEN](http://blog.npmjs.org/post/118393368555/deploying-with-npm-private-modules)
+        1. Authenticating from the npm CLI (Note: you must be added to the Mayflower NPM package project as an owner -- ask a team member for help)
+            - See [npmjs docs](https://docs.npmjs.com/getting-started/publishing-npm-packages#preparation)
 1. Smoke test [Prod](http://mayflower.digital.mass.gov) 
     - Make sure the home page reflects the date and version
-    - Ensure Mayflower featureset (*@todo define*) is functional
-1. Open a GitHub Pull Request to merge `master` into `develop` (this should only bring an updated `release-notes.md`, `@pages/readme2.json`). If possible, have a peer do the merge after a quick review. If no peers are available, proceed with your merge into develop, but ask for a review the following day. If it doesn't pass review, you may have to rollback the delivery.
+1. Open a GitHub Pull Request to merge `master` into `develop` (this should only bring an updated `release-notes.md`, `@pages/readme2.json`). If a feature was reverted on the release branch, have a peer do the merge after a review.
 1. In JIRA Go to the [DP project](https://jira.state.ma.us/projects/DP/).
     1. Click on the Releases icon on the left side (it looks like a boat/ship).
     1. Add a new release version with today's date.
@@ -36,8 +44,12 @@ Mayflower release managers with the necessary repo permissions can follow these 
 ## Rollback
 In the event that a release needs to be rolled back from production, follow these steps:
 
-1. Pull down and checkout the prior release tag and check it out by running `git pull --tags && git checkout <prior-release-tag>` (*Note: you should see a message from git that you are in a [detached head state](https://www.git-tower.com/learn/git/faq/detached-head-when-checkout-commit) and that is okay.*)
-1. Deploy release tag to [Prod](http://mayflower.digital.mass.gov) by running `./scripts/deploy-gh-pages.sh -b <prior-release-tag> -t massgov -c mayflower.digital.mass.gov` from the repo root
-   1. When prompted, confirm your prod deployment by typing: `y`
-1. Validate rollback by browsing to [Prod](http://mayflower.digital.mass.gov) and verifying that the home page reflects the prior version
+1. Pull down and checkout the prior release tag and check it out by running `git pull --tags` then `git checkout <prior-release-tag>` (*Note: you should see a message from git that you are in a [detached head state](https://www.git-tower.com/learn/git/faq/detached-head-when-checkout-commit) and that is okay.*)
+1. Make sure you are in `/styleguide` directory
+1. Deploy prior release tag to:
+    1. [Prod](http://mayflower.digital.mass.gov) by running `../scripts/deploy-prod-s3.sh -b <prior-release-tag>`
+        1. When prompted, confirm your prod deployment by typing: `y`
+    1. Latest minor by running `../scripts/deploy-latest-minor-s3.sh -b <prior-release-tag>`
+        1. When prompted, confirm your latest minor deployment by typing: `y`
+1. Validate rollback by browsing to [Prod](http://mayflower.digital.mass.gov) as well as `https://mayflower.digital.mass.gov/<current-major>/` and verifying that the home page reflects the correct version
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -4,7 +4,7 @@ Mayflower release managers with the necessary repo permissions can follow these 
 *Note: the following steps assume that your local machine and repository is already set up and functioning according to our [Getting Started docs](../.github/CONTRIBUTING.md#getting-started).*
 
 1. If there is new code to be delivered, notify the team at least two hours ahead of time that a release is coming. Follow the [Communicate Releases](https://wiki.state.ma.us/display/massgovredesign/Communicating+Releases) instructions for Upcoming Deployments.
-1. Check out the [massgov/mayflower `dev` branch](https://github.com/massgov/mayflower/commits/dev): `git checkout dev` and pull the latest from upstream `git pull upstream dev`. (This assumes that your massgov/mass remote repo is named `upstream`)
+1. Check out the [massgov/mayflower `dev` branch](https://github.com/massgov/mayflower/commits/dev): `git checkout dev` and pull the latest from upstream `git pull upstream dev`. (This assumes that your massgov/mayflower remote repo is named `upstream`)
 1. Create a release branch `git checkout -b release-#.#.#` where `#.#.#` is the next version (i.e. `5.0.0`).  Read more about [Mayflower and semantic versioning](docs/versioning.md) to ensure that your are creating the right type of version.
 1. Document the new release based on the "Upcoming" queue at the top of [release-notes.md](/release-notes.md), and then commit.
 1. Move into the `stylguide` directory `cd styleguide`

--- a/docs/release.md
+++ b/docs/release.md
@@ -13,7 +13,7 @@ Mayflower release managers with the necessary repo permissions can follow these 
 1. Commit your version bump file updates.
 1. Push release branch to `massgov/mayflower` (i.e. `git push upstream release-#.#.#`).
 1. Wait for [the circle build](https://circleci.com/gh/massgov/mayflower) to pass, which will deploy your release branch to staging automagically :).
-1. Verify release notes against the site rendered at: `https://mayflower.digital.mass.gov/<your-release-branch>/`.
+1. Verify release notes against the site rendered at: `https://mayflower.digital.mass.gov/<your-release-branch>/index.html`.
 1. Smoke test Mayflower (a quick way to do this is to browse around to some of the different pages in the "pages" menu and do a quick gut check)
 1. Open a Github Pull Request to merge (no squash!) the release branch into the `master` branch.
     1. Add the relevant release notes to the PR notes.
@@ -24,7 +24,7 @@ Mayflower release managers with the necessary repo permissions can follow these 
 1. Make sure you are in `styleguide` (cd `styleguide` if you're not)
 1. Deploy the release (to its three locations: prod `/`, current version `/<your-tag-name>/`, and latest minor `/<current-major-version>/`) and publish the [@massds/mayflower package on NPM](https://www.npmjs.com/package/@massds/mayflower) by running `../scripts/deploy-mayflower.s3 -b <your-tag-name>` and follow the prompts.
     1. Protip: In order to push the Mayflower package to [NPM](https://npmjs.com/@massds/mayflower), you need to be authenticated on NPM, by one of the following:
-        1. Having an `.npmrc` file with credentials for the `@massds` account (or your own NPM account if you're added to the Mayflower package as an owner) in your Mayflower repo root (this file is not and should not be versioned -- ask a team member for credentials)
+        1. Having an `.npmrc` file with credentials for the `@massds` account (or your own NPM account if you're added to the Mayflower package as an owner) in the styleguide directory of your Mayflower repo (this file is not and should not be versioned -- ask a team member for credentials)
             - See [npmjs docs re: .npmrc](https://docs.npmjs.com/files/npmrc#per-project-config-file\n\n2) 
         1. Having an `NPM_TOKEN` environment variable for `@massds`
             - See [npmjs docs re: NPM_TOKEN](http://blog.npmjs.org/post/118393368555/deploying-with-npm-private-modules)

--- a/docs/s3-architecture.md
+++ b/docs/s3-architecture.md
@@ -1,0 +1,16 @@
+# Mayflower / Amazon S3 Architecture
+
+We host Mayflower (i.e. the static output of a Pattern Lab “build”) in an amazon s3 bucket, at which we point mayflower.digital.mass.gov.  The table below describes our architecture for the various bucket sub folders.
+
+
+|mayflower.digital.mass.gov paths|
+|---|
+
+|Name|URL path|Example|Purpose|What code gets deployed here?|When does code get deployed here?|How does code get deployed here?|Permanent or temporary?|
+|---|---|---|---|---|---|---|---|
+|**Production**|/|mayflower.digital.mass.gov/|The latest and greatest version of Mayflower.  Mostly used for browsing and (soon) implementation documentation from the home page.|Pattern Lab build artifacts from a production tag (i.e. 5.10.0) cut off master branch..|During the release process, when a release branch is merged into master.|Release manager executes a script command.  See release docs.|Permanent (and dynamic, i.e. the contents change when a new release is deployed here)|
+|**Latest minor**|/<current-major-#>/|/5/|The latest minor version within a given major: implementers who link to these css/js/font/icon assets get safe updates automatically|Pattern Lab build artifacts from a production tag (i.e. 5.10.0) cut off master branch. Note: if the production tag starts a new major release, then a new /<current-major-#> directory will be created automatically.|During the release process, when a release branch is merged into master.|Release manager executes a script command.  See release docs.|Permanent (and dynamic, i.e. the contents change when a new release is deployed here)|
+|**Release**|/<#.#.#>/|/5.10.0/|Static snapshot of a given release: implementers who link to these css/js/font/icon assets get updates only when they manually change their links to the next version|Pattern Lab build artifacts from a production tag (i.e. 5.10.0) cut off master branch..|During the release process, when a release branch is merged into master.|Release manager executes a script command.  See release docs.|Permanent (and static, i.e. once is a release is deployed here it will never change)|
+|**Staging**|/release-#.#.#/|/release-5.11.0/|A given release branch; used to stage an upcoming release for functional / integration testing.|Pattern Lab build artifacts from the release branch.|When a release branch (which has an open PR) has a new commit pushed.|CircleCI deploys as part of build for the release branch.|Temporary (can be deleted when the release testing is done) @TODO script this|
+|**Dev**|/dev/|/dev/|Bleeding edge of our codebase; used for browsing all of the code that has been merged into dev branch prior to release.|Pattern Lab build artifacts from the dev branch. |When a feature PR is squashed and merged into dev branch.|CircleCI deploys as part of build for the  dev branch.|Permanent (and dynamic, i.e. the contents change when new work is merged in)|
+|**Feature branch**|/<my-branch-name>/|/DP-1234-my-ticket/|The feature development done on a particular branch; used for internal and external review functional tests.|Pattern Lab build artifacts from the feature branch.|When a feature branch (which has an open PR) has a new commit pushed.|CircleCI deploys as part of build for the feature branch.|Temporary (can be deleted when the feature testing is done) @TODO script this

--- a/release-notes.md
+++ b/release-notes.md
@@ -11,7 +11,20 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 **For example**
 - DP-1234: The short description text on a [service detail](http://mayflower.digital.mass.gov/?p=pages-detail-for-service-howto-location) page banner ([@organisms/by-template/page-banner](http://mayflower.digital.mass.gov/?p=organisms-page-banner)) should now render ([PR #493](https://github.com/massgov/mayflower/pull/493))
 
-## 5.10.2 (2/2/2018)
+## 5.12.0 (2/7/2018)
+
+### Changed
+- DP-7718: Adds support for Description text to [@molecules/callout-link](https://mayflower.digital.mass.gov/?p=molecules-callout-link-as-description&view=c) (e.g calls to action on a location page header).
+- D-7725: Adds Support for Blue Variant of [@atoms/colored-heading](https://mayflower.digital.mass.gov/?p=atoms-colored-heading-blue&view=c) (e.g. header in the press filter organism)
+
+## Fixed
+- DP-7359: Make line breaks on word in [richtext](https://mayflower.digital.mass.gov/?p=organisms-rich-text) links compatible with non-chrome browsers.
+- DP-7490: Adjust the [page banner](https://mayflower.digital.mass.gov/?p=organisms-page-banner-as-overlay) and its children for flexble height.
+
+## Added
+- (For Devs): Adds shell scripts and circle config to deploy feature branches and production tags to mayflower.digital.mass.gov [s3 bucket|https://github.com/massgov/mayflower/blob/dev/docs/s3-architecture.md] AND to publish static assets on [NPM|https://www.npmjs.com/package/@massds/mayflower]. See new [release process|https://github.com/massgov/mayflower/blob/dev/docs/release.md]
+
+## 5.11.0 (2/5/2018)
 
 ### Changed
 - DP-7478 - Page based alerts can now span multiple rows as needed.
@@ -19,7 +32,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - DP-7265 - Add new 'Mosaic Grid' organism with 'Featured Item' molecules for use on ['Organization Elected Official' pages](https://mayflower.digital.mass.gov/?p=pages-organization-elected-official).
-
 
 ## 5.10.1 (1/3/2018)
 

--- a/scripts/deploy-latest-minor-s3.sh
+++ b/scripts/deploy-latest-minor-s3.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# include shared functions
+. ../scripts/deploy-s3-functions.sh
+
+# Deploying a latest minor version of Mayflower to Amazon S3:
+#   mayflower.digital.mass.gov/<current-major-#>/
+# ----------------------------------------------------------------------------
+#
+# Note: this script updates the latest minor asset URLs which Mayflower consumers may use in their implementations.  Make sure you are not deploying any breaking changes!  See: https://github.com/massgov/mayflower/blob/dev/docs/versioning.md for help determining
+#
+# Run from /styleguide, must have a clean working directory.
+#
+# Usage:
+# ../scripts/deploy-latest-minor-s3.sh [-b (git-branch-or-tag)]
+#   -b Build source: the git branch or tag from which to build (required)
+#
+# Description:
+# 1. Validate the passed arguments: build source
+# 2. Attempt to checkout passed build source
+# 3. Get to mayflower/styleguide directory
+# 4. Write config to support hosting from subdirectory, if necessary
+# 5. Build pattern lab static assets
+# 6. Copy static assets (build output: styleguide/public/) into a new temp directory
+# 7. Execute gulp command to deploy to s3
+# 8. Remove the temp directory
+# 9. Check out the previous branch
+
+# Default variables
+buildSrc=false
+
+# Get passed arguments
+while getopts :b: option
+do
+    case "${option}" in
+        b) buildSrc=${OPTARG};;
+        : ) line="Missing argument for parameter [-${OPTARG}]";
+              log "error" "$line";
+              exit 1;;
+        \? ) line="Whoops, this script only accepts arguments for: git build branch/tag [-b]";
+             log "error" "$line";
+             exit 1;;
+    esac
+done
+
+# 1. Validate build source environment argument exists and is valid git branch or tag
+validateBuildSource
+
+# Confirm latest minor and production deploys if a human is executing this script.
+if [ ! CIRCLECI ];
+then
+    read -p "This script executes a latest minor deploy (i.e. to mayflower.digital.mass.gov/<current-major-#>/).\n\nThis will affect all projects which use our latest minor asset links.\n\nAre you sure you want to proceed? [y/n] " -n 1 -r
+    echo    # move to a new line
+    if [[ ! $REPLY =~ ^[Yy]$ ]];
+    then
+        line="Aborting deploy..."
+        log "error" "$line";
+        exit 1;
+    fi
+fi
+
+# Validate that we have a production tag (i.e. 5.10.0)
+line="Validating that ${buildSrc} is a prod tag..."
+log "log" "$line";
+
+majorVersion=$(getMajorVersion "$buildSrc")
+if [[ ${majorVersion} == "false" ]];
+then
+    line="Your build source doesn't appear to be a prod tag.  Please run the script again and pass the -b argument your desired production tag (i.e. 5.10.0)"
+    log "error" "$line";
+    exit 1;
+else
+    line="Nice! ${buildSrc} appears to be a prod tag (within major version ${majorVersion})."
+    log "success" "$line";
+fi
+
+# 2. Checkout the build source
+checkoutBuildSource
+
+# 3. Get to styleguide directory
+cdStyleguide
+
+# 4. Set the domain and asset path config
+# If we're deploying something that doesn't have the url.json.example file, create it first
+createUrlJson
+
+# Determine the url.assetsPath based arguments passed
+# For root deploy (production):  url.assetsPath = assets (already set by default)
+# For latest minor deploy: = url.assetsPath = <latest minor determined by build source tag>/assets
+# For all other deploys: url.assetsPath = <build source branch or tag name>/assets
+
+domain="https://mayflower.digital.mass.gov"
+# Set up the config value for assetsPath
+subDir="$majorVersion" #$majorVersion is set above when we validate the prod tag
+assetsPath="$subDir/assets"
+
+# Set url.domain and url.assetsPath
+writeAssetsPathConfig
+
+# 5. Build pattern to generate prod static assets
+buildMayflower
+
+# 6. Copy built assets in /public into new tmp directory
+
+# Make temp directory to copy public assets
+line="Making ~/tmp/mayflower/$subDir directory..."
+log "log" "$line";
+
+if [ -d "~/tmp" ];
+then
+    mkdir ~/tmp/mayflower
+    mkdir ~/tmp/mayflower/${subDir}
+else
+    mkdir ~/tmp
+    mkdir ~/tmp/mayflower
+    mkdir ~/tmp/mayflower/${subDir}
+fi
+
+# Copy
+line="Copying Pattern Lab build output to ~/tmp/mayflower/$subDir directory..."
+log "log" "$line";
+cp -r public/. ~/tmp/mayflower/${subDir} >/dev/null
+
+# 7. Run gulp task to deploy to s3 bucket
+line="Uploading contents of ~/tmp/mayflower/$subDir to Mayflower s3 bucket..."
+log "log" "$line";
+if ! gulp s3; then
+    line="gulp s3 task failed"
+    log "error" "$line";
+    exit 1;
+else
+    line="Woo-hoo! The deploy completed successfully.\n\n    You should be able to browse to your deployed code at:\n\n     https://mayflower.digital.mass.gov/${subDir}/"
+    log "success" "$line";
+fi
+
+# 8. Clean up tmp directory + 9. get back to where we want to be.
+cleanup

--- a/scripts/deploy-mayflower.sh
+++ b/scripts/deploy-mayflower.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# include shared functions
+. ../scripts/deploy-s3-functions.sh
+
+# Deploys the latest production release of Mayflower to Amazon S3 and push the NPM package:
+# --------------------------------------------------------------
+#
+# Run from /styleguide, must have a clean working directory.
+#
+# Usage:
+# ../scripts/deploy-mayflower.sh [-b (git-branch-or-tag)]
+#   -b Build source: the git branch or tag from which to build (required)
+#
+# Description:
+# 1. Validate the passed arguments: build source
+# 2. Execute ./scripts/deploy-s3.sh with release tag (deploys to mayflower.digital.mass.gov/#.#.#/)
+# 3. Execute ./scripts/deploy-latest-minor-s3.sh with release tag (deploys to mayflower.digital.mass.gov/#/)
+# 4. Execute ./scripts/deploy-prod-s3.sh with release tag (deploys to mayflower.digital.mass.gov)
+# 5. Execute ./scripts/deploy-npm.sh with release tag (pushes package to https://www.npmjs.com/package/@massds/mayflower)
+
+# Default argument values
+buildSrc=false
+
+# Get passed arguments
+while getopts :b: option
+do
+    case "${option}" in
+        b) buildSrc=${OPTARG};;
+        : ) line="Missing argument for parameter [-${OPTARG}]";
+              log "error" "$line";
+              exit 1;;
+        \? ) line="Whoops, this script only accepts arguments for: git build branch/tag [-b]";
+             log "error" "$line";
+             exit 1;;
+    esac
+done
+
+# 1. Validate build source environment argument exists and is valid git branch or tag
+validateBuildSource
+
+# Get to <repo root>/styleguide
+cdStyleguide
+
+# 2. Deploy tag to mayflower.digital.mass.gov/#.#.#/ where #.#.# is your tag version
+# Execute shell script in a different process (see: http://www.lostsaloon.com/technology/how-to-call-shell-script-sh-file-from-another-shell-script/)
+if ! ../scripts/deploy-s3.sh -b buildSrc; then
+line="Hmmm looks like the deploy to mayflower.digital.mass.gov/<your-tag-name>/ failed.  Hopefully you got a helpful error message from the script execution output."
+    log "error" "$line";
+    exit 1;
+else
+    line="Moving on to execute deploy to mayflower.digital.mass.gov/<current-major>/..."
+    log "log" "$line";
+fi
+
+# Get to <repo root>/styleguide
+cdStyleguide
+
+# 3. Deploy tag to mayflower.digital.mass.gov/#/ where # is the current major version
+# Execute shell script in a different process (see: http://www.lostsaloon.com/technology/how-to-call-shell-script-sh-file-from-another-shell-script/)
+
+if ! ../scripts/deploy-latest-minor.sh -b buildSrc; then
+line="Hmmm looks like the deploy to mayflower.digital.mass.gov/<current-major>/ failed.  Hopefully you got a helpful error message from the script execution output."
+    log "error" "$line";
+    exit 1;
+else
+    line="Moving on to execute deploy to mayflower.digital.mass.gov..."
+    log "log" "$line";
+fi
+
+# Get to <repo root>/styleguide
+cdStyleguide
+
+# 4. Deploy tag to mayflower.digital.mass.gov
+# Execute shell script in a different process (see: http://www.lostsaloon.com/technology/how-to-call-shell-script-sh-file-from-another-shell-script/)
+
+if ! ../scripts/deploy-prod-s3.sh -b buildSrc; then
+line="Hmmm looks like the deploy to mayflower.digital.mass.gov failed.  Hopefully you got a helpful error message from the script execution output."
+    log "error" "$line";
+    exit 1;
+else
+    line="Moving on to execute package and push to https://www.npmjs.com/package/@massds/mayflower..."
+    log "log" "$line";
+fi
+
+# Get to <repo root>/styleguide
+cdStyleguide
+
+# 5. Package contents and push to NPM
+# Execute shell script in a different process (see: http://www.lostsaloon.com/technology/how-to-call-shell-script-sh-file-from-another-shell-script/)
+
+../scripts/deploy-npm.sh -b buildSrc

--- a/scripts/deploy-npm.sh
+++ b/scripts/deploy-npm.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# include shared functions
+. ../scripts/deploy-s3-functions.sh
+
+# Deploying a branch or tag Mayflower to Amazon S3:
+#   mayflower.digital.mass.gov/git-branch-or-tag-name
+# -----------------------------------------------------
+#
+# Run from /styleguide, must have a clean working directory.
+#
+# Usage:
+# ../scripts/deploy-npm.sh [-b (git-branch-or-tag)]
+#   -b Build source: the git branch or tag from which to build (required)
+#
+# Description:
+# 1. Validate the passed arguments: build source
+# 2. Attempt to checkout passed build source
+# 3. Get to mayflower/styleguide directory
+# 4. Build pattern lab static assets
+# 5. Copy static assets (build output: styleguide/public/assets) into tmp/mayflower directory
+# 6. Copy other NPM goodies (README, npmignore, etc.) to tmp/mayflower directory
+# 7. Package assets and deploy NPM package
+# 8. Remove the temp directory
+# 9. Check out the previous branch
+
+# Default variables
+buildSrc=false
+
+# Get passed arguments
+while getopts :b: option
+do
+    case "${option}" in
+        b) buildSrc=${OPTARG};;
+        : ) line="Missing argument for parameter [-${OPTARG}]";
+              log "error" "$line";
+              exit 1;;
+        \? ) line="Whoops, this script only accepts arguments for: git build branch/tag [-b]";
+             log "error" "$line";
+             exit 1;;
+    esac
+done
+
+# 1. Validate build source environment argument exists and is valid git branch or tag name
+validateBuildSource
+
+# 2. Checkout the build source
+checkoutBuildSource
+
+# Confirm authentication if a human is executing this script.
+if [ ! CIRCLECI ];
+then
+    read -p "In order to push the mayflower package to NPM, you need to be authenticated on NPM, either by: \n\n1) Having an .npmrc file with credentials for the @massds account (or your own NPM account if you're added to the Mayflower package as an owner) in your Mayflower repo root (this file is not and should not be versioned -- ask a team member for credentials)\nSee: https://docs.npmjs.com/files/npmrc#per-project-config-file\n\n2) Having an NPM_TOKEN having environment variable for @massds\nSee: http://blog.npmjs.org/post/118393368555/deploying-with-npm-private-modules \n\n3) Authenticating from the npm CLI (Note: you must be added to the Mayflower NPM package project as an owner -- ask a team member for help)\n See: https://docs.npmjs.com/getting-started/publishing-npm-packages#preparation \n\n\nAre you sure you want to proceed? [y/n] " -n 1 -r
+    echo    # move to a new line
+    if [[ ! $REPLY =~ ^[Yy]$ ]];
+    then
+        line="No sweat! Just let a MassDS know that you need help pushing the latest Mayflower up to NPM."
+        log "error" "$line";
+        exit 1;
+    fi
+fi
+
+line="You've indicated a deploy to npm @${buildSrc}"
+log "log" "$line";
+
+# 3. Get to styleguide directory
+cdStyleguide
+
+# 4. Build pattern to generate prod static assets
+buildMayflower
+
+# 5. Copy built assets in /public into new tmp directory
+# Make temp directory to copy public assets
+line="Making ~/tmp/mayflower/npm directory..."
+log "log" "$line";
+
+if [ -d "~/tmp" ];
+then
+    mkdir ~/tmp/mayflower
+else
+    mkdir ~/tmp
+    mkdir ~/tmp/mayflower
+fi
+
+# 6. Copy package assets to temp directory
+line="Copying compiled Mayflower npm package assets to ~/tmp/mayflower directory..."
+log "log" "$line";
+cp -r public/assets/. ~/tmp/mayflower >/dev/null
+cp package.json ~/tmp/mayflower
+cp npm-shrinkwrap.json ~/tmp/mayflower
+cp ../README.md ~/tmp/mayflower
+cp ../LICENSE.txt ~/tmp/mayflower
+cp -a ./.npmignore ~/tmp/mayflower
+cp -a ./.npmrc ~/tmp/mayflower
+
+# Get to tmp directory
+line="Moving into ~/tmp/mayflower directory..."
+log "log" "$line";
+cd ~/tmp/mayflower
+
+# 7. Run npm pack to test
+# npm pack
+
+# 7. Package and deploy NPM
+line="Publishing contents of ~/tmp/mayflower to Mayflower npm package..."
+log "log" "$line";
+
+if ! npm publish --access=public; then
+    line="npm publish failed"
+    log "error" "$line";
+    exit 1;
+else
+    line="Woo-hoo! The deploy completed successfully.\n\n    You should be able to browse to your npm package at:\n\n     https://www.npmjs.com/package/@massds/mayflower"
+    log "success" "$line";
+fi
+
+# 8. Clean up tmp directory + #9 get back to where we want to be.
+cleanup

--- a/scripts/deploy-prod-s3.sh
+++ b/scripts/deploy-prod-s3.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# include shared functions
+. ../scripts/deploy-s3-functions.sh
+
+# Deploying the latest production release of Mayflower to Amazon S3:
+#   mayflower.digital.mass.gov/
+# --------------------------------------------------------------
+#
+# Run from /styleguide, must have a clean working directory.
+#
+# Usage:
+# ../scripts/deploy-prod-s3.sh [-b (git-branch-or-tag)]
+#   -b Build source: the git branch or tag from which to build (required)
+#
+# Description:
+# 1. Validate the passed arguments: build source
+# 2. Attempt to checkout passed build source
+# 3. Get to mayflower/styleguide directory
+# 4. Write config for domain and assetsPath values
+# 5. Build pattern lab static assets
+# 6. Copy static assets (build output: styleguide/public/) into a new temp directory
+# 7. Execute gulp command to deploy to s3
+# 8. Remove the temp directory
+# 9. Check out the previous branch
+
+# Default argument values
+buildSrc=false
+
+# Get passed arguments
+while getopts :b: option
+do
+    case "${option}" in
+        b) buildSrc=${OPTARG};;
+        : ) line="Missing argument for parameter [-${OPTARG}]";
+              log "error" "$line";
+              exit 1;;
+        \? ) line="Whoops, this script only accepts arguments for: git build branch/tag [-b]";
+             log "error" "$line";
+             exit 1;;
+    esac
+done
+
+# 1. Validate build source environment argument exists and is valid git branch or tag
+validateBuildSource
+
+# Confirm production deploy if a human is executing this script.
+if [ ! CIRCLECI ];
+then
+    read -p "This script executes a deploy to production, which will update the content at mayflower.digital.mass.gov.\n\nAre you sure you want to proceed? [y/n] " -n 1 -r
+    echo    # move to a new line
+    if [[ ! $REPLY =~ ^[Yy]$ ]];
+    then
+        line="Aborting deploy..."
+        log "error" "$line";
+        exit 1;
+    fi
+fi
+
+# Validate that we have a production tag (i.e. 5.10.0)
+line="Validating that ${buildSrc} is a prod tag..."
+log "log" "$line";
+
+if [[ $(isProdTag "$buildSrc") == "true" ]];
+then
+    line="Nice! ${buildSrc} appears to be a prod tag."
+    log "success" "$line";
+else
+    line="Your build source doesn't appear to be a prod tag.  Please run the script again and pass the -b argument your desired production tag (i.e. 5.10.0)"
+    log "error" "$line";
+    exit 1;
+fi
+
+# 2. Checkout the build source
+checkoutBuildSource
+
+# 3. Get to styleguide directory
+cdStyleguide
+
+# 4. Set the domain and asset path config
+# If we're deploying something that doesn't have the url.json.example file, create it first
+createUrlJson
+
+# Determine the url.assetsPath based arguments passed
+# For root deploy (production):  url.assetsPath = assets
+# For latest minor deploy: = url.assetsPath = <latest minor determined by build source tag>/assets
+# For all other deploys: url.assetsPath = <build source branch or tag name>/assets
+
+domain="https://mayflower.digital.mass.gov"
+assetsPath='assets'
+
+# Set url.domain and url.assetsPath
+writeAssetsPathConfig
+
+# 5. Build pattern to generate prod static assets
+buildMayflower
+
+# 6. Copy built assets in /public into new tmp directory
+# Make temp directory to copy public assets
+line="Making ~/tmp/mayflower directory..."
+log "log" "$line";
+
+if [ -d "~/tmp" ];
+then
+    mkdir ~/tmp/mayflower
+else
+    mkdir ~/tmp
+    mkdir ~/tmp/mayflower
+fi
+
+# Copy
+line="Copying Pattern Lab build output to ~/tmp/mayflower directory..."
+log "log" "$line";
+cp -r public/. ~/tmp/mayflower >/dev/null
+
+# 7. Run gulp task to deploy to s3 bucket
+line="Uploading contents of ~/tmp/mayflower to Mayflower s3 bucket..."
+log "log" "$line";
+if ! gulp s3; then
+    line="gulp s3 task failed"
+    log "error" "$line";
+    exit 1;
+else
+    line="Woo-hoo! The deploy completed successfully.\n\n    You should be able to browse to your deployed code at:\n\n    https://mayflower.digital.mass.gov/"
+    log "success" "$line";
+fi
+
+# 8. Clean up tmp directory + #9 get back to where we want to be.
+cleanup

--- a/scripts/deploy-s3-functions.sh
+++ b/scripts/deploy-s3-functions.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+#
+# Shared functions used when deploying Mayflower to Amazon S3
+# -------------------------------------------------------------
+
+# Steps to clean up after script execution
+# Runs on success and failure.
+function cleanup {
+    # Remove temp directory
+    line="Cleaning up tmp dir..."
+    log "log" "$line";
+
+    rm -rf ~/tmp/mayflower
+
+    # Check out the previous branch
+    line="Checking out your previous branch..."
+    log "log" "$line";
+
+    git checkout @{-1}
+}
+
+# Output success or error log during execution
+function log {
+    # parameters
+    local theLogType=$1
+    local theMessage=$2
+
+    if [ "$theLogType" == "success" ]; then
+        echo -e "\n\x1B[01;92m [success] "${theMessage}"\x1B[0m \n"
+    elif [ "$theLogType" == "error" ]; then
+        echo -e "\n\x1B[01;91m [error] "${theMessage}"\x1B[0m \n" >&2
+    else
+        echo -e "\n\x1B[01;34m [info] "${theMessage}"\x1B[0m \n"
+    fi
+}
+
+# Determines if a build source is a prod tag (i.e. 5.10.0 with no letters)
+function isProdTag {
+    local theTag=$1
+
+    if [[ ${theTag} =~ ^[0-9]+\.+[0-9]+\.+[0-9]+$ ]];
+    then
+        echo "true"
+    else
+        echo "false"
+    fi
+}
+
+# Determines major version from a passed parameter (i.e. 5.10.0 -> 5)
+function getMajorVersion {
+    local theTag=$1
+
+    if [[ $(isProdTag "$theTag") == "true" ]];
+    then
+        # Split the buildSrc by '.' and put into an array.
+        IFS='.' read -ra VERSION <<< "$theTag";
+        echo ${VERSION[0]}
+    else
+        echo "false";
+    fi
+}
+
+# Validate the -b argument is an actual git branch or tag
+function validateBuildSource {
+    # Validate build source environment argument exists
+    if [ "$buildSrc" = false ];
+    then
+        line="Whoops, we need a git branch or tag name to checkout and build from [-b]."
+        log "error" "$line";
+        exit 1;
+    fi
+
+    # Validate that passed build source is a valid git branch or tag
+    git rev-parse ${buildSrc} &>/dev/null
+    if [ "$?" -ne 0 ];
+    then
+        line="Hmmm, couldn't find a branch/tag named ${buildSrc}... check spelling and make sure you've pulled it."
+        log "error" "$line";
+        exit 1;
+    else
+        line="Validated git build source: ${buildSrc}..."
+        log "success" "$line";
+    fi
+}
+
+# Check out the build source
+function checkoutBuildSource {
+    line="Checking out the build source: ${buildSrc}"
+    log "log" "$line";
+
+    if ! git checkout ${buildSrc};
+    then
+        line="Could not check out $buildSrc, please make sure your working directory is clean and that you have fetched the latest from your remote."
+        log "error" "$line";
+        exit 1;
+    fi
+}
+
+# Get to the styleguide directory
+function cdStyleguide {
+    # Get to styleguide directory (inside of repo root), does not assume repo root is "mayflower"
+    line="Changing directory into <mayflower>/styleguide..."
+    log "log" "$line";
+
+    cd $(git rev-parse --show-toplevel)/styleguide
+}
+
+# Creates a url.json file
+function createUrlJson {
+    line="Setting the domain and asset path config..."
+    log "log" "$line";
+
+    # If we're deploying something that doesn't have the url.json.example file, create it first
+    if [ ! -f ./source/_data/url.json.example ];
+        then
+            line="Could not find url.json.example so creating it now..."
+            log "log" "$line";
+            urljson='{\n\t"url": {\n\t\t"comment": "Save this file as url.json and enter your domain and the path to the assets folder",\n\t\t"domain": "http://localhost:3000",\n\t\t"assetsPath": "assets"\n\t}\n}'
+            echo -e ${urljson} > ./source/_data/url.json.example
+
+            # Set flag to undo these changes in the working directory before leaving script.
+            cleanup=true
+    fi
+
+    # Create url.json from the .example and set the appropriate domain and assetsPath values
+    line="Copying url.json.example into url.json for assets path config..."
+    log "log" "$line";
+    cp ./source/_data/url.json.example ./source/_data/url.json
+}
+
+# Write the asset path config values to url.json
+function writeAssetsPathConfig {
+    line="Writing domain: ${domain} and assetsPath: ${assetsPath} to the build config."
+    log "log" "$line";
+
+    if [ CIRCLECI ];
+    then # Use GNU sed syntax
+         # See: https://stackoverflow.com/questions/43171648/sed-gives-sed-cant-read-no-such-file-or-directory
+        # Set url.domain and url.assetsPath
+        find ./source/_data -type f -name "url.json" -exec sed -i "s!http://localhost:3000!${domain}!g" {} \;
+        find ./source/_data -type f -name "url.json" -exec sed -i "s!assets\"!${assetsPath}\"!g" {} \;
+    else # Assume MacOS sed syntax
+         # See: https://stackoverflow.com/questions/11287564/getting-sed-error-illegal-byte-sequence-in-bash
+        # Set url.domain and url.assetsPath
+        find ./source/_data -type f -name "url.json" -exec sed -i "" "s!http://localhost:3000!${domain}!g" {} \;
+        find ./source/_data -type f -name "url.json" -exec sed -i "" "s!assets\"!${assetsPath}\"!g" {} \;
+    fi
+
+
+}
+
+
+# Build patterns to generate prod static assets
+function buildMayflower {
+    line="Generating mayflower patterns..."
+    log "log" "$line";
+    php core/console --generate >/dev/null
+
+    line="Building mayflower static assets..."
+    log "log" "$line";
+    gulp prod >/dev/null
+
+    # Remove url.json to keep repo clean
+    rm source/_data/url.json
+}

--- a/scripts/deploy-s3.sh
+++ b/scripts/deploy-s3.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# include shared functions
+. ../scripts/deploy-s3-functions.sh
+
+# Deploying a branch or tag Mayflower to Amazon S3:
+#   mayflower.digital.mass.gov/git-branch-or-tag-name/
+# -----------------------------------------------------
+#
+# Run from /styleguide, must have a clean working directory.
+#
+# Usage:
+# ../scripts/deploy-s3.sh [-b (git-branch-or-tag)]
+#   -b Build source: the git branch or tag from which to build (deploys to subdirectory named by that branch or tag) (required)
+#
+# Description:
+# 1. Validate the passed arguments: build source
+# 2. Attempt to checkout passed build source
+# 3. Get to mayflower/styleguide directory
+# 4. Write config to support hosting from subdirectory, if necessary
+# 5. Build pattern lab static assets
+# 6. Copy static assets (build output: styleguide/public/) into a new temp directory
+# 7. Execute gulp command to deploy to s3
+# 8. Remove the temp directory
+# 9. Check out the previous branch
+
+# Default variables
+buildSrc=false
+
+# Get passed arguments
+while getopts :b: option
+do
+    case "${option}" in
+        b) buildSrc=${OPTARG};;
+        : ) line="Missing argument for parameter [-${OPTARG}]";
+              log "error" "$line";
+              exit 1;;
+        \? ) line="Whoops, this script only accepts arguments for: git build branch/tag [-b]";
+             log "error" "$line";
+             exit 1;;
+    esac
+done
+
+# 1. Validate build source environment argument exists and is valid git branch or tag name
+validateBuildSource
+
+# 2. Checkout the build source
+checkoutBuildSource
+
+line="You've indicated a deploy to mayflower.digital.mass.gov/${buildSrc}"
+log "log" "$line";
+
+# 3. Get to styleguide directory
+cdStyleguide
+
+# 4. Set the domain and asset path config
+# If we're deploying something that doesn't have the url.json.example file, create it first
+createUrlJson
+
+# Determine the url.assetsPath based arguments passed
+# For root deploy (production):  url.assetsPath = assets (already set by default)
+# For latest minor deploy: = url.assetsPath = <latest minor determined by build source tag>/assets
+# For all other deploys: url.assetsPath = <build source branch or tag name>/assets
+
+domain="https://mayflower.digital.mass.gov"
+subDir="$buildSrc"
+# Configure assets path accordingly.
+assetsPath="$subDir/assets"
+
+# Set url.domain and url.assetsPath
+writeAssetsPathConfig
+
+# 5. Build pattern to generate prod static assets
+buildMayflower
+
+# 6. Copy built assets in /public into new tmp directory
+# Make temp directory to copy public assets
+line="Making ~/tmp/mayflower/$subDir directory..."
+log "log" "$line";
+
+if [ -d "~/tmp" ];
+then
+    mkdir ~/tmp/mayflower
+    mkdir ~/tmp/mayflower/${subDir}
+else
+    mkdir ~/tmp
+    mkdir ~/tmp/mayflower
+    mkdir ~/tmp/mayflower/${subDir}
+fi
+
+# Copy
+line="Copying Pattern Lab build output to ~/tmp/mayflower/$subDir directory..."
+log "log" "$line";
+cp -r public/. ~/tmp/mayflower/${subDir} >/dev/null
+
+# 7. Run gulp task to deploy to s3 bucket
+line="Uploading contents of ~/tmp/mayflower/$subDir to Mayflower s3 bucket..."
+log "log" "$line";
+if ! gulp s3; then
+    line="gulp s3 task failed"
+    log "error" "$line";
+    exit 1;
+else
+    line="Woo-hoo! The deploy completed successfully.\n\n    You should be able to browse to your deployed code at:\n\n     https://mayflower.digital.mass.gov/${subDir}/"
+    log "success" "$line";
+fi
+
+# 8. Clean up tmp directory + #9 get back to where we want to be.
+cleanup

--- a/styleguide/.gitignore
+++ b/styleguide/.gitignore
@@ -7,5 +7,5 @@ public/styleguide/html/styleguide.html
 public/styleguide/data/patternlab-data.js
 source/_data/url.json
 !public/index.html
-
+.npmrc
 /deploy

--- a/styleguide/.npmignore
+++ b/styleguide/.npmignore
@@ -1,0 +1,13 @@
+## We package from within a deploy script, essentially within /public/assets/
+
+css/pattern-scaffolding*
+css/pilot*
+css/gov-theme*
+data
+js/helpers
+js/index.js
+js/modules
+js/templates
+js/vendor
+patterns
+.npmrc

--- a/styleguide/npm-shrinkwrap.json
+++ b/styleguide/npm-shrinkwrap.json
@@ -1,83 +1,97 @@
 {
-  "name": "MayflowerPatternLibrary",
-  "version": "3.2.2",
+  "name": "Mayflower",
+  "version": "5.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@gulp-sourcemaps/map-sources": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
       "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
       "dev": true,
       "requires": {
-        "normalize-path": "2.1.1",
-        "through2": "2.0.3"
+        "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
+    },
+    "Base64": {
+      "version": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+      "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg=",
+      "dev": true
+    },
+    "JSONStream": {
+      "version": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
       }
     },
     "abbrev": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
       "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
       "dev": true
     },
     "accepts": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
+      "version": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
       "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.16",
-        "negotiator": "0.6.1"
+        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+        "negotiator": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
       }
     },
     "acorn": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+      "version": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
       "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "version": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
       },
       "dependencies": {
         "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "version": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
       }
     },
     "after": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
+      "version": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
       "integrity": "sha1-q11PuIP1loFtNRX495HAr0ht1ic=",
       "dev": true
     },
+    "agent-base": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.2.tgz",
+      "integrity": "sha1-gPps3kQPTc+a8mF88kYJm12Z8Mg=",
+      "dev": true,
+      "requires": {
+        "es6-promisify": "5.0.0"
+      }
+    },
     "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
+        "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
       }
     },
     "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+        "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
       }
     },
     "alter": {
@@ -90,197 +104,200 @@
       }
     },
     "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
+    "ansi-cyan": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+      "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-escapes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "version": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
     },
+    "ansi-red": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true
+    },
     "ansicolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
       "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8=",
       "dev": true
     },
     "anymatch": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "version": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
       "dev": true,
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz"
       }
     },
     "aproba": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
-      "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
+      "version": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
+      "integrity": "sha1-RcZikJTeTpb2k+9+q3SuB5wkD8E=",
       "dev": true
     },
     "archy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
     },
     "are-we-there-yet": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+      "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
+        "delegates": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
       }
     },
     "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
       }
     },
     "arr-diff": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz"
       }
     },
     "arr-flatten": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "version": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+      "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
       "dev": true
     },
     "array-differ": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
       "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
       "dev": true
     },
     "array-each": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
       "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
       "dev": true
     },
     "array-find-index": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
     "array-slice": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/array-slice/-/array-slice-1.0.0.tgz",
       "integrity": "sha1-5zA08A3MH0CHYAj9IP6ud71LfC8=",
       "dev": true
     },
     "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
       }
     },
     "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array-unique": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true
     },
     "arraybuffer.slice": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+      "version": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
       "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco=",
       "dev": true
     },
     "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
       "dev": true
     },
     "asn1.js": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+      "version": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
       "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
       }
     },
     "assert": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
+      "version": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
       "integrity": "sha1-A5OaYiWCqBLMICMgoLmlbJuBWEk=",
       "dev": true,
       "requires": {
-        "util": "0.10.3"
+        "util": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
       }
     },
     "assert-plus": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
       "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
       "dev": true
     },
     "assign": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/assign/-/assign-0.1.7.tgz",
+      "version": "https://registry.npmjs.org/assign/-/assign-0.1.7.tgz",
       "integrity": "sha1-5jv+Ooh7hjCRPCdmPkzJv/Hd0l8=",
       "dev": true,
       "requires": {
-        "fusing": "0.4.0"
+        "fusing": "https://registry.npmjs.org/fusing/-/fusing-0.4.0.tgz"
       },
       "dependencies": {
         "fusing": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/fusing/-/fusing-0.4.0.tgz",
+          "version": "https://registry.npmjs.org/fusing/-/fusing-0.4.0.tgz",
           "integrity": "sha1-yZBo9Uyj4R3AEYkCFSq/Nnq6Sk0=",
           "dev": true,
           "requires": {
-            "emits": "1.0.2",
-            "predefine": "0.1.2"
+            "emits": "https://registry.npmjs.org/emits/-/emits-1.0.2.tgz",
+            "predefine": "https://registry.npmjs.org/predefine/-/predefine-0.1.2.tgz"
           }
         }
       }
@@ -298,79 +315,123 @@
       "dev": true
     },
     "astw": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
+      "version": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
       "integrity": "sha1-e9QXhNMkk5h66yOba04cV6hzuRc=",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13"
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz"
       }
     },
     "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
     "async-each": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
     },
     "async-each-series": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
       "integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI=",
       "dev": true
     },
     "async-foreach": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+      "version": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
       "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
       "dev": true
     },
     "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "atob": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
+      "version": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
       "integrity": "sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M=",
       "dev": true
     },
     "autoprefixer": {
-      "version": "6.7.7",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+      "version": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
       "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
       "dev": true,
       "requires": {
-        "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000717",
-        "normalize-range": "0.1.2",
-        "num2fraction": "1.2.2",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
+        "browserslist": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+        "caniuse-db": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000717.tgz",
+        "normalize-range": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+        "num2fraction": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      }
+    },
+    "aws-sdk": {
+      "version": "2.175.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.175.0.tgz",
+      "integrity": "sha1-MzRiR7O5ymdPJ17qdG7f37ZHnkQ=",
+      "dev": true,
+      "requires": {
+        "buffer": "4.9.1",
+        "crypto-browserify": "1.0.9",
+        "events": "1.1.1",
+        "jmespath": "0.15.0",
+        "querystring": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+        "sax": "1.2.1",
+        "url": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+        "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+        "xml2js": "0.4.17",
+        "xmlbuilder": "4.2.1"
+      },
+      "dependencies": {
+        "base64-js": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
+          "integrity": "sha1-qRlH2h9KUW6jjltOwOw3c2deCIY=",
+          "dev": true
+        },
+        "buffer": {
+          "version": "4.9.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+          "dev": true,
+          "requires": {
+            "base64-js": "1.2.1",
+            "ieee754": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
+        },
+        "crypto-browserify": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz",
+          "integrity": "sha1-zFRJaF37hesRyYKKzHy4erW7/MA=",
+          "dev": true
+        },
+        "events": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+          "dev": true
+        },
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+          "dev": true
+        }
       }
     },
     "aws-sign2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
       "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
       "dev": true
     },
     "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "version": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
     },
     "babel-core": {
-      "version": "5.8.38",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
+      "version": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
       "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
       "dev": true,
       "requires": {
@@ -389,35 +450,35 @@
         "babel-plugin-runtime": "1.0.7",
         "babel-plugin-undeclared-variables-check": "1.0.2",
         "babel-plugin-undefined-to-void": "1.1.6",
-        "babylon": "5.8.38",
+        "babylon": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
         "bluebird": "2.11.0",
-        "chalk": "1.1.3",
-        "convert-source-map": "1.5.0",
-        "core-js": "1.2.7",
-        "debug": "2.6.8",
-        "detect-indent": "3.0.1",
-        "esutils": "2.0.2",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+        "core-js": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "detect-indent": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
         "fs-readdir-recursive": "0.1.2",
         "globals": "6.4.1",
-        "home-or-tmp": "1.0.0",
+        "home-or-tmp": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
         "is-integer": "1.0.7",
         "js-tokens": "1.0.1",
-        "json5": "0.4.0",
-        "lodash": "3.10.1",
-        "minimatch": "2.0.10",
+        "json5": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
         "output-file-sync": "1.1.2",
-        "path-exists": "1.0.0",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.7",
+        "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+        "private": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
         "regenerator": "0.8.40",
         "regexpu": "1.3.0",
-        "repeating": "1.1.3",
-        "resolve": "1.4.0",
+        "repeating": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
         "shebang-regex": "1.0.0",
-        "slash": "1.0.0",
-        "source-map": "0.5.7",
-        "source-map-support": "0.2.10",
-        "to-fast-properties": "1.0.3",
+        "slash": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+        "source-map-support": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+        "to-fast-properties": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
         "trim-right": "1.0.1",
         "try-resolve": "1.0.1"
       }
@@ -470,7 +531,7 @@
       "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
       "dev": true,
       "requires": {
-        "lodash": "3.10.1"
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
       }
     },
     "babel-plugin-react-constant-elements": {
@@ -524,146 +585,122 @@
       "integrity": "sha1-yvQ4iLpzG4drVWe2Q+7MZhR2k6U=",
       "dev": true,
       "requires": {
-        "babel-core": "5.8.38",
-        "object-assign": "4.1.1"
+        "babel-core": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
       }
     },
     "babylon": {
-      "version": "5.8.38",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+      "version": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
       "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
       "dev": true
     },
     "back": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/back/-/back-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/back/-/back-1.0.1.tgz",
       "integrity": "sha1-cE+KI9p641t9R7ZI+aef0qJVcOM=",
       "dev": true,
       "requires": {
-        "xtend": "4.0.1"
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
       }
     },
     "backo2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
       "dev": true
     },
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "Base64": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
-      "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg=",
-      "dev": true
-    },
     "base64-arraybuffer": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+      "version": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
       "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
       "dev": true
     },
     "base64-js": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "version": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
       "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=",
       "dev": true
     },
     "base64id": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
       "integrity": "sha1-As4P3u4M709ACA4ec+g08LG/zj8=",
       "dev": true
     },
     "batch": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
+      "version": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
       "integrity": "sha1-PzQU84AyF0O/wQQvmoP/HVgk1GQ=",
       "dev": true
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
       }
     },
     "beeper": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
       "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
       "dev": true
     },
     "better-assert": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
       "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
       "dev": true,
       "requires": {
-        "callsite": "1.0.0"
+        "callsite": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
       }
     },
     "binary-extensions": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
+      "version": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
       "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
       "dev": true
     },
     "bl": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+      "version": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
       "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.0.34"
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
       },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
       }
     },
     "blob": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+      "version": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
       "dev": true
     },
     "block-stream": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
       }
     },
     "bluebird": {
@@ -673,57 +710,50 @@
       "dev": true
     },
     "bn.js": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+      "version": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
       "dev": true
     },
     "boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
     "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
       }
     },
     "bourbon": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/bourbon/-/bourbon-4.3.4.tgz",
+      "version": "https://registry.npmjs.org/bourbon/-/bourbon-4.3.4.tgz",
       "integrity": "sha1-TaOAAp6SwMj5dkx3lFGhNLEefMM=",
       "dev": true
     },
     "bourbon-neat": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/bourbon-neat/-/bourbon-neat-1.7.2.tgz",
+      "version": "https://registry.npmjs.org/bourbon-neat/-/bourbon-neat-1.7.2.tgz",
       "integrity": "sha1-oiixJ0R53iR20yszFTEHylBTzz0=",
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
       }
     },
     "braces": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "version": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+        "preserve": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+        "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
       }
     },
     "breakable": {
@@ -733,769 +763,704 @@
       "dev": true
     },
     "brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
     "browser-pack": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-5.0.1.tgz",
+      "version": "https://registry.npmjs.org/browser-pack/-/browser-pack-5.0.1.tgz",
       "integrity": "sha1-QZdxmyDG4KqglFHFER5T77b7wY0=",
       "dev": true,
       "requires": {
-        "combine-source-map": "0.6.1",
-        "defined": "1.0.0",
-        "JSONStream": "1.3.1",
-        "through2": "1.1.1",
-        "umd": "3.0.1"
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+        "combine-source-map": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+        "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+        "umd": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
       },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
         "through2": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+          "version": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "integrity": "sha1-CEfLxESfNAVXTb3M2buEG4OsNUU=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.1.14",
-            "xtend": "4.0.1"
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
           }
         }
       }
     },
     "browser-resolve": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+      "version": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
       "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
       "dev": true,
       "requires": {
-        "resolve": "1.1.7"
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
       },
       "dependencies": {
         "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "version": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
         }
       }
     },
     "browser-sync": {
-      "version": "2.18.13",
-      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.18.13.tgz",
-      "integrity": "sha512-qhdrmgshVGwweogT/bdOKkZDxVxqiF4+9mibaDeAxvDBeoUtdgABk5x7YQ1KCcLRchAfv8AVtp9NuITl5CTNqg==",
+      "version": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.18.13.tgz",
+      "integrity": "sha1-wo3D6zvmfJepBwgrdyo3+RXBTX0=",
       "dev": true,
       "requires": {
-        "browser-sync-client": "2.5.1",
-        "browser-sync-ui": "0.6.3",
-        "bs-recipes": "1.3.4",
-        "chokidar": "1.7.0",
-        "connect": "3.5.0",
-        "dev-ip": "1.0.1",
-        "easy-extender": "2.3.2",
-        "eazy-logger": "3.0.2",
-        "emitter-steward": "1.0.0",
-        "fs-extra": "3.0.1",
-        "http-proxy": "1.15.2",
-        "immutable": "3.8.1",
-        "localtunnel": "1.8.3",
-        "micromatch": "2.3.11",
-        "opn": "4.0.2",
-        "portscanner": "2.1.1",
-        "qs": "6.2.1",
-        "resp-modifier": "6.0.2",
-        "rx": "4.1.0",
-        "serve-index": "1.8.0",
-        "serve-static": "1.12.2",
-        "server-destroy": "1.0.1",
-        "socket.io": "1.6.0",
-        "socket.io-client": "1.6.0",
-        "ua-parser-js": "0.7.12",
-        "yargs": "6.4.0"
+        "browser-sync-client": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.5.1.tgz",
+        "browser-sync-ui": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-0.6.3.tgz",
+        "bs-recipes": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
+        "chokidar": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+        "connect": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz",
+        "dev-ip": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
+        "easy-extender": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.2.tgz",
+        "eazy-logger": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.0.2.tgz",
+        "emitter-steward": "https://registry.npmjs.org/emitter-steward/-/emitter-steward-1.0.0.tgz",
+        "fs-extra": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+        "http-proxy": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
+        "immutable": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
+        "localtunnel": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.8.3.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "opn": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+        "portscanner": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
+        "qs": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
+        "resp-modifier": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
+        "rx": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+        "serve-index": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz",
+        "serve-static": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.2.tgz",
+        "server-destroy": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+        "socket.io": "https://registry.npmjs.org/socket.io/-/socket.io-1.6.0.tgz",
+        "socket.io-client": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.6.0.tgz",
+        "ua-parser-js": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz",
+        "yargs": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz"
       },
       "dependencies": {
         "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         },
         "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
           }
         },
         "window-size": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+          "version": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
           "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
           "dev": true
         },
         "yargs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
+          "version": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
           "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "window-size": "0.2.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "4.2.1"
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+            "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+            "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+            "require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "which-module": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+            "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz"
           }
         }
       }
     },
     "browser-sync-client": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.5.1.tgz",
+      "version": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.5.1.tgz",
       "integrity": "sha1-7BrWmknC4tS2RbGLHAbCmz2a+Os=",
       "dev": true,
       "requires": {
-        "etag": "1.8.0",
-        "fresh": "0.3.0"
+        "etag": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+        "fresh": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
       }
     },
     "browser-sync-ui": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-0.6.3.tgz",
+      "version": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-0.6.3.tgz",
       "integrity": "sha1-ZApTfBgGiTA9W+krxHa568RBwLw=",
       "dev": true,
       "requires": {
-        "async-each-series": "0.1.1",
-        "connect-history-api-fallback": "1.3.0",
-        "immutable": "3.8.1",
-        "server-destroy": "1.0.1",
-        "stream-throttle": "0.1.3",
-        "weinre": "2.0.0-pre-I0Z7U9OV"
+        "async-each-series": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
+        "connect-history-api-fallback": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz",
+        "immutable": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
+        "server-destroy": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+        "stream-throttle": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
+        "weinre": "https://registry.npmjs.org/weinre/-/weinre-2.0.0-pre-I0Z7U9OV.tgz"
       }
     },
     "browserify": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/browserify/-/browserify-10.2.6.tgz",
+      "version": "https://registry.npmjs.org/browserify/-/browserify-10.2.6.tgz",
       "integrity": "sha1-3L/veU9Uj1+EmCFIFPaXpcUMCJY=",
       "dev": true,
       "requires": {
-        "assert": "1.3.0",
-        "browser-pack": "5.0.1",
-        "browser-resolve": "1.11.2",
-        "browserify-zlib": "0.1.4",
-        "buffer": "3.6.0",
-        "builtins": "0.0.7",
-        "commondir": "0.0.1",
-        "concat-stream": "1.4.10",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "0.0.1",
-        "crypto-browserify": "3.11.1",
-        "defined": "1.0.0",
-        "deps-sort": "1.3.9",
-        "domain-browser": "1.1.7",
-        "duplexer2": "0.0.2",
-        "events": "1.0.2",
-        "glob": "4.5.3",
-        "has": "1.0.1",
-        "htmlescape": "1.1.1",
-        "http-browserify": "1.7.0",
-        "https-browserify": "0.0.1",
-        "inherits": "2.0.3",
-        "insert-module-globals": "6.6.3",
-        "isarray": "0.0.1",
-        "JSONStream": "1.3.1",
-        "labeled-stream-splicer": "1.0.2",
-        "module-deps": "3.9.1",
-        "os-browserify": "0.1.2",
-        "parents": "1.0.1",
-        "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "read-only-stream": "1.1.1",
-        "readable-stream": "1.1.14",
-        "resolve": "1.4.0",
-        "shasum": "1.0.2",
-        "shell-quote": "0.0.1",
-        "stream-browserify": "1.0.0",
-        "string_decoder": "0.10.31",
-        "subarg": "1.0.0",
-        "syntax-error": "1.3.0",
-        "through2": "1.1.1",
-        "timers-browserify": "1.4.2",
-        "tty-browserify": "0.0.0",
-        "url": "0.10.3",
-        "util": "0.10.3",
-        "vm-browserify": "0.0.4",
-        "xtend": "4.0.1"
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+        "assert": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
+        "browser-pack": "https://registry.npmjs.org/browser-pack/-/browser-pack-5.0.1.tgz",
+        "browser-resolve": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+        "browserify-zlib": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+        "buffer": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+        "builtins": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
+        "commondir": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
+        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+        "console-browserify": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+        "constants-browserify": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
+        "crypto-browserify": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
+        "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+        "deps-sort": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
+        "domain-browser": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+        "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+        "events": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+        "htmlescape": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+        "http-browserify": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+        "https-browserify": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "insert-module-globals": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+        "labeled-stream-splicer": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
+        "module-deps": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
+        "os-browserify": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+        "parents": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+        "path-browserify": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+        "process": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+        "querystring-es3": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+        "read-only-stream": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-1.1.1.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+        "shasum": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+        "shell-quote": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
+        "stream-browserify": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+        "subarg": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+        "syntax-error": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.3.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+        "timers-browserify": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+        "tty-browserify": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+        "url": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+        "util": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+        "vm-browserify": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
       },
       "dependencies": {
         "glob": {
-          "version": "4.5.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "version": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0"
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
           }
         },
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
         "through2": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+          "version": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "integrity": "sha1-CEfLxESfNAVXTb3M2buEG4OsNUU=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.1.14",
-            "xtend": "4.0.1"
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
           }
         }
       }
     },
     "browserify-aes": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+      "version": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
       "integrity": "sha1-Xncl297x/Vkw1OurSFZ85FHEigo=",
       "dev": true,
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.2",
-        "inherits": "2.0.3"
+        "buffer-xor": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+        "cipher-base": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+        "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+        "evp_bytestokey": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.2.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
       }
     },
     "browserify-cipher": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.0.6",
-        "browserify-des": "1.0.0",
-        "evp_bytestokey": "1.0.2"
+        "browserify-aes": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+        "browserify-des": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+        "evp_bytestokey": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.2.tgz"
       }
     },
     "browserify-des": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
       "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.3"
+        "cipher-base": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+        "des.js": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
       }
     },
     "browserify-rsa": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "version": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.0.5"
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+        "randombytes": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz"
       }
     },
     "browserify-sign": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "version": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "elliptic": "6.4.0",
-        "inherits": "2.0.3",
-        "parse-asn1": "5.1.0"
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+        "browserify-rsa": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+        "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+        "create-hmac": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+        "elliptic": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "parse-asn1": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz"
       }
     },
     "browserify-zlib": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "version": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
       "dev": true,
       "requires": {
-        "pako": "0.2.9"
+        "pako": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
       }
     },
     "browserslist": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+      "version": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000717",
-        "electron-to-chromium": "1.3.18"
+        "caniuse-db": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000717.tgz",
+        "electron-to-chromium": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz"
       }
     },
     "bs-recipes": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
+      "version": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
       "integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU=",
       "dev": true
     },
     "buffer": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+      "version": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
       "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
       "dev": true,
       "requires": {
-        "base64-js": "0.0.8",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
+        "base64-js": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+        "ieee754": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
       }
     },
     "buffer-xor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
     "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
     "builtins": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
+      "version": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
       "integrity": "sha1-NVIZzWzxjb58Acx/0tznZc/cVJo=",
       "dev": true
     },
+    "bump-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bump-regex/-/bump-regex-3.0.0.tgz",
+      "integrity": "sha512-TKMnVs6csJB9R+fs9hl/f2Qm+KrnNe2ffJOVw/cCZpsbuxw7Ko6XWBDS2DL0/hAB1TaxE/NbReLFXAiD+bw65Q==",
+      "dev": true,
+      "requires": {
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      }
+    },
     "caller-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
       }
     },
     "callsite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
       "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
       "dev": true
     },
     "callsites": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
     "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
       "dev": true
     },
     "camelcase-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "version": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+        "map-obj": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
       },
       "dependencies": {
         "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "version": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
           "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
           "dev": true
         }
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000717",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000717.tgz",
+      "version": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000717.tgz",
       "integrity": "sha1-J931/szdM4yZpiyXiMJpT5n2ftc=",
       "dev": true
     },
     "cardinal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
       "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
       "dev": true,
       "requires": {
-        "ansicolors": "0.2.1",
-        "redeyed": "1.0.1"
+        "ansicolors": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+        "redeyed": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz"
       }
     },
     "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "version": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
     "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
       }
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+        "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
       }
     },
     "cheerio": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
+      "version": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
       "integrity": "sha1-dy5wFfLuKZZQltcepBdbdas1SSU=",
       "dev": true,
       "requires": {
-        "css-select": "1.0.0",
-        "dom-serializer": "0.1.0",
-        "entities": "1.1.1",
-        "htmlparser2": "3.8.3",
-        "lodash": "3.10.1"
+        "css-select": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
+        "dom-serializer": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+        "entities": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+        "htmlparser2": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
       }
     },
     "chokidar": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+      "version": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "anymatch": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+        "async-each": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+        "fsevents": "1.1.3",
+        "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "is-binary-path": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+        "readdirp": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz"
       }
     },
     "cipher-base": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "version": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
       }
     },
     "circular-json": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "version": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "clap": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.0.tgz",
+      "version": "https://registry.npmjs.org/clap/-/clap-1.2.0.tgz",
       "integrity": "sha1-WckP4+E3EEdG/xlGmiemNP9oyFc=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3"
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
       }
     },
     "cli-color": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.2.0.tgz",
+      "version": "https://registry.npmjs.org/cli-color/-/cli-color-1.2.0.tgz",
       "integrity": "sha1-OlrnT9drYmevZm5p4q+70B3vNNE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1",
-        "d": "1.0.0",
-        "es5-ext": "0.10.29",
-        "es6-iterator": "2.0.1",
-        "memoizee": "0.4.5",
-        "timers-ext": "0.1.2"
+        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.29.tgz",
+        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+        "memoizee": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.5.tgz",
+        "timers-ext": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.2.tgz"
       }
     },
     "cli-cursor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
       }
     },
     "cli-table": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+      "version": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
       "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
       "dev": true,
       "requires": {
-        "colors": "1.0.3"
+        "colors": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
       }
     },
     "cli-usage": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/cli-usage/-/cli-usage-0.1.4.tgz",
+      "version": "https://registry.npmjs.org/cli-usage/-/cli-usage-0.1.4.tgz",
       "integrity": "sha1-fAHg3HBsI0s5yTODjI4gshdXduI=",
       "dev": true,
       "requires": {
-        "marked": "0.3.6",
-        "marked-terminal": "1.7.0"
+        "marked": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+        "marked-terminal": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-1.7.0.tgz"
       },
       "dependencies": {
         "marked-terminal": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-1.7.0.tgz",
+          "version": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-1.7.0.tgz",
           "integrity": "sha1-yMRgiBx3LHYEtkNnAH7l938SWQQ=",
           "dev": true,
           "requires": {
-            "cardinal": "1.0.0",
-            "chalk": "1.1.3",
-            "cli-table": "0.3.1",
-            "lodash.assign": "4.2.0",
-            "node-emoji": "1.8.1"
+            "cardinal": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "cli-table": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+            "lodash.assign": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+            "node-emoji": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz"
           }
         }
       }
     },
     "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "version": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
-        "wordwrap": "0.0.2"
+        "center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+        "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
       }
     },
     "clone": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
       "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
       "dev": true
     },
     "clone-buffer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
       "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
       "dev": true
     },
     "clone-stats": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
       "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
       "dev": true
     },
     "cloneable-readable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
       "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "process-nextick-args": "1.0.7",
-        "through2": "2.0.3"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
       }
     },
     "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "coa": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+      "version": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
       "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
       "dev": true,
       "requires": {
-        "q": "1.5.0"
+        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
       }
     },
     "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "color": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/color/-/color-0.8.0.tgz",
+      "version": "https://registry.npmjs.org/color/-/color-0.8.0.tgz",
       "integrity": "sha1-iQwHw/1OZJU3Y4kRz2keVFi2/KU=",
       "dev": true,
       "requires": {
-        "color-convert": "0.5.3",
-        "color-string": "0.3.0"
+        "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+        "color-string": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz"
       }
     },
     "color-convert": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+      "version": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
       "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=",
       "dev": true
     },
     "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "version": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "color-string": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+      "version": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
       }
     },
     "colornames": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz",
+      "version": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz",
       "integrity": "sha1-2BH9bIT1kClJmorEQ2ICk1uSvjE=",
       "dev": true
     },
     "colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
       "dev": true
     },
     "colorspace": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/colorspace/-/colorspace-1.0.1.tgz",
       "integrity": "sha1-yZx5btMRKLmHalLh7l7gOkpxl0k=",
       "dev": true,
       "requires": {
-        "color": "0.8.0",
-        "text-hex": "0.0.0"
+        "color": "https://registry.npmjs.org/color/-/color-0.8.0.tgz",
+        "text-hex": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz"
       }
     },
     "combine-source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+      "version": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
       "integrity": "sha1-m0oJwxYDPXaODxHgKfonMOB5rZY=",
       "dev": true,
       "requires": {
-        "convert-source-map": "1.1.3",
-        "inline-source-map": "0.5.0",
-        "lodash.memoize": "3.0.4",
-        "source-map": "0.4.4"
+        "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+        "inline-source-map": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
+        "lodash.memoize": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
       },
       "dependencies": {
         "convert-source-map": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+          "version": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
           "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
           "dev": true
         },
         "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
           }
         }
       }
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
       }
     },
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "version": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
       "dev": true
     },
     "commondir": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
       "integrity": "sha1-ifAP3NUbUZxXhzP+xWPmptp/W+I=",
       "dev": true
     },
@@ -1505,14 +1470,14 @@
       "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
       "dev": true,
       "requires": {
-        "commander": "2.11.0",
-        "detective": "4.5.0",
-        "glob": "5.0.15",
-        "graceful-fs": "4.1.11",
-        "iconv-lite": "0.4.18",
-        "mkdirp": "0.5.1",
-        "private": "0.1.7",
-        "q": "1.5.0",
+        "commander": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+        "detective": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "private": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
         "recast": "0.11.23"
       },
       "dependencies": {
@@ -1530,409 +1495,362 @@
           "requires": {
             "ast-types": "0.9.6",
             "esprima": "3.1.3",
-            "private": "0.1.7",
-            "source-map": "0.5.7"
+            "private": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
           }
         }
       }
     },
     "component-bind": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
       "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
       "dev": true
     },
     "component-emitter": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+      "version": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
       "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM=",
       "dev": true
     },
     "component-inherit": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+      "version": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
       "dev": true
     },
     "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concat-stream": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+      "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
       "integrity": "sha1-rMO79WAsuMyYDGrIQPp9hgPj7zY=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "1.1.14",
-        "typedarray": "0.0.6"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+        "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
       },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
       }
     },
     "concat-with-sourcemaps": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
+      "version": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
       "integrity": "sha1-9Vs74q60dgGxCi1SWcz7cP0vHdY=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
       }
     },
     "connect": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz",
+      "version": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz",
       "integrity": "sha1-s1dSWgtMH1BZnNmD4dnv7qlncZg=",
       "dev": true,
       "requires": {
-        "debug": "2.2.0",
-        "finalhandler": "0.5.0",
-        "parseurl": "1.3.1",
-        "utils-merge": "1.0.0"
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "finalhandler": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
+        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+        "utils-merge": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
       },
       "dependencies": {
         "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "dev": true,
           "requires": {
-            "ms": "0.7.1"
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
           }
         },
         "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
           "dev": true
         }
       }
     },
     "connect-history-api-fallback": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz",
+      "version": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz",
       "integrity": "sha1-5R0X+PDvDbkKZP20feMFFVbp8Wk=",
       "dev": true
     },
     "console-browserify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
       }
     },
     "console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
     "constants-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
       "integrity": "sha1-kld9tSe6bEzwpFaNhLwDH0QeIfI=",
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+      "version": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
       "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
       "dev": true
     },
     "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "version": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
       "dev": true
     },
     "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "version": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
       "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
       "dev": true
     },
     "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "create-ecdh": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+      "version": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
       "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.0"
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+        "elliptic": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz"
       }
     },
     "create-hash": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+      "version": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "sha.js": "2.4.8"
+        "cipher-base": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "ripemd160": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+        "sha.js": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
       }
     },
     "create-hmac": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+      "version": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.8"
+        "cipher-base": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+        "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "ripemd160": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+        "sha.js": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
       }
     },
     "cross-spawn": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+      "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
       "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
-        "which": "1.3.0"
+        "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+        "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
       },
       "dependencies": {
         "lru-cache": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+          "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "yallist": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
           }
         }
       }
     },
     "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "dev": true,
       "requires": {
-        "boom": "2.10.1"
+        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
       }
     },
     "crypto-browserify": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
-      "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+      "version": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
+      "integrity": "sha1-lIlF78Z1ekANbl5a9HGU0QBkJ58=",
       "dev": true,
       "requires": {
-        "browserify-cipher": "1.0.0",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.0",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "diffie-hellman": "5.0.2",
-        "inherits": "2.0.3",
-        "pbkdf2": "3.0.13",
-        "public-encrypt": "4.0.0",
-        "randombytes": "2.0.5"
+        "browserify-cipher": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+        "browserify-sign": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+        "create-ecdh": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+        "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+        "create-hmac": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+        "diffie-hellman": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "pbkdf2": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.13.tgz",
+        "public-encrypt": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+        "randombytes": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz"
       }
     },
     "css": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
+      "version": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
       "integrity": "sha1-c6TIHehdtmTU7mdPfUcIXjstVdw=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "source-map": "0.1.43",
-        "source-map-resolve": "0.3.1",
-        "urix": "0.1.0"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+        "source-map-resolve": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+        "urix": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
       },
       "dependencies": {
         "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
           }
         }
       }
     },
     "css-select": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
       "integrity": "sha1-sRIcpRhI3SZOIkTQWM7iVN7rRLA=",
       "dev": true,
       "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "1.0.0",
-        "domutils": "1.4.3",
-        "nth-check": "1.0.1"
+        "boolbase": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+        "css-what": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz",
+        "domutils": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+        "nth-check": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
       }
     },
     "css-what": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz",
       "integrity": "sha1-18wt9FGAZm+Z0rFEYmOUaeAPc2w=",
       "dev": true
     },
     "csso": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+      "version": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
       "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
       "dev": true,
       "requires": {
-        "clap": "1.2.0",
-        "source-map": "0.5.7"
+        "clap": "https://registry.npmjs.org/clap/-/clap-1.2.0.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
       }
     },
     "currently-unhandled": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "version": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
       }
     },
     "d": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.29"
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.29.tgz"
       }
     },
     "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
       },
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
       }
     },
     "date-now": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "version": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
     "dateformat": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
       "integrity": "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc=",
       "dev": true
     },
     "deap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/deap/-/deap-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/deap/-/deap-1.0.0.tgz",
       "integrity": "sha1-sUi/gkMKJ2mbdIOgPra2dYW/yIg=",
       "dev": true
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "version": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
       "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
       }
     },
     "debug-fabulous": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
+      "version": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
       "integrity": "sha1-+gccXYdIRoVCSAdCHKSxawsaB2M=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
-        "lazy-debug-legacy": "0.0.1",
-        "object-assign": "4.1.0"
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "lazy-debug-legacy": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
       },
       "dependencies": {
         "lazy-debug-legacy": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
-          "integrity": "sha1-U3cWwHduTPeePtG2IfdljCkRsbE=",
+          "version": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
+          "integrity": "sha1-gswqb03PNvrPDHp5RoV7/2KCisc=",
           "dev": true
         },
         "object-assign": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+          "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
           "dev": true
         }
       }
     },
     "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
     "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "version": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
     "defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "1.0.2"
+        "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
       }
     },
     "defined": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
     },
@@ -1960,742 +1878,687 @@
           "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
           "dev": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "os-locale": "1.4.0",
-            "window-size": "0.1.4",
-            "y18n": "3.2.1"
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+            "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
           }
         }
       }
     },
     "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "version": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.1"
+        "globby": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+        "is-path-cwd": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+        "is-path-in-cwd": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
       }
     },
     "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
     "delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
     "depd": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
       "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
       "dev": true
     },
     "deprecated": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
       "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=",
       "dev": true
     },
     "deps-sort": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
+      "version": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
       "integrity": "sha1-Kd//U+F7Nq7K51MK27v2IsLtGnE=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
-        "shasum": "1.0.2",
-        "subarg": "1.0.0",
-        "through2": "1.1.1"
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+        "shasum": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+        "subarg": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz"
       },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
         "through2": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+          "version": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "integrity": "sha1-CEfLxESfNAVXTb3M2buEG4OsNUU=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.1.14",
-            "xtend": "4.0.1"
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
           }
         }
       }
     },
     "des.js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
       }
     },
     "destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "version": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
     "detect-file": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
       "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
       "dev": true,
       "requires": {
-        "fs-exists-sync": "0.1.0"
+        "fs-exists-sync": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz"
       }
     },
     "detect-indent": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+      "version": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
       "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1",
-        "minimist": "1.2.0",
-        "repeating": "1.1.3"
+        "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "repeating": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
       }
     },
     "detect-newline": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+      "version": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true
     },
     "detective": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
+      "version": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
       "integrity": "sha1-blqMaybmx6JUsca210kNmOyR7dE=",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13",
-        "defined": "1.0.0"
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+        "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
       }
     },
     "dev-ip": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
       "integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA=",
       "dev": true
     },
     "diagnostics": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.0.1.tgz",
       "integrity": "sha1-rM2wgMgrsl0N1zQwqeaof7tDFUE=",
       "dev": true,
       "requires": {
-        "colorspace": "1.0.1",
-        "enabled": "1.0.2",
-        "kuler": "0.0.0"
+        "colorspace": "https://registry.npmjs.org/colorspace/-/colorspace-1.0.1.tgz",
+        "enabled": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+        "kuler": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz"
       }
     },
     "diffie-hellman": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+      "version": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.0",
-        "randombytes": "2.0.5"
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+        "miller-rabin": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
+        "randombytes": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz"
       }
     },
     "doctrine": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+      "version": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
       "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
       }
     },
     "dom-serializer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+        "entities": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
       },
       "dependencies": {
         "domelementtype": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "version": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
           "dev": true
         }
       }
     },
     "domain-browser": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+      "version": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
       "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
       "dev": true
     },
     "domelementtype": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "version": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
       "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
       "dev": true
     },
     "domhandler": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+      "version": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
       }
     },
     "domutils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+      "version": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
       "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
       }
     },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "dev": true
+    },
     "duplexer2": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+      "version": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
       },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
       }
     },
     "duplexify": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
-      "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
+      "version": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
+      "integrity": "sha1-ThUWvmiDi8kKSZlPCzmm5ZYL780=",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "stream-shift": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz"
       },
       "dependencies": {
         "end-of-stream": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+          "version": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
           "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
           "dev": true,
           "requires": {
-            "once": "1.4.0"
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
           }
         }
       }
     },
     "easy-extender": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.2.tgz",
+      "version": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.2.tgz",
       "integrity": "sha1-PTJI/r4rFZYHMW2PnPSRwWZIIh0=",
       "dev": true,
       "requires": {
-        "lodash": "3.10.1"
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
       }
     },
     "eazy-logger": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.0.2.tgz",
+      "version": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.0.2.tgz",
       "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
       "dev": true,
       "requires": {
-        "tfunk": "3.1.0"
+        "tfunk": "https://registry.npmjs.org/tfunk/-/tfunk-3.1.0.tgz"
       }
     },
     "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
       }
     },
     "ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.18",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz",
+      "version": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz",
       "integrity": "sha1-PcyZ2j5rZl9qu8ccKK1Ros1zGpw=",
       "dev": true
     },
     "elliptic": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+      "version": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.3",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+        "brorand": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+        "hash.js": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+        "hmac-drbg": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+        "minimalistic-crypto-utils": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
       }
     },
     "emits": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/emits/-/emits-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/emits/-/emits-1.0.2.tgz",
       "integrity": "sha1-2yDsZmgyUHHDE0QeMM/ipp6nOFk=",
       "dev": true
     },
     "emitter-steward": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/emitter-steward/-/emitter-steward-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/emitter-steward/-/emitter-steward-1.0.0.tgz",
       "integrity": "sha1-80Ea3pdYp1Zd+Eiy2gy70bRsvWQ=",
       "dev": true
     },
     "enabled": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "dev": true,
       "requires": {
-        "env-variable": "0.0.3"
+        "env-variable": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.3.tgz"
       }
     },
     "encodeurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
       "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
       "dev": true
     },
     "end-of-stream": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+      "version": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
       "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
       "dev": true,
       "requires": {
-        "once": "1.3.3"
+        "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
       },
       "dependencies": {
         "once": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
           }
         }
       }
     },
     "engine.io": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.0.tgz",
+      "version": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.0.tgz",
       "integrity": "sha1-PutfJky3XbvsG6rqJtYfWk6s4qo=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.3",
-        "base64id": "0.1.0",
-        "cookie": "0.3.1",
-        "debug": "2.3.3",
-        "engine.io-parser": "1.3.1",
-        "ws": "1.1.1"
+        "accepts": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+        "base64id": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
+        "cookie": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+        "engine.io-parser": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.1.tgz",
+        "ws": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz"
       },
       "dependencies": {
         "accepts": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+          "version": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
           "dev": true,
           "requires": {
-            "mime-types": "2.1.16",
-            "negotiator": "0.6.1"
+            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+            "negotiator": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
           }
         },
         "debug": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "version": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
           "dev": true,
           "requires": {
-            "ms": "0.7.2"
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
           }
         },
         "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
           "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
           "dev": true
         }
       }
     },
     "engine.io-client": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.0.tgz",
+      "version": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.0.tgz",
       "integrity": "sha1-e3MOQSdBQIdZbZvjyI0rxf22z1w=",
       "dev": true,
       "requires": {
-        "component-emitter": "1.2.1",
-        "component-inherit": "0.0.3",
-        "debug": "2.3.3",
-        "engine.io-parser": "1.3.1",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "parsejson": "0.0.3",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
-        "ws": "1.1.1",
-        "xmlhttprequest-ssl": "1.5.3",
-        "yeast": "0.1.2"
+        "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+        "component-inherit": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+        "engine.io-parser": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.1.tgz",
+        "has-cors": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+        "indexof": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+        "parsejson": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
+        "parseqs": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+        "parseuri": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+        "ws": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
+        "xmlhttprequest-ssl": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
+        "yeast": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz"
       },
       "dependencies": {
         "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "version": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
           "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
           "dev": true
         },
         "debug": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "version": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
           "dev": true,
           "requires": {
-            "ms": "0.7.2"
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
           }
         },
         "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
           "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
           "dev": true
         }
       }
     },
     "engine.io-parser": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.1.tgz",
+      "version": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.1.tgz",
       "integrity": "sha1-lVTxrjMQfW+9FwylRm0vgz9qB88=",
       "dev": true,
       "requires": {
-        "after": "0.8.1",
-        "arraybuffer.slice": "0.0.6",
-        "base64-arraybuffer": "0.1.5",
-        "blob": "0.0.4",
-        "has-binary": "0.1.6",
-        "wtf-8": "1.0.0"
+        "after": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
+        "arraybuffer.slice": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+        "base64-arraybuffer": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+        "blob": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+        "has-binary": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
+        "wtf-8": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz"
       },
       "dependencies": {
         "has-binary": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
+          "version": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
           "integrity": "sha1-JTJvOc+k9hath4eJTjryz7x7bhA=",
           "dev": true,
           "requires": {
-            "isarray": "0.0.1"
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
           }
         },
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         }
       }
     },
     "entities": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
       "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
       "dev": true
     },
     "env-variable": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.3.tgz",
+      "version": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.3.tgz",
       "integrity": "sha1-uGwWQb5WECZ9UG8YBx6nbXBwl8s=",
       "dev": true
     },
     "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
       }
     },
     "es5-ext": {
-      "version": "0.10.29",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.29.tgz",
-      "integrity": "sha512-KXla9NXo5sdaEkGSmbFPYgjH6m75kxsthL6GDRSug/Y2OiMoYm0I9giL39j4cgmaFmAbkIFJ6gG+SGKnLSmOvA==",
+      "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.29.tgz",
+      "integrity": "sha1-do6y38SVe881+gVo8ZOrce3lP9g=",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1"
+        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
       }
     },
     "es6-iterator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.29",
-        "es6-symbol": "3.1.1"
+        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.29.tgz",
+        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
       }
     },
     "es6-map": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "version": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.29",
-        "es6-iterator": "2.0.1",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.29.tgz",
+        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+        "es6-set": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+        "event-emitter": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.2.tgz",
+      "integrity": "sha1-9yLXdpr4i9M7wT7GYF4fkpZrgtk=",
+      "dev": true
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "4.2.2"
       }
     },
     "es6-set": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "version": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.29",
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.29.tgz",
+        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+        "event-emitter": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
       }
     },
     "es6-symbol": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.29"
+        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.29.tgz"
       }
     },
     "es6-weak-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "version": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.29",
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1"
+        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.29.tgz",
+        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
       }
     },
     "escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
     },
     "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "escope": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "version": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
+        "es6-map": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+        "es6-weak-map": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+        "esrecurse": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
       }
     },
     "eslint": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+      "version": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
       "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "concat-stream": "1.4.10",
-        "debug": "2.6.8",
-        "doctrine": "1.5.0",
-        "es6-map": "0.1.5",
-        "escope": "3.6.0",
-        "espree": "3.5.0",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "1.3.1",
-        "glob": "7.1.2",
-        "globals": "9.18.0",
-        "ignore": "3.3.3",
-        "imurmurhash": "0.1.4",
-        "inquirer": "0.12.0",
-        "is-my-json-valid": "2.16.1",
-        "is-resolvable": "1.0.0",
-        "js-yaml": "3.9.1",
-        "json-stable-stringify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "optionator": "0.8.2",
-        "path-is-absolute": "1.0.1",
-        "path-is-inside": "1.0.2",
-        "pluralize": "1.2.1",
-        "progress": "1.1.8",
-        "require-uncached": "1.0.3",
-        "shelljs": "0.6.1",
-        "strip-json-comments": "1.0.4",
-        "table": "3.8.3",
-        "text-table": "0.2.0",
-        "user-home": "2.0.0"
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+        "es6-map": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+        "escope": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+        "espree": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
+        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+        "file-entry-cache": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+        "globals": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+        "ignore": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
+        "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+        "inquirer": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+        "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+        "is-resolvable": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
+        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+        "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+        "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+        "pluralize": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+        "progress": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+        "require-uncached": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+        "shelljs": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
+        "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+        "table": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+        "text-table": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+        "user-home": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
           }
         },
         "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "version": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
           "dev": true
         },
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         },
         "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
           }
         },
         "user-home": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+          "version": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
           "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
           "dev": true,
           "requires": {
-            "os-homedir": "1.0.2"
+            "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
           }
         }
       }
     },
     "eslint-plugin-react": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-5.2.2.tgz",
+      "version": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-5.2.2.tgz",
       "integrity": "sha1-fbBo4fVIf2hx5N7vNqOBwwPqwWE=",
       "dev": true,
       "requires": {
-        "doctrine": "1.5.0",
-        "jsx-ast-utils": "1.4.1"
+        "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+        "jsx-ast-utils": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz"
       }
     },
     "espree": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
+      "version": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
       "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
       "dev": true,
       "requires": {
-        "acorn": "5.1.1",
-        "acorn-jsx": "3.0.1"
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+        "acorn-jsx": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
-          "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
+          "version": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+          "integrity": "sha1-U/4WERH5EquZnuiHqQoLxSgi/XU=",
           "dev": true
         }
       }
@@ -2707,414 +2570,386 @@
       "dev": true
     },
     "esrecurse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+      "version": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
+        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
       }
     },
     "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
     "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "etag": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+      "version": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
       "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE=",
       "dev": true
     },
     "event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "version": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.29"
+        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.29.tgz"
+      }
+    },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "dev": true,
+      "requires": {
+        "duplexer": "0.1.1",
+        "from": "0.1.7",
+        "map-stream": "0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3.3",
+        "stream-combiner": "0.0.4",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
       }
     },
     "eventemitter3": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+      "version": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
       "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
       "dev": true
     },
     "events": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
       "integrity": "sha1-dYSdz+k9EPsFfDAFWv29UdBqjiQ=",
       "dev": true
     },
     "evp_bytestokey": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.2.tgz",
-      "integrity": "sha512-ni0r0lrm7AOzsh2qC5mi9sj8S0gmj5fLNjfFpxN05FB4tAVZEKotbkjOtLPqTCX/CXT7NsUr6juZb4IFJeNNdA==",
+      "version": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.2.tgz",
+      "integrity": "sha1-9mu4js1X9xp2aCHiAoPqOMaL+Ao=",
       "dev": true,
       "requires": {
-        "md5.js": "1.3.4",
-        "safe-buffer": "5.1.1"
+        "md5.js": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
       }
     },
     "exit-hook": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
       "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
     "expand-brackets": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "version": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
       }
     },
     "expand-range": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "version": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
       }
     },
     "expand-tilde": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+      "version": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
       "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
       }
     },
     "express": {
-      "version": "2.5.11",
-      "resolved": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
+      "version": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
       "integrity": "sha1-TOjqHzY15p5J8Ou0l7aksKUc5vA=",
       "dev": true,
       "requires": {
-        "connect": "1.9.2",
-        "mime": "1.2.4",
-        "mkdirp": "0.3.0",
-        "qs": "0.4.2"
+        "connect": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
+        "mime": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+        "qs": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz"
       },
       "dependencies": {
         "connect": {
-          "version": "1.9.2",
-          "resolved": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
+          "version": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
           "integrity": "sha1-QogKIulDiuWait105Df1iujlKAc=",
           "dev": true,
           "requires": {
-            "formidable": "1.0.17",
-            "mime": "1.2.4",
-            "qs": "0.4.2"
+            "formidable": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
+            "mime": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz",
+            "qs": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz"
           }
         },
         "mkdirp": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
           "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
           "dev": true
         },
         "qs": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz",
+          "version": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz",
           "integrity": "sha1-PKxMhh43GoycR3CsI82o3mObjl8=",
           "dev": true
         }
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "version": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
     },
     "extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true,
       "requires": {
-        "is-extendable": "0.1.1"
+        "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
       }
     },
     "extendible": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/extendible/-/extendible-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/extendible/-/extendible-0.1.1.tgz",
       "integrity": "sha1-4qN+2HEp+0+VM+io11BiMKU5yQU=",
       "dev": true
     },
     "extglob": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "version": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
       }
     },
     "extract-github": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/extract-github/-/extract-github-0.0.5.tgz",
+      "version": "https://registry.npmjs.org/extract-github/-/extract-github-0.0.5.tgz",
       "integrity": "sha1-9UJTbbjBm5g6O+yduW0u8qX/GoY=",
       "dev": true
     },
     "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
     "fancy-log": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+      "version": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
       "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "time-stamp": "1.1.0"
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "time-stamp": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz"
       }
     },
     "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "version": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "figures": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "version": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
       }
     },
     "file-entry-cache": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+      "version": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
       "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.2.2",
-        "object-assign": "4.1.1"
+        "flat-cache": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
       }
     },
     "filename-regex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
       "dev": true
     },
     "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+      "version": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+        "randomatic": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+        "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+        "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
       }
     },
     "finalhandler": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
+      "version": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
       "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
       "dev": true,
       "requires": {
-        "debug": "2.2.0",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+        "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+        "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+        "unpipe": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
       },
       "dependencies": {
         "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "dev": true,
           "requires": {
-            "ms": "0.7.1"
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
           }
         },
         "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
           "dev": true
         }
       }
     },
     "find-index": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
       "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
       "dev": true
     },
     "find-up": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
       },
       "dependencies": {
         "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "version": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
           }
         }
       }
     },
     "findup-sync": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
+      "version": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
       "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
       "dev": true,
       "requires": {
-        "detect-file": "0.1.0",
-        "is-glob": "2.0.1",
-        "micromatch": "2.3.11",
-        "resolve-dir": "0.1.1"
+        "detect-file": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "resolve-dir": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz"
       }
     },
     "fined": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
       "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
       "dev": true,
       "requires": {
-        "expand-tilde": "2.0.2",
-        "is-plain-object": "2.0.4",
-        "object.defaults": "1.1.0",
-        "object.pick": "1.3.0",
-        "parse-filepath": "1.0.1"
+        "expand-tilde": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+        "is-plain-object": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+        "object.defaults": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+        "object.pick": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+        "parse-filepath": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz"
       },
       "dependencies": {
         "expand-tilde": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+          "version": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
           "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
           "dev": true,
           "requires": {
-            "homedir-polyfill": "1.0.1"
+            "homedir-polyfill": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz"
           }
         }
       }
     },
     "first-chunk-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
       "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
       "dev": true
     },
     "flagged-respawn": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
+      "version": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
       "integrity": "sha1-/xke3c1wiKZ1smEP/8l2vpuAdLU=",
       "dev": true
     },
     "flat-cache": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+      "version": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+        "del": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "write": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
       }
     },
     "for-in": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
     "for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "version": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
       }
     },
     "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
     "fork-stream": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz",
+      "version": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz",
       "integrity": "sha1-24Sfznf2cIpfjzhq5TOgkHtUrnA=",
       "dev": true
     },
     "form-data": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.16"
+        "asynckit": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz"
       }
     },
     "formidable": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
+      "version": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
       "integrity": "sha1-71SRSQ+UM7cF+qdyScmQKa40hVk=",
       "dev": true
     },
     "fresh": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+      "version": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
       "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8=",
       "dev": true
     },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+      "dev": true
+    },
     "fs-exists-sync": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
       "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
       "dev": true
     },
     "fs-extra": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+      "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
       "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "3.0.1",
-        "universalify": "0.1.1"
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "jsonfile": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+        "universalify": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz"
       }
     },
     "fs-readdir-recursive": {
@@ -3124,280 +2959,368 @@
       "dev": true
     },
     "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha1-EfgjGPX+e7LNIpZaEI6TBiCCFtg=",
       "dev": true,
+      "optional": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.1"
-      }
-    },
-    "function-bind": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
-      "dev": true
-    },
-    "fusing": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/fusing/-/fusing-0.2.3.tgz",
-      "integrity": "sha1-0O76+YXSuv3tRK+LGFMW9uQp4ds=",
-      "dev": true,
-      "requires": {
-        "predefine": "0.1.2"
-      }
-    },
-    "gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "dev": true,
-      "requires": {
-        "aproba": "1.1.2",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
-      }
-    },
-    "gaze": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-      "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
-      "dev": true,
-      "requires": {
-        "globule": "0.1.0"
-      }
-    },
-    "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-      "dev": true
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
-      "requires": {
-        "is-property": "1.0.2"
-      }
-    },
-    "get-caller-file": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-      "dev": true
-    },
-    "get-stdin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-      "dev": true
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0"
+        "nan": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
+        "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+          "dev": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+          "dev": true,
+          "optional": true
+        },
         "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "dev": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
           "dev": true
-        }
-      }
-    },
-    "githulk": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/githulk/-/githulk-0.0.7.tgz",
-      "integrity": "sha1-2Wyinw7EMRfFOOUh1mNWbqhLTv8=",
-      "dev": true,
-      "requires": {
-        "debug": "0.7.4",
-        "extract-github": "0.0.5",
-        "mana": "0.1.41"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+          "dev": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
-        }
-      }
-    },
-    "glob": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-      "dev": true,
-      "requires": {
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "2.0.10",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
-    },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
-      "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
-      }
-    },
-    "glob-parent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true,
-      "requires": {
-        "is-glob": "2.0.1"
-      }
-    },
-    "glob-stream": {
-      "version": "3.1.18",
-      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-      "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
-      "dev": true,
-      "requires": {
-        "glob": "4.5.3",
-        "glob2base": "0.0.12",
-        "minimatch": "2.0.10",
-        "ordered-read-streams": "0.1.0",
-        "through2": "0.6.5",
-        "unique-stream": "1.0.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "4.5.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0"
+            "delayed-stream": "1.0.0"
           }
         },
-        "isarray": {
+        "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+        "console-control-strings": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
+          "integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
             "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
           }
         },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
           "dev": true,
+          "optional": true,
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
           }
-        }
-      }
-    },
-    "glob-watcher": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-      "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
-      "dev": true,
-      "requires": {
-        "gaze": "0.5.2"
-      }
-    },
-    "glob2base": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-      "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-      "dev": true,
-      "requires": {
-        "find-index": "0.1.1"
-      }
-    },
-    "global-modules": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
-      "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
-      "dev": true,
-      "requires": {
-        "global-prefix": "0.1.5",
-        "is-windows": "0.2.0"
-      }
-    },
-    "global-prefix": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
-      "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
-      "dev": true,
-      "requires": {
-        "homedir-polyfill": "1.0.1",
-        "ini": "1.3.4",
-        "is-windows": "0.2.0",
-        "which": "1.3.0"
-      }
-    },
-    "globals": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
-      "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
-      "dev": true
-    },
-    "globby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true,
-      "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      },
-      "dependencies": {
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -3412,1226 +3335,2076 @@
             "path-is-absolute": "1.0.1"
           }
         },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+          "dev": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+          "dev": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
+          "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+          "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "dev": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+          "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+          "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+          "dev": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "dev": true
+        }
+      }
+    },
+    "fstream": {
+      "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+      }
+    },
+    "function-bind": {
+      "version": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "dev": true
+    },
+    "fusing": {
+      "version": "https://registry.npmjs.org/fusing/-/fusing-0.2.3.tgz",
+      "integrity": "sha1-0O76+YXSuv3tRK+LGFMW9uQp4ds=",
+      "dev": true,
+      "requires": {
+        "predefine": "https://registry.npmjs.org/predefine/-/predefine-0.1.2.tgz"
+      }
+    },
+    "gauge": {
+      "version": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
+      "requires": {
+        "aproba": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
+        "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+        "has-unicode": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+        "wide-align": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz"
+      }
+    },
+    "gaze": {
+      "version": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+      "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
+      "dev": true,
+      "requires": {
+        "globule": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz"
+      }
+    },
+    "generate-function": {
+      "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
+    },
+    "generate-object-property": {
+      "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+      }
+    },
+    "get-caller-file": {
+      "version": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "githulk": {
+      "version": "https://registry.npmjs.org/githulk/-/githulk-0.0.7.tgz",
+      "integrity": "sha1-2Wyinw7EMRfFOOUh1mNWbqhLTv8=",
+      "dev": true,
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+        "extract-github": "https://registry.npmjs.org/extract-github/-/extract-github-0.0.5.tgz",
+        "mana": "https://registry.npmjs.org/mana/-/mana-0.1.41.tgz"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+          "dev": true
+        }
+      }
+    },
+    "glob": {
+      "version": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+      "dev": true,
+      "requires": {
+        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+      }
+    },
+    "glob-base": {
+      "version": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "dev": true,
+      "requires": {
+        "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+      }
+    },
+    "glob-parent": {
+      "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "dev": true,
+      "requires": {
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+      }
+    },
+    "glob-stream": {
+      "version": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+      "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
+      "dev": true,
+      "requires": {
+        "glob": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+        "glob2base": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+        "ordered-read-streams": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+        "unique-stream": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+          "dev": true,
+          "requires": {
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+          }
+        },
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
+        "through2": {
+          "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          }
+        }
+      }
+    },
+    "glob-watcher": {
+      "version": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+      "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
+      "dev": true,
+      "requires": {
+        "gaze": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz"
+      }
+    },
+    "glob2base": {
+      "version": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+      "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
+      "dev": true,
+      "requires": {
+        "find-index": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
+      }
+    },
+    "global-modules": {
+      "version": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+      "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+      "dev": true,
+      "requires": {
+        "global-prefix": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+        "is-windows": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz"
+      }
+    },
+    "global-prefix": {
+      "version": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+      "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+        "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+        "is-windows": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+        "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
+      }
+    },
+    "globals": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+      "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
+      "dev": true
+    },
+    "globby": {
+      "version": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "requires": {
+        "array-union": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        },
+        "minimatch": {
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
           }
         }
       }
     },
     "globule": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
       "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
       "dev": true,
       "requires": {
-        "glob": "3.1.21",
-        "lodash": "1.0.2",
-        "minimatch": "0.2.14"
+        "glob": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
       },
       "dependencies": {
         "glob": {
-          "version": "3.1.21",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "version": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "dev": true,
           "requires": {
-            "graceful-fs": "1.2.3",
-            "inherits": "1.0.2",
-            "minimatch": "0.2.14"
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
           }
         },
         "graceful-fs": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
           "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
           "dev": true
         },
         "inherits": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+          "version": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
           "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
           "dev": true
         },
         "lodash": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+          "version": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
           "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
           "dev": true
         },
         "minimatch": {
-          "version": "0.2.14",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+            "sigmund": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
           }
         }
       }
     },
     "glogg": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
       "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
       "dev": true,
       "requires": {
-        "sparkles": "1.0.0"
+        "sparkles": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
     "growly": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+      "version": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
     "gulp": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
+      "version": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
       "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
       "dev": true,
       "requires": {
-        "archy": "1.0.0",
-        "chalk": "1.1.3",
-        "deprecated": "0.0.1",
-        "gulp-util": "3.0.8",
-        "interpret": "1.0.3",
-        "liftoff": "2.3.0",
-        "minimist": "1.2.0",
-        "orchestrator": "0.3.8",
-        "pretty-hrtime": "1.0.3",
-        "semver": "4.3.6",
-        "tildify": "1.2.0",
-        "v8flags": "2.1.1",
-        "vinyl-fs": "0.3.14"
+        "archy": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "deprecated": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "interpret": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+        "liftoff": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "orchestrator": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
+        "pretty-hrtime": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+        "tildify": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
+        "v8flags": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+        "vinyl-fs": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz"
       },
       "dependencies": {
         "semver": {
-          "version": "4.3.6",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "version": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
           "dev": true
         }
       }
     },
     "gulp-autoprefixer": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-3.1.1.tgz",
+      "version": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-3.1.1.tgz",
       "integrity": "sha1-dSMAUc0NFxND14O36bXREg7u+bA=",
       "dev": true,
       "requires": {
-        "autoprefixer": "6.7.7",
-        "gulp-util": "3.0.8",
-        "postcss": "5.2.17",
-        "through2": "2.0.3",
-        "vinyl-sourcemaps-apply": "0.2.1"
+        "autoprefixer": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "vinyl-sourcemaps-apply": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz"
+      }
+    },
+    "gulp-bump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-bump/-/gulp-bump-3.0.0.tgz",
+      "integrity": "sha512-w/1qP+pa+0wZhMg2eSZEfmIZHlVaHqRyJYMtSOL8Jkby6Lne+iIm0PIkyYBZs7nGKDriYGYZuh/+lQ7InHVwIQ==",
+      "dev": true,
+      "requires": {
+        "bump-regex": "3.0.0",
+        "plugin-error": "0.1.2",
+        "plugin-log": "0.1.0",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
       }
     },
     "gulp-cached": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/gulp-cached/-/gulp-cached-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/gulp-cached/-/gulp-cached-1.1.1.tgz",
       "integrity": "sha1-/nzU+H83YB5gc8/t7lwr2vi2rM4=",
       "dev": true,
       "requires": {
-        "lodash.defaults": "4.2.0",
-        "through2": "2.0.3"
+        "lodash.defaults": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
       }
     },
     "gulp-concat": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
+      "version": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
       "integrity": "sha1-Yz0WyV2IUEYorQJmVmPO5aR5M1M=",
       "dev": true,
       "requires": {
-        "concat-with-sourcemaps": "1.0.4",
-        "through2": "2.0.3",
-        "vinyl": "2.1.0"
+        "concat-with-sourcemaps": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz"
       },
       "dependencies": {
         "clone": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+          "version": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
           "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
           "dev": true
         },
         "clone-stats": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
           "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
           "dev": true
         },
         "replace-ext": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
           "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
           "dev": true
         },
         "vinyl": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
+          "version": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "dev": true,
           "requires": {
-            "clone": "2.1.1",
-            "clone-buffer": "1.0.0",
-            "clone-stats": "1.0.0",
-            "cloneable-readable": "1.0.0",
-            "remove-trailing-separator": "1.1.0",
-            "replace-ext": "1.0.0"
+            "clone": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+            "clone-buffer": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+            "cloneable-readable": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
+            "remove-trailing-separator": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz"
           }
         }
       }
     },
     "gulp-copy": {
       "version": "1.0.1",
-      "from": "gulp-copy@latest",
       "resolved": "https://registry.npmjs.org/gulp-copy/-/gulp-copy-1.0.1.tgz",
-      "dev": true
+      "integrity": "sha1-93c724Ab5Mj5EjtXW48zun2x+d8=",
+      "dev": true,
+      "requires": {
+        "gulp": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
     },
     "gulp-debug": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/gulp-debug/-/gulp-debug-2.1.2.tgz",
+      "version": "https://registry.npmjs.org/gulp-debug/-/gulp-debug-2.1.2.tgz",
       "integrity": "sha1-L1/l9kvNH0zxicFg4IDIrQZUMJQ=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "gulp-util": "3.0.8",
-        "object-assign": "4.1.1",
-        "plur": "2.1.2",
-        "stringify-object": "2.4.0",
-        "through2": "2.0.3",
-        "tildify": "1.2.0"
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "plur": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+        "stringify-object": "https://registry.npmjs.org/stringify-object/-/stringify-object-2.4.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "tildify": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz"
       }
     },
     "gulp-environments": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/gulp-environments/-/gulp-environments-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/gulp-environments/-/gulp-environments-0.1.2.tgz",
       "integrity": "sha1-hkYQc5IZNYKv+RnVPeMwJ3f/tus=",
       "dev": true,
       "requires": {
-        "gulp-if": "2.0.2",
-        "yargs": "5.0.0"
+        "gulp-if": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+        "yargs": "https://registry.npmjs.org/yargs/-/yargs-5.0.0.tgz"
       },
       "dependencies": {
         "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         },
         "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
           }
         },
         "window-size": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+          "version": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
           "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
           "dev": true
         },
         "yargs": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-5.0.0.tgz",
+          "version": "https://registry.npmjs.org/yargs/-/yargs-5.0.0.tgz",
           "integrity": "sha1-M1UUSXfQV1fbuG1uOOwFYSOzpm4=",
           "dev": true,
           "requires": {
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "lodash.assign": "4.2.0",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "window-size": "0.2.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "3.2.0"
+            "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+            "lodash.assign": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+            "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+            "require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "which-module": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+            "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-3.2.0.tgz"
           }
         },
         "yargs-parser": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-3.2.0.tgz",
+          "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-3.2.0.tgz",
           "integrity": "sha1-UIE1XRnZ0MjF2BrakIy05tGGZk8=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0",
-            "lodash.assign": "4.2.0"
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+            "lodash.assign": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
           }
         }
       }
     },
     "gulp-filter": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-3.0.1.tgz",
+      "version": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-3.0.1.tgz",
       "integrity": "sha1-fG/85bVj6J3nqQ387/FuyKjLFWI=",
       "dev": true,
       "requires": {
-        "gulp-util": "3.0.8",
-        "multimatch": "2.1.0",
-        "streamfilter": "1.0.5"
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "multimatch": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+        "streamfilter": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.5.tgz"
       }
     },
     "gulp-header": {
-      "version": "1.8.9",
-      "resolved": "https://registry.npmjs.org/gulp-header/-/gulp-header-1.8.9.tgz",
+      "version": "https://registry.npmjs.org/gulp-header/-/gulp-header-1.8.9.tgz",
       "integrity": "sha1-yfEP7gYy2B6Tl4nG7PRaFRvzCYs=",
       "dev": true,
       "requires": {
-        "concat-with-sourcemaps": "1.0.4",
-        "gulp-util": "3.0.8",
-        "object-assign": "4.1.1",
-        "through2": "2.0.3"
+        "concat-with-sourcemaps": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
       }
     },
     "gulp-if": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+      "version": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
       "integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
       "dev": true,
       "requires": {
-        "gulp-match": "1.0.3",
-        "ternary-stream": "2.0.1",
-        "through2": "2.0.3"
+        "gulp-match": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+        "ternary-stream": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
       }
     },
     "gulp-match": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
       "integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
       "dev": true,
       "requires": {
-        "minimatch": "3.0.4"
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
       },
       "dependencies": {
         "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
           }
         }
       }
     },
     "gulp-notify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/gulp-notify/-/gulp-notify-2.2.0.tgz",
+      "version": "https://registry.npmjs.org/gulp-notify/-/gulp-notify-2.2.0.tgz",
       "integrity": "sha1-BGyChcKS6X7tThWgCcJsu+XO8TU=",
       "dev": true,
       "requires": {
-        "gulp-util": "3.0.8",
-        "lodash.template": "3.6.2",
-        "node-notifier": "4.6.1",
-        "node.extend": "1.1.6",
-        "through2": "0.6.5"
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+        "node-notifier": "https://registry.npmjs.org/node-notifier/-/node-notifier-4.6.1.tgz",
+        "node.extend": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
       },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
         "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
           }
         }
       }
     },
     "gulp-pixrem": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-pixrem/-/gulp-pixrem-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/gulp-pixrem/-/gulp-pixrem-1.0.0.tgz",
       "integrity": "sha1-b0p1tPtTOBWGJh4zkfywzArjLcI=",
       "dev": true,
       "requires": {
-        "gulp-util": "3.0.8",
-        "object-assign": "4.1.1",
-        "pixrem": "3.0.2",
-        "postcss": "5.2.17",
-        "through2": "2.0.3",
-        "vinyl-sourcemaps-apply": "0.1.4"
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "pixrem": "https://registry.npmjs.org/pixrem/-/pixrem-3.0.2.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "vinyl-sourcemaps-apply": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz"
       },
       "dependencies": {
         "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
           }
         },
         "vinyl-sourcemaps-apply": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
+          "version": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
           "integrity": "sha1-xfy9Q+LyOEI8LcmL3db3m3K8NFs=",
           "dev": true,
           "requires": {
-            "source-map": "0.1.43"
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
           }
         }
       }
     },
     "gulp-plumber": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.1.0.tgz",
       "integrity": "sha1-8SF2wtBCL2AwbCQv/2oBo5T6ugk=",
       "dev": true,
       "requires": {
-        "gulp-util": "3.0.8",
-        "through2": "2.0.3"
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
       }
     },
     "gulp-rename": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
+      "version": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
       "integrity": "sha1-OtRCh2PwXidk3sHGfYaNsnVoeBc=",
       "dev": true
     },
     "gulp-run": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/gulp-run/-/gulp-run-1.7.1.tgz",
+      "version": "https://registry.npmjs.org/gulp-run/-/gulp-run-1.7.1.tgz",
       "integrity": "sha1-4XwKy3wwtuKu7iPAREKpbAys7/o=",
       "dev": true,
       "requires": {
-        "gulp-util": "3.0.8",
-        "lodash.defaults": "4.2.0",
-        "lodash.template": "4.4.0",
-        "vinyl": "0.4.6"
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "lodash.defaults": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+        "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
       },
       "dependencies": {
         "clone": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "version": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
           "dev": true
         },
         "lodash.template": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+          "version": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
           "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "3.0.0",
-            "lodash.templatesettings": "4.1.0"
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+            "lodash.templatesettings": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz"
           }
         },
         "lodash.templatesettings": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+          "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
           "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "3.0.0"
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
           }
         },
         "vinyl": {
-          "version": "0.4.6",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
           "requires": {
-            "clone": "0.2.0",
-            "clone-stats": "0.0.1"
+            "clone": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
           }
         }
       }
     },
+    "gulp-s3-upload": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/gulp-s3-upload/-/gulp-s3-upload-1.6.6.tgz",
+      "integrity": "sha1-axnZVjB1q3xHq+BrDTN/PqapGYo=",
+      "dev": true,
+      "requires": {
+        "aws-sdk": "2.175.0",
+        "event-stream": "3.3.4",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "hasha": "3.0.0",
+        "https-proxy-agent": "2.1.1",
+        "mime": "1.6.0",
+        "underscore": "1.8.3"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
+          "dev": true
+        },
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+          "dev": true
+        }
+      }
+    },
     "gulp-sass": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-3.1.0.tgz",
+      "version": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-3.1.0.tgz",
       "integrity": "sha1-U9xLaKH13f5EJKtMJHZVJpqLdLc=",
       "dev": true,
       "requires": {
-        "gulp-util": "3.0.8",
-        "lodash.clonedeep": "4.5.0",
-        "node-sass": "4.5.3",
-        "through2": "2.0.3",
-        "vinyl-sourcemaps-apply": "0.2.1"
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "lodash.clonedeep": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+        "node-sass": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "vinyl-sourcemaps-apply": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz"
       },
       "dependencies": {
         "lodash.clonedeep": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+          "version": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
           "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
           "dev": true
         }
       }
     },
     "gulp-sourcemaps": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.12.0.tgz",
+      "version": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.12.0.tgz",
       "integrity": "sha1-eG+XyUoPloSSRl1wVY4EJCxnlZg=",
       "dev": true,
       "requires": {
-        "@gulp-sourcemaps/map-sources": "1.0.0",
-        "acorn": "4.0.13",
-        "convert-source-map": "1.5.0",
-        "css": "2.2.1",
-        "debug-fabulous": "0.0.4",
-        "detect-newline": "2.1.0",
-        "graceful-fs": "4.1.11",
-        "source-map": "0.5.7",
-        "strip-bom": "2.0.0",
-        "through2": "2.0.3",
-        "vinyl": "1.2.0"
+        "@gulp-sourcemaps/map-sources": "https://registry.npmjs.org/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+        "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+        "css": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
+        "debug-fabulous": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
+        "detect-newline": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz"
       },
       "dependencies": {
         "vinyl": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+          "version": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
           "requires": {
-            "clone": "1.0.2",
-            "clone-stats": "0.0.1",
-            "replace-ext": "0.0.1"
+            "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+            "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
           }
         }
       }
     },
     "gulp-svgmin": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/gulp-svgmin/-/gulp-svgmin-1.2.4.tgz",
+      "version": "https://registry.npmjs.org/gulp-svgmin/-/gulp-svgmin-1.2.4.tgz",
       "integrity": "sha1-pKqeJhXPEQXvVVrqhuhilswg4nM=",
       "dev": true,
       "requires": {
-        "gulp-util": "3.0.8",
-        "svgo": "0.7.2"
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "svgo": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz"
       }
     },
     "gulp-svgstore": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/gulp-svgstore/-/gulp-svgstore-5.0.5.tgz",
+      "version": "https://registry.npmjs.org/gulp-svgstore/-/gulp-svgstore-5.0.5.tgz",
       "integrity": "sha1-StXOxddToWJKAOSc71/IakXZcyc=",
       "dev": true,
       "requires": {
-        "cheerio": "0.19.0",
-        "gulp-util": "3.0.8"
+        "cheerio": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz"
       }
     },
     "gulp-uglify": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-1.5.4.tgz",
+      "version": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-1.5.4.tgz",
       "integrity": "sha1-UkeI2HZm0J+dDCH7IXf5ADmmWMk=",
       "dev": true,
       "requires": {
-        "deap": "1.0.0",
-        "fancy-log": "1.3.0",
-        "gulp-util": "3.0.8",
-        "isobject": "2.1.0",
-        "through2": "2.0.3",
-        "uglify-js": "2.6.4",
-        "uglify-save-license": "0.4.1",
-        "vinyl-sourcemaps-apply": "0.2.1"
+        "deap": "https://registry.npmjs.org/deap/-/deap-1.0.0.tgz",
+        "fancy-log": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
+        "uglify-save-license": "https://registry.npmjs.org/uglify-save-license/-/uglify-save-license-0.4.1.tgz",
+        "vinyl-sourcemaps-apply": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz"
       }
     },
     "gulp-util": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+      "version": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
       "dev": true,
       "requires": {
-        "array-differ": "1.0.0",
-        "array-uniq": "1.0.3",
-        "beeper": "1.1.1",
-        "chalk": "1.1.3",
-        "dateformat": "2.0.0",
-        "fancy-log": "1.3.0",
-        "gulplog": "1.0.0",
-        "has-gulplog": "0.1.0",
-        "lodash._reescape": "3.0.0",
-        "lodash._reevaluate": "3.0.0",
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.template": "3.6.2",
-        "minimist": "1.2.0",
-        "multipipe": "0.1.2",
-        "object-assign": "3.0.0",
-        "replace-ext": "0.0.1",
-        "through2": "2.0.3",
-        "vinyl": "0.5.3"
+        "array-differ": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+        "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+        "beeper": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+        "fancy-log": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+        "gulplog": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+        "has-gulplog": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+        "lodash._reescape": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+        "lodash._reevaluate": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+        "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+        "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "multipipe": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+        "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
       },
       "dependencies": {
         "object-assign": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "version": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
           "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
           "dev": true
         }
       }
     },
     "gulp-watch": {
-      "version": "4.3.11",
-      "resolved": "https://registry.npmjs.org/gulp-watch/-/gulp-watch-4.3.11.tgz",
+      "version": "https://registry.npmjs.org/gulp-watch/-/gulp-watch-4.3.11.tgz",
       "integrity": "sha1-Fi/FY96fx3DpH5p845VVE6mhGMA=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "chokidar": "1.7.0",
-        "glob-parent": "3.1.0",
-        "gulp-util": "3.0.8",
-        "object-assign": "4.1.1",
-        "path-is-absolute": "1.0.1",
-        "readable-stream": "2.3.3",
-        "slash": "1.0.0",
-        "vinyl": "1.2.0",
-        "vinyl-file": "2.0.0"
+        "anymatch": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+        "chokidar": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+        "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "slash": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+        "vinyl-file": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz"
       },
       "dependencies": {
         "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+            "path-dirname": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz"
           }
         },
         "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
           "dev": true
         },
         "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "version": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
           }
         },
         "vinyl": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+          "version": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
           "requires": {
-            "clone": "1.0.2",
-            "clone-stats": "0.0.1",
-            "replace-ext": "0.0.1"
+            "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+            "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
           }
         }
       }
     },
     "gulplog": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "dev": true,
       "requires": {
-        "glogg": "1.0.0"
+        "glogg": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz"
       }
     },
     "har-schema": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+      "version": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
       "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
       "dev": true
     },
     "har-validator": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+      "version": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
       "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "har-schema": "1.0.5"
+        "ajv": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+        "har-schema": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
       }
     },
     "has": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.0"
+        "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
       }
     },
     "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
       }
     },
     "has-binary": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+      "version": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
       "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
       "dev": true,
       "requires": {
-        "isarray": "0.0.1"
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
       },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         }
       }
     },
     "has-cors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
       "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
       "dev": true
     },
     "has-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
     "has-gulplog": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
       "dev": true,
       "requires": {
-        "sparkles": "1.0.0"
+        "sparkles": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
       }
     },
     "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
     "hash-base": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+      "version": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
       }
     },
     "hash.js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+      "version": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+      "integrity": "sha1-NA3tvmKQGHFRweodd3o0SJNd+EY=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+      }
+    },
+    "hasha": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
+      "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+      "dev": true,
+      "requires": {
+        "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
       }
     },
     "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "dev": true,
       "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
+        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+        "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+        "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
       }
     },
     "hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "1.1.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+        "minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+        "minimalistic-crypto-utils": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
       }
     },
     "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "dev": true
     },
     "home-or-tmp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
       "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2",
-        "user-home": "1.1.1"
+        "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+        "user-home": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
       }
     },
     "homedir-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "1.0.0"
+        "parse-passwd": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz"
       }
     },
     "hosted-git-info": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
       "dev": true
     },
     "htmlescape": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
       "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
       "dev": true
     },
     "htmlparser2": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "version": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.3.0",
-        "domutils": "1.5.1",
-        "entities": "1.0.0",
-        "readable-stream": "1.1.14"
+        "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+        "domhandler": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+        "domutils": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+        "entities": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
       },
       "dependencies": {
         "domutils": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+          "version": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
           "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
           "dev": true,
           "requires": {
-            "dom-serializer": "0.1.0",
-            "domelementtype": "1.3.0"
+            "dom-serializer": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+            "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
           }
         },
         "entities": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
           "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
           "dev": true
         },
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
       }
     },
     "http-browserify": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+      "version": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
       "integrity": "sha1-M3la3nLfiKz7/TZ3PO/tp2RzWyA=",
       "dev": true,
       "requires": {
-        "Base64": "0.2.1",
-        "inherits": "2.0.3"
+        "Base64": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
       }
     },
     "http-errors": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+      "version": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
       "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "setprototypeof": "1.0.2",
-        "statuses": "1.3.1"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "setprototypeof": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
+        "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
       }
     },
     "http-proxy": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
+      "version": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
       "integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
       "dev": true,
       "requires": {
-        "eventemitter3": "1.2.0",
-        "requires-port": "1.0.0"
+        "eventemitter3": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+        "requires-port": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
       }
     },
     "http-signature": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "dev": true,
       "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+        "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+        "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz"
       }
     },
     "https-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
       "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
       "dev": true
     },
+    "https-proxy-agent": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz",
+      "integrity": "sha1-p85DgqG6gmbuhIV4d4Ei1JEmD9k=",
+      "dev": true,
+      "requires": {
+        "agent-base": "4.1.2",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "dev": true,
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+          }
+        }
+      }
+    },
     "iconv-lite": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
+      "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
+      "integrity": "sha1-I9hlaxaq5nQqwpcy6o8DNqR4nPI=",
       "dev": true
     },
     "ieee754": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "version": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
       "dev": true
     },
     "ignore": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
+      "version": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
       "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
       "dev": true
     },
     "immutable": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
+      "version": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
       "integrity": "sha1-IAgH8Rqw9ycQ6khVQt4IgHX2jNI=",
       "dev": true
     },
     "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "in-publish": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
       "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
       "dev": true
     },
     "indent-string": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "version": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
       },
       "dependencies": {
         "repeating": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+          "version": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
           "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "dev": true,
           "requires": {
-            "is-finite": "1.0.2"
+            "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
           }
         }
       }
     },
     "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
       "dev": true
     },
     "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
     "ini": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
       "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
       "dev": true
     },
     "inline-source-map": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
+      "version": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
       "integrity": "sha1-Skxd2OT7Xps82mDIIt+tyu5m4K8=",
       "dev": true,
       "requires": {
-        "source-map": "0.4.4"
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
       },
       "dependencies": {
         "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
           }
         }
       }
     },
     "inquirer": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+      "version": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.1.1",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "2.2.0",
-        "figures": "1.7.0",
-        "lodash": "4.17.4",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "3.1.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
+        "ansi-escapes": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "cli-cursor": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+        "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+        "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "readline2": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+        "run-async": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+        "rx-lite": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         }
       }
     },
     "insert-module-globals": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
+      "version": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
       "integrity": "sha1-IGOOKaMPntHKLjqCX7wsulJG3fw=",
       "dev": true,
       "requires": {
-        "combine-source-map": "0.6.1",
-        "concat-stream": "1.4.10",
-        "is-buffer": "1.1.5",
-        "JSONStream": "1.3.1",
-        "lexical-scope": "1.2.0",
-        "process": "0.11.10",
-        "through2": "1.1.1",
-        "xtend": "4.0.1"
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+        "combine-source-map": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+        "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+        "lexical-scope": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
+        "process": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
       },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
         "through2": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+          "version": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "integrity": "sha1-CEfLxESfNAVXTb3M2buEG4OsNUU=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.1.14",
-            "xtend": "4.0.1"
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
           }
         }
       }
     },
     "interpret": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
       "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
       "dev": true
     },
     "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
     "irregular-plurals": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.3.0.tgz",
-      "integrity": "sha512-njf5A+Mxb3kojuHd1DzISjjIl+XhyzovXEOyPPSzdQozq/Lf2tN27mOrAAsxEPZxpn6I4MGzs1oo9TxXxPFpaA==",
+      "version": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.3.0.tgz",
+      "integrity": "sha1-evBpMb33S+M9z1haE+BvzMFsrs8=",
       "dev": true
     },
     "is": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
+      "version": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
       "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
       "dev": true
     },
     "is-absolute": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+      "version": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
       "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
       "dev": true,
       "requires": {
-        "is-relative": "0.2.1",
-        "is-windows": "0.2.0"
+        "is-relative": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
+        "is-windows": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz"
       }
     },
     "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-binary-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.10.0"
+        "binary-extensions": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz"
       }
     },
     "is-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+      "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
       "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
       "dev": true
     },
     "is-builtin-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
       }
     },
     "is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
       "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
       "dev": true
     },
     "is-equal-shallow": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "version": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
       }
     },
     "is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
     "is-extglob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
       "dev": true
     },
     "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
       }
     },
     "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
       }
     },
     "is-glob": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
       }
     },
     "is-integer": {
@@ -4640,203 +5413,182 @@
       "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
       }
     },
     "is-my-json-valid": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
-      "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+      "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+      "integrity": "sha1-WoRnd+LCYg0eaRBOXToDsfYIjxE=",
       "dev": true,
       "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+        "generate-object-property": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+        "jsonpointer": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
       }
     },
     "is-number": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "version": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
       }
     },
     "is-number-like": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
-      "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
+      "version": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
+      "integrity": "sha1-LhKWILUIkQQuROm7uzBZPnXPu+M=",
       "dev": true,
       "requires": {
-        "lodash.isfinite": "3.3.2"
+        "lodash.isfinite": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz"
       }
     },
     "is-path-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
       "dev": true
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
       }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
       }
     },
     "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
     "is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "version": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
       },
       "dependencies": {
         "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "version": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
       }
     },
     "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
       "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
       "dev": true
     },
     "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
     "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "version": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
     "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
     "is-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
       "dev": true
     },
     "is-relative": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
       "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
       "dev": true,
       "requires": {
-        "is-unc-path": "0.1.2"
+        "is-unc-path": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz"
       }
     },
     "is-resolvable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
       "dev": true,
       "requires": {
-        "tryit": "1.0.3"
+        "tryit": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz"
       }
     },
     "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
     "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "is-unc-path": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
       "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
       "dev": true,
       "requires": {
-        "unc-path-regex": "0.1.2"
+        "unc-path-regex": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz"
       }
     },
     "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
     "is-valid-glob": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+      "version": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
       "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
       "dev": true
     },
     "is-windows": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
       "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
       "dev": true
     },
     "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isobject": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
       "dev": true,
       "requires": {
-        "isarray": "1.0.0"
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
       }
     },
     "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "dev": true
+    },
     "js-base64": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+      "version": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
       "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4=",
       "dev": true
     },
@@ -4847,208 +5599,173 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
-      "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
+      "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
+      "integrity": "sha1-CHdc69/dNZIJ8NKs04PI+GppBKA=",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+        "esprima": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz"
       },
       "dependencies": {
         "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "version": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
           "dev": true
         }
       }
     },
     "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "optional": true
     },
     "jsesc": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "version": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
       "dev": true
     },
     "json-align": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/json-align/-/json-align-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/json-align/-/json-align-0.1.0.tgz",
       "integrity": "sha1-vnh5eVMg3VPnr2+DblwrNcnx61A=",
       "dev": true,
       "requires": {
-        "commander": "2.0.0"
+        "commander": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz"
       },
       "dependencies": {
         "commander": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz",
+          "version": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz",
           "integrity": "sha1-0bhvkB+LZL2UG96tr5JFMDk76Sg=",
           "dev": true
         }
       }
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
       }
     },
     "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "json3": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "version": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
     },
     "json5": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+      "version": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
       "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
       "dev": true
     },
     "jsonfile": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+      "version": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
       "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
       }
     },
     "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
     "jsonparse": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "version": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
     "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+        "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+        "verror": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz"
       },
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
       }
     },
     "jsx-ast-utils": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
+      "version": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
       "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
       "dev": true
     },
     "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.5"
+        "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
       }
     },
     "kuler": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz",
+      "version": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz",
       "integrity": "sha1-tmu0a5NOVQ9Z2BiEjgq7pPf1VTw=",
       "dev": true,
       "requires": {
-        "colornames": "0.0.2"
+        "colornames": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz"
       }
     },
     "labeled-stream-splicer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
       "integrity": "sha1-RhUzFTd4SYHo/SZOHzpDTE4N3WU=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "isarray": "0.0.1",
-        "stream-splicer": "1.3.2"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+        "stream-splicer": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz"
       },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         }
       }
     },
     "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "dev": true
     },
     "lazystream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
       }
     },
     "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
       }
     },
     "leven": {
@@ -5058,604 +5775,535 @@
       "dev": true
     },
     "levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "version": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+        "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
       }
     },
     "lexical-scope": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
+      "version": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
       "integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
       "dev": true,
       "requires": {
-        "astw": "2.2.0"
+        "astw": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz"
       }
     },
     "licenses": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/licenses/-/licenses-0.0.20.tgz",
+      "version": "https://registry.npmjs.org/licenses/-/licenses-0.0.20.tgz",
       "integrity": "sha1-8YpXsmp46vKKhz4qN4oz6B9Z0TY=",
       "dev": true,
       "requires": {
-        "async": "0.6.2",
-        "debug": "0.8.1",
-        "fusing": "0.2.3",
-        "githulk": "0.0.7",
-        "npm-registry": "0.1.13"
+        "async": "https://registry.npmjs.org/async/-/async-0.6.2.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
+        "fusing": "https://registry.npmjs.org/fusing/-/fusing-0.2.3.tgz",
+        "githulk": "https://registry.npmjs.org/githulk/-/githulk-0.0.7.tgz",
+        "npm-registry": "https://registry.npmjs.org/npm-registry/-/npm-registry-0.1.13.tgz"
       },
       "dependencies": {
         "async": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.6.2.tgz",
+          "version": "https://registry.npmjs.org/async/-/async-0.6.2.tgz",
           "integrity": "sha1-Qf0DijgSwKi8GELs8IumPrA5K+8=",
           "dev": true
         },
         "debug": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
+          "version": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
           "integrity": "sha1-IP9NJvXkIstoobrLu2EDmtjBwTA=",
           "dev": true
         }
       }
     },
     "liftoff": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
+      "version": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
       "integrity": "sha1-qY8v9nGD2Lp8+soQVIvX/wVQs4U=",
       "dev": true,
       "requires": {
-        "extend": "3.0.1",
-        "findup-sync": "0.4.3",
-        "fined": "1.1.0",
-        "flagged-respawn": "0.3.2",
-        "lodash.isplainobject": "4.0.6",
-        "lodash.isstring": "4.0.1",
-        "lodash.mapvalues": "4.6.0",
-        "rechoir": "0.6.2",
-        "resolve": "1.4.0"
+        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+        "findup-sync": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
+        "fined": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
+        "flagged-respawn": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
+        "lodash.isplainobject": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+        "lodash.isstring": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+        "lodash.mapvalues": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+        "rechoir": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz"
       }
     },
     "limiter": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.2.tgz",
-      "integrity": "sha512-JIKZ0xb6fZZYa3deZ0BgXCgX6HgV8Nx3mFGeFHmFWW8Fb2c08e0CyE+G3nalpD0xGvGssjGb1UdFr+PprxZEbw==",
+      "version": "https://registry.npmjs.org/limiter/-/limiter-1.1.2.tgz",
+      "integrity": "sha1-Ip2AVYkcixGvng7lIA6OCbs9y+s=",
       "dev": true
     },
     "load-json-file": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
       }
     },
     "localtunnel": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.8.3.tgz",
+      "version": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.8.3.tgz",
       "integrity": "sha1-3MWSL9hWUQN9S94k/ZMkjQsk6wU=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
-        "openurl": "1.1.1",
-        "request": "2.81.0",
-        "yargs": "3.29.0"
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "openurl": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
+        "request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+        "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.29.0.tgz"
       },
       "dependencies": {
         "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
           }
         },
         "yargs": {
-          "version": "3.29.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.29.0.tgz",
+          "version": "https://registry.npmjs.org/yargs/-/yargs-3.29.0.tgz",
           "integrity": "sha1-GquWYOrnnYuPZ1vK7qtu40ws9pw=",
           "dev": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "os-locale": "1.4.0",
-            "window-size": "0.1.4",
-            "y18n": "3.2.1"
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+            "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
           }
         }
       }
     },
     "lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "version": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
       "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
       "dev": true
     },
     "lodash._arraycopy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+      "version": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
       "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
       "dev": true
     },
     "lodash._arrayeach": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+      "version": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
       "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
       "dev": true
     },
     "lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
       }
     },
     "lodash._baseclone": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+      "version": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
       "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
       "dev": true,
       "requires": {
-        "lodash._arraycopy": "3.0.0",
-        "lodash._arrayeach": "3.0.0",
-        "lodash._baseassign": "3.2.0",
-        "lodash._basefor": "3.0.3",
-        "lodash.isarray": "3.0.4",
-        "lodash.keys": "3.1.2"
+        "lodash._arraycopy": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+        "lodash._arrayeach": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+        "lodash._baseassign": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+        "lodash._basefor": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+        "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
       }
     },
     "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
       "dev": true
     },
     "lodash._basefor": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+      "version": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
       "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
       "dev": true
     },
     "lodash._basetostring": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+      "version": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
       "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
       "dev": true
     },
     "lodash._basevalues": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+      "version": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
       "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
       "dev": true
     },
     "lodash._bindcallback": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "version": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
       "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
       "dev": true
     },
     "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "version": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true
     },
     "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "version": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true
     },
     "lodash._reescape": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+      "version": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
       "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
       "dev": true
     },
     "lodash._reevaluate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+      "version": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
       "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
       "dev": true
     },
     "lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "version": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
     "lodash._root": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "version": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
       "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
       "dev": true
     },
     "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "version": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
       "dev": true
     },
     "lodash.clonedeep": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+      "version": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
       "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
       "dev": true,
       "requires": {
-        "lodash._baseclone": "3.3.0",
-        "lodash._bindcallback": "3.0.1"
+        "lodash._baseclone": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+        "lodash._bindcallback": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
       }
     },
     "lodash.defaults": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "version": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
       "dev": true
     },
     "lodash.escape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+      "version": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
       "dev": true,
       "requires": {
-        "lodash._root": "3.0.1"
+        "lodash._root": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
       }
     },
     "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "version": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
       "dev": true
     },
     "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "version": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
     "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "version": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
     "lodash.isfinite": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
+      "version": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
       "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M=",
       "dev": true
     },
     "lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "version": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "dev": true
     },
     "lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "version": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
       "dev": true
     },
     "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+        "lodash.isarguments": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+        "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
       }
     },
     "lodash.mapvalues": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+      "version": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
       "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
       "dev": true
     },
     "lodash.memoize": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+      "version": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
       "dev": true
     },
     "lodash.mergewith": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
+      "version": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
       "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU=",
       "dev": true
     },
     "lodash.restparam": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "version": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "dev": true
     },
     "lodash.template": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+      "version": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash._basetostring": "3.0.1",
-        "lodash._basevalues": "3.0.0",
-        "lodash._isiterateecall": "3.0.9",
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.escape": "3.2.0",
-        "lodash.keys": "3.1.2",
-        "lodash.restparam": "3.6.1",
-        "lodash.templatesettings": "3.1.1"
+        "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+        "lodash._basetostring": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+        "lodash._basevalues": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+        "lodash._isiterateecall": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+        "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+        "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+        "lodash.restparam": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+        "lodash.templatesettings": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
       }
     },
     "lodash.templatesettings": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+      "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.escape": "3.2.0"
+        "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+        "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz"
       }
     },
     "lodash.toarray": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+      "version": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
       "dev": true
     },
     "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
     "loud-rejection": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "version": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+        "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
       }
     },
     "lru-cache": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
     },
     "lru-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
       "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.29"
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.29.tgz"
       }
     },
     "main-bower-files": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/main-bower-files/-/main-bower-files-2.13.1.tgz",
+      "version": "https://registry.npmjs.org/main-bower-files/-/main-bower-files-2.13.1.tgz",
       "integrity": "sha1-fhvFxJg1LM7NXfCH8T1fMbwFfT4=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "extend": "2.0.1",
-        "globby": "2.1.0",
-        "multimatch": "2.1.0",
-        "path-exists": "1.0.0",
-        "strip-json-comments": "1.0.4",
-        "vinyl-fs": "2.4.4"
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "extend": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
+        "globby": "https://registry.npmjs.org/globby/-/globby-2.1.0.tgz",
+        "multimatch": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+        "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+        "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+        "vinyl-fs": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz"
       },
       "dependencies": {
         "extend": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
+          "version": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
           "integrity": "sha1-HugBBonnOV/5RIJByYZSvHWagmA=",
           "dev": true
         },
         "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+            "path-dirname": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz"
           }
         },
         "glob-stream": {
-          "version": "5.3.5",
-          "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+          "version": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
           "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
           "dev": true,
           "requires": {
-            "extend": "3.0.1",
-            "glob": "5.0.15",
-            "glob-parent": "3.1.0",
-            "micromatch": "2.3.11",
-            "ordered-read-streams": "0.3.0",
-            "through2": "0.6.5",
-            "to-absolute-glob": "0.1.1",
-            "unique-stream": "2.2.1"
+            "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+            "glob": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+            "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+            "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+            "ordered-read-streams": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+            "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+            "to-absolute-glob": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+            "unique-stream": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz"
           },
           "dependencies": {
             "extend": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+              "version": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
               "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
               "dev": true
             },
             "readable-stream": {
-              "version": "1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
               }
             },
             "through2": {
-              "version": "0.6.5",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+              "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
               "dev": true,
               "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "4.0.1"
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
               }
             }
           }
         },
         "globby": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-2.1.0.tgz",
+          "version": "https://registry.npmjs.org/globby/-/globby-2.1.0.tgz",
           "integrity": "sha1-npGSvNM/Srak+JTl5+qLcTITxII=",
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "async": "1.5.2",
-            "glob": "5.0.15",
-            "object-assign": "3.0.0"
+            "array-union": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+            "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "glob": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+            "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
           }
         },
         "gulp-sourcemaps": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+          "version": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
           "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
           "dev": true,
           "requires": {
-            "convert-source-map": "1.5.0",
-            "graceful-fs": "4.1.11",
-            "strip-bom": "2.0.0",
-            "through2": "2.0.3",
-            "vinyl": "1.2.0"
+            "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+            "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+            "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz"
           }
         },
         "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
           "dev": true
         },
         "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "version": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
           }
         },
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "object-assign": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "version": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
           "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
           "dev": true
         },
         "ordered-read-streams": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+          "version": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
           "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
           "dev": true,
           "requires": {
-            "is-stream": "1.1.0",
-            "readable-stream": "2.3.3"
+            "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
         "strip-bom-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
           "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
           "dev": true,
           "requires": {
-            "first-chunk-stream": "1.0.0",
-            "strip-bom": "2.0.0"
+            "first-chunk-stream": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+            "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
           }
         },
         "unique-stream": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
+          "version": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
           "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
           "dev": true,
           "requires": {
-            "json-stable-stringify": "1.0.1",
-            "through2-filter": "2.0.0"
+            "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+            "through2-filter": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz"
           }
         },
         "vinyl": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+          "version": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
           "requires": {
-            "clone": "1.0.2",
-            "clone-stats": "0.0.1",
-            "replace-ext": "0.0.1"
+            "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+            "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
           }
         },
         "vinyl-fs": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+          "version": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
           "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
           "dev": true,
           "requires": {
-            "duplexify": "3.5.1",
-            "glob-stream": "5.3.5",
-            "graceful-fs": "4.1.11",
-            "gulp-sourcemaps": "1.6.0",
-            "is-valid-glob": "0.3.0",
-            "lazystream": "1.0.0",
-            "lodash.isequal": "4.5.0",
-            "merge-stream": "1.0.1",
-            "mkdirp": "0.5.1",
-            "object-assign": "4.1.1",
-            "readable-stream": "2.3.3",
-            "strip-bom": "2.0.0",
-            "strip-bom-stream": "1.0.0",
-            "through2": "2.0.3",
-            "through2-filter": "2.0.0",
-            "vali-date": "1.0.0",
-            "vinyl": "1.2.0"
+            "duplexify": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
+            "glob-stream": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "gulp-sourcemaps": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+            "is-valid-glob": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+            "lazystream": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+            "lodash.isequal": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+            "merge-stream": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+            "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+            "strip-bom-stream": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+            "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+            "through2-filter": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+            "vali-date": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+            "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz"
           },
           "dependencies": {
             "object-assign": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
               "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "dev": true
             }
@@ -5664,844 +6312,759 @@
       }
     },
     "mana": {
-      "version": "0.1.41",
-      "resolved": "https://registry.npmjs.org/mana/-/mana-0.1.41.tgz",
+      "version": "https://registry.npmjs.org/mana/-/mana-0.1.41.tgz",
       "integrity": "sha1-fLE/cyGGaGVCKWNcT8Wxfib5O30=",
       "dev": true,
       "requires": {
-        "assign": "0.1.7",
-        "back": "1.0.1",
-        "diagnostics": "1.0.1",
-        "eventemitter3": "1.2.0",
-        "fusing": "1.0.0",
-        "millisecond": "0.1.2",
-        "request": "2.81.0"
+        "assign": "https://registry.npmjs.org/assign/-/assign-0.1.7.tgz",
+        "back": "https://registry.npmjs.org/back/-/back-1.0.1.tgz",
+        "diagnostics": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.0.1.tgz",
+        "eventemitter3": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+        "fusing": "https://registry.npmjs.org/fusing/-/fusing-1.0.0.tgz",
+        "millisecond": "https://registry.npmjs.org/millisecond/-/millisecond-0.1.2.tgz",
+        "request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz"
       },
       "dependencies": {
         "emits": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/emits/-/emits-3.0.0.tgz",
+          "version": "https://registry.npmjs.org/emits/-/emits-3.0.0.tgz",
           "integrity": "sha1-MnUrupXhcHshlWI4Srm7ix/WL3A=",
           "dev": true
         },
         "fusing": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fusing/-/fusing-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/fusing/-/fusing-1.0.0.tgz",
           "integrity": "sha1-VQwV12r5Jld4qgUezkTUAAoJjUU=",
           "dev": true,
           "requires": {
-            "emits": "3.0.0",
-            "predefine": "0.1.2"
+            "emits": "https://registry.npmjs.org/emits/-/emits-3.0.0.tgz",
+            "predefine": "https://registry.npmjs.org/predefine/-/predefine-0.1.2.tgz"
           }
         }
       }
     },
     "map-cache": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "version": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
     "map-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+      "dev": true
+    },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+      "version": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
       "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
       "dev": true
     },
     "math-expression-evaluator": {
-      "version": "1.2.17",
-      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
+      "version": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
       "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
       "dev": true
     },
     "md5.js": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+      "version": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
       },
       "dependencies": {
         "hash-base": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+          "version": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
           "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.1"
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
           }
         }
       }
     },
     "memoizee": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.5.tgz",
+      "version": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.5.tgz",
       "integrity": "sha1-G8PqHkvgVt1HXVIZede+PV5bIcg=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.29",
-        "es6-weak-map": "2.0.2",
-        "event-emitter": "0.3.5",
-        "is-promise": "2.1.0",
-        "lru-queue": "0.1.0",
-        "next-tick": "1.0.0",
-        "timers-ext": "0.1.2"
+        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.29.tgz",
+        "es6-weak-map": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+        "event-emitter": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+        "is-promise": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+        "lru-queue": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+        "next-tick": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+        "timers-ext": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.2.tgz"
       }
     },
     "meow": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "version": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+        "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+        "loud-rejection": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+        "map-obj": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+        "redent": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+        "trim-newlines": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
       }
     },
     "merge-stream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
       }
     },
     "micromatch": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "version": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.3"
+        "arr-diff": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+        "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+        "braces": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+        "expand-brackets": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+        "extglob": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+        "filename-regex": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+        "object.omit": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+        "parse-glob": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+        "regex-cache": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
       }
     },
     "miller-rabin": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
+      "version": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
       "integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+        "brorand": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz"
       }
     },
     "millisecond": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/millisecond/-/millisecond-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/millisecond/-/millisecond-0.1.2.tgz",
       "integrity": "sha1-bMWtOGJByrjniv+WT4cCjuyS2sU=",
       "dev": true
     },
     "mime": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz",
+      "version": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz",
       "integrity": "sha1-EbX9rynCUJJVF2uArVIClPXekrc=",
       "dev": true
     },
     "mime-db": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
+      "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
       "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+      "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
       "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
       "dev": true,
       "requires": {
-        "mime-db": "1.29.0"
+        "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
       }
     },
     "minimalistic-assert": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
       "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=",
       "dev": true
     },
     "minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
       "dev": true
     },
     "minimatch": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+      "version": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
       "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
       },
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
       }
     },
     "module-deps": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
+      "version": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
       "integrity": "sha1-6nXK+RmQkNJbDVUStaysuW5/h/M=",
       "dev": true,
       "requires": {
-        "browser-resolve": "1.11.2",
-        "concat-stream": "1.4.10",
-        "defined": "1.0.0",
-        "detective": "4.5.0",
-        "duplexer2": "0.0.2",
-        "inherits": "2.0.3",
-        "JSONStream": "1.3.1",
-        "parents": "1.0.1",
-        "readable-stream": "1.1.14",
-        "resolve": "1.4.0",
-        "stream-combiner2": "1.0.2",
-        "subarg": "1.0.0",
-        "through2": "1.1.1",
-        "xtend": "4.0.1"
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+        "browser-resolve": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+        "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+        "detective": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
+        "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "parents": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+        "stream-combiner2": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+        "subarg": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
       },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
         "through2": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+          "version": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "integrity": "sha1-CEfLxESfNAVXTb3M2buEG4OsNUU=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.1.14",
-            "xtend": "4.0.1"
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
           }
         }
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "multimatch": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+      "version": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "dev": true,
       "requires": {
-        "array-differ": "1.0.0",
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "minimatch": "3.0.4"
+        "array-differ": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+        "array-union": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
       },
       "dependencies": {
         "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
           }
         }
       }
     },
     "multipipe": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
       "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
       "dev": true,
       "requires": {
-        "duplexer2": "0.0.2"
+        "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
       }
     },
     "mute-stream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
       "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
     },
     "nan": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
+      "version": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
       "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
       "dev": true
     },
     "natives": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
       "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE=",
       "dev": true
     },
     "negotiator": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "version": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
     },
     "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
     "node-bourbon": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/node-bourbon/-/node-bourbon-4.2.8.tgz",
+      "version": "https://registry.npmjs.org/node-bourbon/-/node-bourbon-4.2.8.tgz",
       "integrity": "sha1-5ETx8JQ0q3ZQ6jGMKOLhA9P5Qs0=",
       "dev": true,
       "requires": {
-        "bourbon": "4.3.4"
+        "bourbon": "https://registry.npmjs.org/bourbon/-/bourbon-4.3.4.tgz"
       }
     },
     "node-emoji": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
-      "integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
+      "version": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
+      "integrity": "sha1-buxr+wdCHiFIx1xrunJCH4UwqCY=",
       "dev": true,
       "requires": {
-        "lodash.toarray": "4.4.0"
+        "lodash.toarray": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz"
       }
     },
     "node-gyp": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+      "version": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
       "dev": true,
       "requires": {
-        "fstream": "1.0.11",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "npmlog": "4.1.2",
-        "osenv": "0.1.4",
-        "request": "2.81.0",
-        "rimraf": "2.6.1",
-        "semver": "5.3.0",
-        "tar": "2.2.1",
-        "which": "1.3.0"
+        "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+        "npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+        "osenv": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+        "request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+        "tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+        "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
           }
         },
         "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
           }
         },
         "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
       }
     },
     "node-neat": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/node-neat/-/node-neat-1.7.2.tgz",
+      "version": "https://registry.npmjs.org/node-neat/-/node-neat-1.7.2.tgz",
       "integrity": "sha1-OEcpELgV4mG4sbmbpRmZRGWhXCE=",
       "dev": true,
       "requires": {
-        "bourbon-neat": "1.7.2",
-        "node-bourbon": "4.2.8"
+        "bourbon-neat": "https://registry.npmjs.org/bourbon-neat/-/bourbon-neat-1.7.2.tgz",
+        "node-bourbon": "https://registry.npmjs.org/node-bourbon/-/node-bourbon-4.2.8.tgz"
       }
     },
     "node-normalize-scss": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/node-normalize-scss/-/node-normalize-scss-3.0.0.tgz",
+      "version": "https://registry.npmjs.org/node-normalize-scss/-/node-normalize-scss-3.0.0.tgz",
       "integrity": "sha1-EZv11btxFgRl6fEgTEH2kdJuz3c=",
       "dev": true
     },
     "node-notifier": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-4.6.1.tgz",
+      "version": "https://registry.npmjs.org/node-notifier/-/node-notifier-4.6.1.tgz",
       "integrity": "sha1-BW0UJE89zBzq3+aK+c/wxUc6M/M=",
       "dev": true,
       "requires": {
-        "cli-usage": "0.1.4",
-        "growly": "1.3.0",
-        "lodash.clonedeep": "3.0.2",
-        "minimist": "1.2.0",
-        "semver": "5.4.1",
-        "shellwords": "0.1.1",
-        "which": "1.3.0"
+        "cli-usage": "https://registry.npmjs.org/cli-usage/-/cli-usage-0.1.4.tgz",
+        "growly": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+        "lodash.clonedeep": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+        "shellwords": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+        "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
       }
     },
     "node-sass": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
+      "version": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
       "integrity": "sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=",
       "dev": true,
       "requires": {
-        "async-foreach": "0.1.3",
-        "chalk": "1.1.3",
-        "cross-spawn": "3.0.1",
-        "gaze": "1.1.2",
-        "get-stdin": "4.0.1",
-        "glob": "7.1.2",
-        "in-publish": "2.0.0",
-        "lodash.assign": "4.2.0",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.mergewith": "4.6.0",
-        "meow": "3.7.0",
-        "mkdirp": "0.5.1",
-        "nan": "2.6.2",
-        "node-gyp": "3.6.2",
-        "npmlog": "4.1.2",
-        "request": "2.81.0",
-        "sass-graph": "2.2.4",
-        "stdout-stream": "1.4.0"
+        "async-foreach": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+        "gaze": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
+        "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+        "in-publish": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+        "lodash.assign": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+        "lodash.clonedeep": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+        "lodash.mergewith": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
+        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "nan": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
+        "node-gyp": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+        "npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+        "request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+        "sass-graph": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
+        "stdout-stream": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz"
       },
       "dependencies": {
         "gaze": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
+          "version": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
           "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
           "dev": true,
           "requires": {
-            "globule": "1.2.0"
+            "globule": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz"
           }
         },
         "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
           }
         },
         "globule": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
+          "version": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
           "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
           "dev": true,
           "requires": {
-            "glob": "7.1.2",
-            "lodash": "4.17.4",
-            "minimatch": "3.0.4"
+            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
           }
         },
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         },
         "lodash.clonedeep": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+          "version": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
           "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
           "dev": true
         },
         "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
           }
         }
       }
     },
     "node.extend": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
+      "version": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
       "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
       "dev": true,
       "requires": {
-        "is": "3.2.1"
+        "is": "https://registry.npmjs.org/is/-/is-3.2.1.tgz"
       }
     },
     "nopt": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.0"
+        "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
       }
     },
     "normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+        "is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+        "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
       }
     },
     "normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "version": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz"
       }
     },
     "normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
     },
     "npm-registry": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/npm-registry/-/npm-registry-0.1.13.tgz",
+      "version": "https://registry.npmjs.org/npm-registry/-/npm-registry-0.1.13.tgz",
       "integrity": "sha1-nl2LL9/Bq1mQ1H99674jHXmp6CI=",
       "dev": true,
       "requires": {
-        "debug": "0.8.1",
-        "extract-github": "0.0.5",
-        "licenses": "0.0.20",
-        "mana": "0.1.41",
-        "semver": "2.2.1"
+        "debug": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
+        "extract-github": "https://registry.npmjs.org/extract-github/-/extract-github-0.0.5.tgz",
+        "licenses": "https://registry.npmjs.org/licenses/-/licenses-0.0.20.tgz",
+        "mana": "https://registry.npmjs.org/mana/-/mana-0.1.41.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz"
       },
       "dependencies": {
         "debug": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
+          "version": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
           "integrity": "sha1-IP9NJvXkIstoobrLu2EDmtjBwTA=",
           "dev": true
         },
         "semver": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz",
+          "version": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz",
           "integrity": "sha1-eUEYKz/8xYC/8cF5QqzfeVHA0hM=",
           "dev": true
         }
       }
     },
     "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "version": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+        "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+        "gauge": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+        "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
       }
     },
     "nth-check": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
       "dev": true,
       "requires": {
-        "boolbase": "1.0.0"
+        "boolbase": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
       }
     },
     "num2fraction": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "version": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
       "dev": true
     },
     "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
     "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
       "dev": true
     },
     "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-component": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+      "version": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
       "dev": true
     },
     "object-path": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
+      "version": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
       "integrity": "sha1-D9mnT8X60a45aLWGvaXGMr1sBaU=",
       "dev": true
     },
     "object.defaults": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
       "dev": true,
       "requires": {
-        "array-each": "1.0.1",
-        "array-slice": "1.0.0",
-        "for-own": "1.0.0",
-        "isobject": "3.0.1"
+        "array-each": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+        "array-slice": "https://registry.npmjs.org/array-slice/-/array-slice-1.0.0.tgz",
+        "for-own": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
       },
       "dependencies": {
         "for-own": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "dev": true,
           "requires": {
-            "for-in": "1.0.2"
+            "for-in": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
           }
         },
         "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "version": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
       }
     },
     "object.omit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+        "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
       }
     },
     "object.pick": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "version": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
       },
       "dependencies": {
         "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "version": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
       }
     },
     "on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "version": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "dev": true,
       "requires": {
-        "ee-first": "1.1.1"
+        "ee-first": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
       }
     },
     "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
       }
     },
     "onetime": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
     "openurl": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
       "integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c=",
       "dev": true
     },
     "opn": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+      "version": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
       "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
       "dev": true,
       "requires": {
-        "object-assign": "4.1.1",
-        "pinkie-promise": "2.0.1"
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
       }
     },
     "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "version": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+        "fast-levenshtein": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+        "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+        "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
       },
       "dependencies": {
         "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
           "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
           "dev": true
         }
       }
     },
     "options": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "version": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
       "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=",
       "dev": true
     },
     "orchestrator": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
+      "version": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
       "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
       "dev": true,
       "requires": {
-        "end-of-stream": "0.1.5",
-        "sequencify": "0.0.7",
-        "stream-consume": "0.1.0"
+        "end-of-stream": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+        "sequencify": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
+        "stream-consume": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
       }
     },
     "ordered-read-streams": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
       "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
       "dev": true
     },
     "os-browserify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
       "integrity": "sha1-ScoCk+CxlZCl9d4Qx/JlphfY/lQ=",
       "dev": true
     },
     "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "version": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
-        "lcid": "1.0.0"
+        "lcid": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
       }
     },
     "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
     "osenv": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+      "version": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+        "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
       }
     },
     "output-file-sync": {
@@ -6510,578 +7073,587 @@
       "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1"
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
       }
     },
     "pako": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "version": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
       "dev": true
     },
     "parents": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
       "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
       "dev": true,
       "requires": {
-        "path-platform": "0.11.15"
+        "path-platform": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
       }
     },
     "parse-asn1": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+      "version": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "dev": true,
       "requires": {
-        "asn1.js": "4.9.1",
-        "browserify-aes": "1.0.6",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.2",
-        "pbkdf2": "3.0.13"
+        "asn1.js": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+        "browserify-aes": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+        "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+        "evp_bytestokey": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.2.tgz",
+        "pbkdf2": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.13.tgz"
       }
     },
     "parse-filepath": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
       "integrity": "sha1-FZ1hVdQ5BNFsEO9piRHaHpGWm3M=",
       "dev": true,
       "requires": {
-        "is-absolute": "0.2.6",
-        "map-cache": "0.2.2",
-        "path-root": "0.1.1"
+        "is-absolute": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+        "map-cache": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+        "path-root": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz"
       }
     },
     "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "version": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+        "is-dotfile": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
       }
     },
     "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
       }
     },
     "parse-passwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
     "parsejson": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
+      "version": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
       "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz"
       }
     },
     "parseqs": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+      "version": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz"
       }
     },
     "parseuri": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+      "version": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz"
       }
     },
     "parseurl": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+      "version": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
       "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
       "dev": true
     },
     "path-browserify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "version": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
       "dev": true
     },
     "path-dirname": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
       "dev": true
     },
     "path-exists": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
       "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
       "dev": true
     },
     "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-is-inside": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "version": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
     "path-platform": {
-      "version": "0.11.15",
-      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+      "version": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
       "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
       "dev": true
     },
     "path-root": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "dev": true,
       "requires": {
-        "path-root-regex": "0.1.2"
+        "path-root-regex": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz"
       }
     },
     "path-root-regex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
       "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
       "dev": true
     },
     "path-type": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+      }
+    },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "dev": true,
+      "requires": {
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
       }
     },
     "pbkdf2": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.13.tgz",
-      "integrity": "sha512-+dCHxDH+djNtjgWmvVC/my3SYBAKpKNqKSjLkp+GtWWYe4XPE+e/PSD2aCanlEZZnqPk2uekTKNC/ccbwd2X2Q==",
+      "version": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.13.tgz",
+      "integrity": "sha1-w30pVTHnhrHaPj6tyEBCasywriU=",
       "dev": true,
       "requires": {
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.8"
+        "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+        "create-hmac": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+        "ripemd160": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+        "sha.js": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
       }
     },
     "performance-now": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
       "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
       "dev": true
     },
     "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
     "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
       }
     },
     "pixrem": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pixrem/-/pixrem-3.0.2.tgz",
+      "version": "https://registry.npmjs.org/pixrem/-/pixrem-3.0.2.tgz",
       "integrity": "sha1-MNG6+0w73Ojpu0vVahOYVhkyDDQ=",
       "dev": true,
       "requires": {
-        "browserslist": "1.7.7",
-        "postcss": "5.2.17",
-        "reduce-css-calc": "1.3.0"
+        "browserslist": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+        "reduce-css-calc": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz"
+      }
+    },
+    "plugin-error": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+      "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+      "dev": true,
+      "requires": {
+        "ansi-cyan": "0.1.1",
+        "ansi-red": "0.1.1",
+        "arr-diff": "1.1.0",
+        "arr-union": "2.1.0",
+        "extend-shallow": "1.1.4"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+          "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "array-slice": "0.2.3"
+          }
+        },
+        "array-slice": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+          "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
+          "dev": true
+        },
+        "extend-shallow": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+          "dev": true,
+          "requires": {
+            "kind-of": "1.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+          "dev": true
+        }
+      }
+    },
+    "plugin-log": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/plugin-log/-/plugin-log-0.1.0.tgz",
+      "integrity": "sha1-hgSc9qsQgzOYqTHzaJy67nteEzM=",
+      "dev": true,
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "dateformat": "1.0.12"
+      },
+      "dependencies": {
+        "dateformat": {
+          "version": "1.0.12",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+          "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+          "dev": true,
+          "requires": {
+            "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+            "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
+          }
+        }
       }
     },
     "plur": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+      "version": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
       "dev": true,
       "requires": {
-        "irregular-plurals": "1.3.0"
+        "irregular-plurals": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.3.0.tgz"
       }
     },
     "pluralize": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+      "version": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
       "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
       "dev": true
     },
     "portscanner": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
+      "version": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
       "integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "is-number-like": "1.0.8"
+        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+        "is-number-like": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz"
       }
     },
     "postcss": {
-      "version": "5.2.17",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+      "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
       "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "js-base64": "2.1.9",
-        "source-map": "0.5.7",
-        "supports-color": "3.2.3"
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
       },
       "dependencies": {
         "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
           }
         }
       }
     },
     "postcss-value-parser": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+      "version": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
       "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
       "dev": true
     },
     "predefine": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/predefine/-/predefine-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/predefine/-/predefine-0.1.2.tgz",
       "integrity": "sha1-KqkrRJa8H4VU5DpF92v75Q0z038=",
       "dev": true,
       "requires": {
-        "extendible": "0.1.1"
+        "extendible": "https://registry.npmjs.org/extendible/-/extendible-0.1.1.tgz"
       }
     },
     "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "preserve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
     "pretty-hrtime": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
     "private": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+      "version": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
       "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
       "dev": true
     },
     "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "version": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
       "dev": true
     },
     "progress": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "version": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
     "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
     "public-encrypt": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+      "version": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
       "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "parse-asn1": "5.1.0",
-        "randombytes": "2.0.5"
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+        "browserify-rsa": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+        "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+        "parse-asn1": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+        "randombytes": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz"
       }
     },
     "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
     },
     "q": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
+      "version": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
       "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
       "dev": true
     },
     "qs": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
+      "version": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
       "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU=",
       "dev": true
     },
     "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
     "querystring-es3": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
     "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "version": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz"
       },
       "dependencies": {
         "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "version": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
           },
           "dependencies": {
             "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
               }
             }
           }
         },
         "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
           }
         }
       }
     },
     "randombytes": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
-      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+      "version": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
+      "integrity": "sha1-3ACaJGuNCaF3tLegrne8Vw9LG3k=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
       }
     },
     "range-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "version": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
       "dev": true
     },
     "read-only-stream": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-1.1.1.tgz",
       "integrity": "sha1-Xad8eZ7ROI0++IoYRxu1kk+KC6E=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14",
-        "readable-wrap": "1.0.0"
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+        "readable-wrap": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
       },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
       }
     },
     "read-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+        "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+        "path-type": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
       }
     },
     "read-pkg-up": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+        "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
       }
     },
     "readable-stream": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+        "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+        "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
       }
     },
     "readable-wrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
       "integrity": "sha1-O1ohHGMeEjA6VJkcgGwX564ga/8=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
       },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
       }
     },
     "readdirp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+      "version": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "set-immediate-shim": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
       },
       "dependencies": {
         "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
           }
         }
       }
     },
     "readline2": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "mute-stream": "0.0.5"
+        "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+        "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+        "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
       }
     },
     "recast": {
@@ -7092,8 +7664,8 @@
       "requires": {
         "ast-types": "0.8.12",
         "esprima-fb": "15001.1001.0-dev-harmony-fb",
-        "private": "0.1.7",
-        "source-map": "0.5.7"
+        "private": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
       },
       "dependencies": {
         "ast-types": {
@@ -7105,80 +7677,71 @@
       }
     },
     "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "version": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.4.0"
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz"
       }
     },
     "redent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+        "strip-indent": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
       }
     },
     "redeyed": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
       "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
       "dev": true,
       "requires": {
-        "esprima": "3.0.0"
+        "esprima": "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz"
       },
       "dependencies": {
         "esprima": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz",
+          "version": "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz",
           "integrity": "sha1-U88kes2ncxPlUcOqLnM0LT+099k=",
           "dev": true
         }
       }
     },
     "reduce-css-calc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+      "version": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
       "dev": true,
       "requires": {
-        "balanced-match": "0.4.2",
-        "math-expression-evaluator": "1.2.17",
-        "reduce-function-call": "1.0.2"
+        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+        "math-expression-evaluator": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
+        "reduce-function-call": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz"
       },
       "dependencies": {
         "balanced-match": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
           "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
           "dev": true
         }
       }
     },
     "reduce-function-call": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
       "dev": true,
       "requires": {
-        "balanced-match": "0.4.2"
+        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
       },
       "dependencies": {
         "balanced-match": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
           "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
           "dev": true
         }
       }
     },
     "regenerate": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+      "version": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
       "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA=",
       "dev": true
     },
@@ -7191,19 +7754,18 @@
         "commoner": "0.10.8",
         "defs": "1.1.1",
         "esprima-fb": "15001.1001.0-dev-harmony-fb",
-        "private": "0.1.7",
+        "private": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
         "recast": "0.10.33",
-        "through": "2.3.8"
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
       }
     },
     "regex-cache": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+      "version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3",
-        "is-primitive": "2.0.0"
+        "is-equal-shallow": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+        "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
       }
     },
     "regexpu": {
@@ -7214,9 +7776,9 @@
       "requires": {
         "esprima": "2.7.3",
         "recast": "0.10.33",
-        "regenerate": "1.3.2",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+        "regjsgen": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+        "regjsparser": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
       },
       "dependencies": {
         "esprima": {
@@ -7228,570 +7790,508 @@
       }
     },
     "regjsgen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
       "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
       "dev": true
     },
     "regjsparser": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "version": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
       }
     },
     "remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "repeat-element": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "version": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
       "dev": true
     },
     "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "repeating": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+      "version": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
       "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
       }
     },
     "replace-ext": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
       "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
       "dev": true
     },
     "request": {
-      "version": "2.81.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+      "version": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
       "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "4.2.1",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.16",
-        "oauth-sign": "0.8.2",
-        "performance-now": "0.2.0",
-        "qs": "6.4.0",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+        "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+        "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+        "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+        "form-data": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+        "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+        "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+        "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+        "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+        "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+        "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+        "performance-now": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+        "qs": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+        "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+        "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+        "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+        "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
       },
       "dependencies": {
         "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "version": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
           "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
           "dev": true
         }
       }
     },
     "require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "version": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-main-filename": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
     "require-uncached": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+        "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
       }
     },
     "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
     "resolve": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "version": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+      "integrity": "sha1-p1vgHFPaJdk0qY69DkxKcxL5KoY=",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
       }
     },
     "resolve-dir": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
       "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "1.2.2",
-        "global-modules": "0.2.3"
+        "expand-tilde": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+        "global-modules": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz"
       }
     },
     "resolve-from": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
       "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
       "dev": true
     },
     "resolve-url": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
     "resp-modifier": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
+      "version": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
       "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
-        "minimatch": "3.0.4"
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
       },
       "dependencies": {
         "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
           }
         }
       }
     },
     "restore-cursor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "exit-hook": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+        "onetime": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
       }
     },
     "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
       }
     },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+      "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
           }
         },
         "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
           }
         }
       }
     },
     "ripemd160": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
       "dev": true,
       "requires": {
-        "hash-base": "2.0.2",
-        "inherits": "2.0.3"
+        "hash-base": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
       }
     },
     "run-async": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
       }
     },
     "run-sequence": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.2.2.tgz",
+      "version": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.2.2.tgz",
       "integrity": "sha1-UJWgvr6YczsBQL0I3YDsAw3azes=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "gulp-util": "3.0.8"
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz"
       }
     },
     "rx": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+      "version": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
       "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
       "dev": true
     },
     "rx-lite": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "version": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
       "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
       "dev": true
     },
     "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
       "dev": true
     },
     "sass-graph": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
+      "version": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "scss-tokenizer": "0.2.3",
-        "yargs": "7.1.0"
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "scss-tokenizer": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+        "yargs": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz"
       },
       "dependencies": {
         "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         },
         "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
           }
         },
         "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
           }
         },
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         },
         "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
           }
         },
         "yargs": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "version": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "5.0.0"
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+            "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+            "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+            "require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "which-module": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz"
           }
         },
         "yargs-parser": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
           "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0"
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
           }
         }
       }
     },
     "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "version": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
       "dev": true
     },
     "scss-tokenizer": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "version": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
-        "js-base64": "2.1.9",
-        "source-map": "0.4.4"
+        "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
       },
       "dependencies": {
         "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
           }
         }
       }
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "version": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
       "dev": true
     },
     "send": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.15.2.tgz",
+      "version": "https://registry.npmjs.org/send/-/send-0.15.2.tgz",
       "integrity": "sha1-+R+rRAO8+H5xb3DOtdsvV4vcF9Y=",
       "dev": true,
       "requires": {
-        "debug": "2.6.4",
-        "depd": "1.1.1",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.0",
-        "fresh": "0.5.0",
-        "http-errors": "1.6.2",
-        "mime": "1.3.4",
-        "ms": "1.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.3.1"
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+        "depd": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+        "destroy": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+        "etag": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+        "fresh": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
+        "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+        "mime": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+        "ms": "https://registry.npmjs.org/ms/-/ms-1.0.0.tgz",
+        "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+        "range-parser": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+        "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+          "version": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
           "integrity": "sha1-dYaps8OXQcAoKuM0RcTorHRzT+A=",
           "dev": true,
           "requires": {
-            "ms": "0.7.3"
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz"
           },
           "dependencies": {
             "ms": {
-              "version": "0.7.3",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+              "version": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
               "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8=",
               "dev": true
             }
           }
         },
         "fresh": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
+          "version": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
           "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
           "dev": true
         },
         "http-errors": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+          "version": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
           "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
           "dev": true,
           "requires": {
-            "depd": "1.1.1",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.0.3",
-            "statuses": "1.3.1"
+            "depd": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "setprototypeof": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+            "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
           }
         },
         "mime": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+          "version": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
           "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
           "dev": true
         },
         "ms": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/ms/-/ms-1.0.0.tgz",
           "integrity": "sha1-Wa3NIu3FQ/e1OBhi0xOHsfS8lHM=",
           "dev": true
         },
         "setprototypeof": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+          "version": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
           "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
           "dev": true
         }
       }
     },
     "sequencify": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
+      "version": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
       "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
       "dev": true
     },
     "serve-index": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz",
+      "version": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz",
       "integrity": "sha1-fF2WwT+xMRAfk8HFd0+FFqHnjTs=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.4",
-        "batch": "0.5.3",
-        "debug": "2.2.0",
-        "escape-html": "1.0.3",
-        "http-errors": "1.5.1",
-        "mime-types": "2.1.16",
-        "parseurl": "1.3.1"
+        "accepts": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
+        "batch": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+        "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
       },
       "dependencies": {
         "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "dev": true,
           "requires": {
-            "ms": "0.7.1"
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
           }
         },
         "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
           "dev": true
         }
       }
     },
     "serve-static": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.2.tgz",
+      "version": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.2.tgz",
       "integrity": "sha1-5UbicmCBuBtLzsjpCAjrzdMjr7o=",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.1",
-        "send": "0.15.2"
+        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+        "send": "https://registry.npmjs.org/send/-/send-0.15.2.tgz"
       }
     },
     "server-destroy": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
       "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0=",
       "dev": true
     },
     "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
     },
     "setprototypeof": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
       "integrity": "sha1-gaVSFB7BBLiOic44MQOtXGZWTQg=",
       "dev": true
     },
     "sha.js": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
+      "version": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
       "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
       }
     },
     "shasum": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
       "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
       "dev": true,
       "requires": {
-        "json-stable-stringify": "0.0.1",
-        "sha.js": "2.4.8"
+        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+        "sha.js": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
       },
       "dependencies": {
         "json-stable-stringify": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
           "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
           "dev": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
           }
         }
       }
@@ -7803,58 +8303,50 @@
       "dev": true
     },
     "shell-quote": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
       "integrity": "sha1-GkEZbzwDM8SCMjWT1ohuzxU92YY=",
       "dev": true
     },
     "shelljs": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
+      "version": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
       "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
       "dev": true
     },
     "shellwords": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "version": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+      "integrity": "sha1-1rkYHBpI05cyTISHHvvPxz/AZUs=",
       "dev": true
     },
     "shrinkwrap": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/shrinkwrap/-/shrinkwrap-0.4.0.tgz",
+      "version": "https://registry.npmjs.org/shrinkwrap/-/shrinkwrap-0.4.0.tgz",
       "integrity": "sha1-kcSTGPxmWhS7ZDJN6CEBzQK8WbI=",
       "dev": true,
       "requires": {
-        "debug": "0.8.1",
-        "eventemitter3": "0.1.6",
-        "fusing": "0.2.3",
-        "npm-registry": "0.1.13"
+        "debug": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
+        "eventemitter3": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.6.tgz",
+        "fusing": "https://registry.npmjs.org/fusing/-/fusing-0.2.3.tgz",
+        "npm-registry": "https://registry.npmjs.org/npm-registry/-/npm-registry-0.1.13.tgz"
       },
       "dependencies": {
         "debug": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
+          "version": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
           "integrity": "sha1-IP9NJvXkIstoobrLu2EDmtjBwTA=",
           "dev": true
         },
         "eventemitter3": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.6.tgz",
+          "version": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.6.tgz",
           "integrity": "sha1-jHrES4e6q1XNUMgo3Dh3jqwFLqU=",
           "dev": true
         }
       }
     },
     "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
@@ -7871,264 +8363,243 @@
       "dev": true
     },
     "slash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
     },
     "slice-ansi": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "version": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
     "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
       }
     },
     "socket.io": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.6.0.tgz",
+      "version": "https://registry.npmjs.org/socket.io/-/socket.io-1.6.0.tgz",
       "integrity": "sha1-PkDZMmN+a9kjmBslyvfFPoO24uE=",
       "dev": true,
       "requires": {
-        "debug": "2.3.3",
-        "engine.io": "1.8.0",
-        "has-binary": "0.1.7",
-        "object-assign": "4.1.0",
-        "socket.io-adapter": "0.5.0",
-        "socket.io-client": "1.6.0",
-        "socket.io-parser": "2.3.1"
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+        "engine.io": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.0.tgz",
+        "has-binary": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+        "socket.io-adapter": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
+        "socket.io-client": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.6.0.tgz",
+        "socket.io-parser": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz"
       },
       "dependencies": {
         "debug": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "version": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
           "dev": true,
           "requires": {
-            "ms": "0.7.2"
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
           }
         },
         "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
           "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
           "dev": true
         },
         "object-assign": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+          "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
           "dev": true
         }
       }
     },
     "socket.io-adapter": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
+      "version": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
       "integrity": "sha1-y21LuL7IHhB4uZZ3+c7QBGBmu4s=",
       "dev": true,
       "requires": {
-        "debug": "2.3.3",
-        "socket.io-parser": "2.3.1"
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+        "socket.io-parser": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz"
       },
       "dependencies": {
         "debug": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "version": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
           "dev": true,
           "requires": {
-            "ms": "0.7.2"
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
           }
         },
         "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
           "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
           "dev": true
         }
       }
     },
     "socket.io-client": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.6.0.tgz",
+      "version": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.6.0.tgz",
       "integrity": "sha1-W2aPT3cTBN/u0XkGRwg4b6ZxeFM=",
       "dev": true,
       "requires": {
-        "backo2": "1.0.2",
-        "component-bind": "1.0.0",
-        "component-emitter": "1.2.1",
-        "debug": "2.3.3",
-        "engine.io-client": "1.8.0",
-        "has-binary": "0.1.7",
-        "indexof": "0.0.1",
-        "object-component": "0.0.3",
-        "parseuri": "0.0.5",
-        "socket.io-parser": "2.3.1",
-        "to-array": "0.1.4"
+        "backo2": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+        "component-bind": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+        "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+        "engine.io-client": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.0.tgz",
+        "has-binary": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+        "indexof": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+        "object-component": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+        "parseuri": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+        "socket.io-parser": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
+        "to-array": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz"
       },
       "dependencies": {
         "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "version": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
           "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
           "dev": true
         },
         "debug": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "version": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
           "dev": true,
           "requires": {
-            "ms": "0.7.2"
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
           }
         },
         "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
           "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
           "dev": true
         }
       }
     },
     "socket.io-parser": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
+      "version": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
       "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
       "dev": true,
       "requires": {
-        "component-emitter": "1.1.2",
-        "debug": "2.2.0",
-        "isarray": "0.0.1",
-        "json3": "3.3.2"
+        "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+        "json3": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
       },
       "dependencies": {
         "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "dev": true,
           "requires": {
-            "ms": "0.7.1"
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
           }
         },
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
           "dev": true
         }
       }
     },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
     "source-map-resolve": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+      "version": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
       "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
       "dev": true,
       "requires": {
-        "atob": "1.1.3",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.3.0",
-        "urix": "0.1.0"
+        "atob": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
+        "resolve-url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+        "source-map-url": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+        "urix": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
       }
     },
     "source-map-support": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+      "version": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
       "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
       "dev": true,
       "requires": {
-        "source-map": "0.1.32"
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz"
       },
       "dependencies": {
         "source-map": {
-          "version": "0.1.32",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
           "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
           }
         }
       }
     },
     "source-map-url": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+      "version": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
       "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk=",
       "dev": true
     },
     "sparkles": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
       "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
       "dev": true
     },
     "spdx-correct": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
       }
     },
     "spdx-expression-parse": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
       "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
       "dev": true
     },
     "spdx-license-ids": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "version": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
     },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "dev": true,
+      "requires": {
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      }
+    },
     "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+        "bcrypt-pbkdf": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+        "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+        "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+        "getpass": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
       },
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
@@ -8141,217 +8612,202 @@
       "dev": true
     },
     "statuses": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+      "version": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
       "dev": true
     },
     "stdout-stream": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
+      "version": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
       "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
       }
     },
     "stream-browserify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
       "integrity": "sha1-v5tKv7QrJ011FHnkTg/yZWtvEZM=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "1.1.14"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
       },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
       }
     },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "dev": true,
+      "requires": {
+        "duplexer": "0.1.1"
+      }
+    },
     "stream-combiner2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
       "integrity": "sha1-unKmtQy/q/qVD8i8h2BL0B62BnE=",
       "dev": true,
       "requires": {
-        "duplexer2": "0.0.2",
-        "through2": "0.5.1"
+        "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
       },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
         "through2": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+          "version": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
           "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "3.0.0"
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
           }
         },
         "xtend": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+          "version": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
           "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
           "dev": true
         }
       }
     },
     "stream-consume": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
       "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8=",
       "dev": true
     },
     "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
     "stream-splicer": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
+      "version": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
       "integrity": "sha1-PARBvhW5v04iYnXm3IOWR0VUZmE=",
       "dev": true,
       "requires": {
-        "indexof": "0.0.1",
-        "inherits": "2.0.3",
-        "isarray": "0.0.1",
-        "readable-stream": "1.1.14",
-        "readable-wrap": "1.0.0",
-        "through2": "1.1.1"
+        "indexof": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+        "readable-wrap": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz"
       },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
         "through2": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+          "version": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "integrity": "sha1-CEfLxESfNAVXTb3M2buEG4OsNUU=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.1.14",
-            "xtend": "4.0.1"
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
           }
         }
       }
     },
     "stream-throttle": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
+      "version": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
       "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
       "dev": true,
       "requires": {
-        "commander": "2.11.0",
-        "limiter": "1.1.2"
+        "commander": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+        "limiter": "https://registry.npmjs.org/limiter/-/limiter-1.1.2.tgz"
       }
     },
     "streamfilter": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.5.tgz",
+      "version": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.5.tgz",
       "integrity": "sha1-h1BxEb644phFFxe1Ec/tjwAqv1M=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
       }
     },
     "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+        "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+      }
+    },
+    "string_decoder": {
+      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
       }
     },
     "stringify-object": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-2.4.0.tgz",
+      "version": "https://registry.npmjs.org/stringify-object/-/stringify-object-2.4.0.tgz",
       "integrity": "sha1-xi0RAj6yH+LZsIe+A5om3zsioJ0=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "1.1.0",
-        "is-regexp": "1.0.0"
+        "is-plain-obj": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+        "is-regexp": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz"
       }
     },
     "stringmap": {
@@ -8367,325 +8823,287 @@
       "dev": true
     },
     "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
       "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
       "dev": true
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
       }
     },
     "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
       }
     },
     "strip-bom-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
       "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
       "dev": true,
       "requires": {
-        "first-chunk-stream": "2.0.0",
-        "strip-bom": "2.0.0"
+        "first-chunk-stream": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
       },
       "dependencies": {
         "first-chunk-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
+          "version": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
           "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.3"
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
           }
         }
       }
     },
     "strip-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
       }
     },
     "strip-json-comments": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
       "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
       "dev": true
     },
     "subarg": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
       "dev": true,
       "requires": {
-        "minimist": "1.2.0"
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
       }
     },
     "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
     "svgo": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
+      "version": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
       "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
       "dev": true,
       "requires": {
-        "coa": "1.0.4",
-        "colors": "1.1.2",
-        "csso": "2.3.2",
-        "js-yaml": "3.7.0",
-        "mkdirp": "0.5.1",
-        "sax": "1.2.4",
-        "whet.extend": "0.9.9"
+        "coa": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+        "colors": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+        "csso": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "sax": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+        "whet.extend": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
       },
       "dependencies": {
         "colors": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+          "version": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
           "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
           "dev": true
         },
         "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "version": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
           "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
           "dev": true
         },
         "js-yaml": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+          "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
           "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "2.7.3"
+            "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+            "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
           }
         }
       }
     },
     "syntax-error": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.3.0.tgz",
+      "version": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.3.0.tgz",
       "integrity": "sha1-HtkmbE1AvnXcVb+bsct3Biu5bKE=",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13"
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz"
       }
     },
     "table": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "version": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
-        "lodash": "4.17.4",
-        "slice-ansi": "0.0.4",
-        "string-width": "2.1.1"
+        "ajv": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+        "ajv-keywords": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "slice-ansi": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz"
       },
       "dependencies": {
         "ajv-keywords": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+          "version": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
           "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
           "dev": true
         },
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         },
         "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "version": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
           }
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
           }
         }
       }
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
+        "block-stream": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+        "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
       }
     },
     "ternary-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
       "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
       "dev": true,
       "requires": {
-        "duplexify": "3.5.1",
-        "fork-stream": "0.0.4",
-        "merge-stream": "1.0.1",
-        "through2": "2.0.3"
+        "duplexify": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
+        "fork-stream": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz",
+        "merge-stream": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
       }
     },
     "text-hex": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz",
+      "version": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz",
       "integrity": "sha1-V4+8haapJjbkLdF7QdAhjM6esrM=",
       "dev": true
     },
     "text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "tfunk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-3.1.0.tgz",
+      "version": "https://registry.npmjs.org/tfunk/-/tfunk-3.1.0.tgz",
       "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "object-path": "0.9.2"
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "object-path": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz"
       }
     },
     "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "through2": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
       }
     },
     "through2-filter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "dev": true,
       "requires": {
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
       }
     },
     "tildify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
+      "version": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
       "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
       }
     },
     "time-stamp": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
       "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
       "dev": true
     },
     "timers-browserify": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "version": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
       "dev": true,
       "requires": {
-        "process": "0.11.10"
+        "process": "https://registry.npmjs.org/process/-/process-0.11.10.tgz"
       }
     },
     "timers-ext": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.2.tgz",
       "integrity": "sha1-YcxHp2wavTGV8UUn+XjViulMUgQ=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.29",
-        "next-tick": "1.0.0"
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.29.tgz",
+        "next-tick": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz"
       }
     },
     "to-absolute-glob": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
       "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1"
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
       }
     },
     "to-array": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+      "version": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
       "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
       "dev": true
     },
     "to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
     "tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+      "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
       "dev": true,
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
       }
     },
     "trim-newlines": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
     },
@@ -8702,8 +9120,7 @@
       "dev": true
     },
     "tryit": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
       "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
       "dev": true
     },
@@ -8714,695 +9131,639 @@
       "dev": true
     },
     "tty-browserify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "version": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
     "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
       }
     },
     "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true,
       "optional": true
     },
     "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
       }
     },
     "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "version": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.12",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz",
+      "version": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz",
       "integrity": "sha1-BMgamb3V3FImPqKdJMa/jUgYpLs=",
       "dev": true
     },
     "uglify-js": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
+      "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
       "integrity": "sha1-ZeovswWck5RpLxX+2HwrNsFrmt8=",
       "dev": true,
       "requires": {
-        "async": "0.2.10",
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "async": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+        "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+        "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
       },
       "dependencies": {
         "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "version": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
           "dev": true
         },
         "window-size": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
           "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
           "dev": true
         },
         "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+            "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
           }
         }
       }
     },
     "uglify-save-license": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/uglify-save-license/-/uglify-save-license-0.4.1.tgz",
+      "version": "https://registry.npmjs.org/uglify-save-license/-/uglify-save-license-0.4.1.tgz",
       "integrity": "sha1-lXJsF8xv0XHDYX479NjYKqjEzOE=",
       "dev": true
     },
     "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true
     },
     "ultron": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
       "dev": true
     },
     "umd": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
+      "version": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
       "integrity": "sha1-iuVW4RAR9jwllnCKiDclnwGz1g4=",
       "dev": true
     },
     "unc-path-regex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
       "dev": true
     },
     "underscore": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "version": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
       "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
       "dev": true
     },
     "unique-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
       "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
       "dev": true
     },
     "universalify": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
       "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
       "dev": true
     },
     "unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
     "urix": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
     "url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "version": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
       "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
       "dev": true,
       "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
+        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+        "querystring": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
       },
       "dependencies": {
         "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "version": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
       }
     },
     "user-home": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
       "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
       "dev": true
     },
     "util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "version": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.1"
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
       },
       "dependencies": {
         "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
           "dev": true
         }
       }
     },
     "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "utils-merge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
       "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
       "dev": true
     },
     "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+      "version": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
       "dev": true
     },
     "v8flags": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+      "version": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "dev": true,
       "requires": {
-        "user-home": "1.1.1"
+        "user-home": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
       }
     },
     "vali-date": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
       "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
       "dev": true
     },
     "validate-npm-package-license": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+        "spdx-expression-parse": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
       }
     },
     "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "version": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
       },
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
       }
     },
     "vinyl": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+      "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
       "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
       "dev": true,
       "requires": {
-        "clone": "1.0.2",
-        "clone-stats": "0.0.1",
-        "replace-ext": "0.0.1"
+        "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+        "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+        "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
       }
     },
     "vinyl-buffer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vinyl-buffer/-/vinyl-buffer-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/vinyl-buffer/-/vinyl-buffer-1.0.0.tgz",
       "integrity": "sha1-ygZ+oIQx1QdyKx3lCD9gJhbrwjQ=",
       "dev": true,
       "requires": {
-        "bl": "0.9.5",
-        "through2": "0.6.5"
+        "bl": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
       },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
         "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
           }
         }
       }
     },
     "vinyl-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
       "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0",
-        "strip-bom-stream": "2.0.0",
-        "vinyl": "1.2.0"
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+        "strip-bom-stream": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz"
       },
       "dependencies": {
         "vinyl": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+          "version": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
           "requires": {
-            "clone": "1.0.2",
-            "clone-stats": "0.0.1",
-            "replace-ext": "0.0.1"
+            "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+            "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
           }
         }
       }
     },
     "vinyl-fs": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
+      "version": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
       "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
       "dev": true,
       "requires": {
-        "defaults": "1.0.3",
-        "glob-stream": "3.1.18",
-        "glob-watcher": "0.0.6",
-        "graceful-fs": "3.0.11",
-        "mkdirp": "0.5.1",
-        "strip-bom": "1.0.0",
-        "through2": "0.6.5",
-        "vinyl": "0.4.6"
+        "defaults": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+        "glob-stream": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+        "glob-watcher": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
       },
       "dependencies": {
         "clone": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "version": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
           "dev": true
         },
         "graceful-fs": {
-          "version": "3.0.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true,
           "requires": {
-            "natives": "1.1.0"
+            "natives": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz"
           }
         },
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
         "strip-bom": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
           "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
           "dev": true,
           "requires": {
-            "first-chunk-stream": "1.0.0",
-            "is-utf8": "0.2.1"
+            "first-chunk-stream": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+            "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
           }
         },
         "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
           }
         },
         "vinyl": {
-          "version": "0.4.6",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
           "requires": {
-            "clone": "0.2.0",
-            "clone-stats": "0.0.1"
+            "clone": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
           }
         }
       }
     },
     "vinyl-source-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz",
       "integrity": "sha1-RMvlEIIFJ53rDFZTwJSiiHk4sas=",
       "dev": true,
       "requires": {
-        "through2": "0.6.5",
-        "vinyl": "0.4.6"
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
       },
       "dependencies": {
         "clone": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "version": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
           "dev": true
         },
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
         "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
           }
         },
         "vinyl": {
-          "version": "0.4.6",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
           "requires": {
-            "clone": "0.2.0",
-            "clone-stats": "0.0.1"
+            "clone": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
           }
         }
       }
     },
     "vinyl-sourcemaps-apply": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
       "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
       }
     },
     "vm-browserify": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "version": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
       "dev": true,
       "requires": {
-        "indexof": "0.0.1"
+        "indexof": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
       }
     },
     "weinre": {
-      "version": "2.0.0-pre-I0Z7U9OV",
-      "resolved": "https://registry.npmjs.org/weinre/-/weinre-2.0.0-pre-I0Z7U9OV.tgz",
+      "version": "https://registry.npmjs.org/weinre/-/weinre-2.0.0-pre-I0Z7U9OV.tgz",
       "integrity": "sha1-/viqIjkh97QLu71MPtQwL2/QqBM=",
       "dev": true,
       "requires": {
-        "express": "2.5.11",
-        "nopt": "3.0.6",
-        "underscore": "1.7.0"
+        "express": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
+        "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+        "underscore": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
       }
     },
     "whet.extend": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+      "version": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
       "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
       "dev": true
     },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "version": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
       }
     },
     "which-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
       "dev": true
     },
     "wide-align": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
       }
     },
     "window-size": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
       "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
       "dev": true
     },
     "wordwrap": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
       "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
       "dev": true
     },
     "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "version": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
       }
     },
     "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "write": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
       }
     },
     "ws": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
       "integrity": "sha1-CC3bbGQehdS7RR8D1S8G6r2x8Bg=",
       "dev": true,
       "requires": {
-        "options": "0.0.6",
-        "ultron": "1.0.2"
+        "options": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+        "ultron": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
       }
     },
     "wtf-8": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
       "integrity": "sha1-OS2LotDxw00e4tYw8V0O+2jhBIo=",
       "dev": true
     },
+    "xml2js": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+      "dev": true,
+      "requires": {
+        "sax": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+        "xmlbuilder": "4.2.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        }
+      }
+    },
     "xmlhttprequest-ssl": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
+      "version": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
       "integrity": "sha1-GFqIjATspGw+QHDZn3tJ3jUomS0=",
       "dev": true
     },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     },
     "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "version": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
     },
     "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "version": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yargs": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+      "version": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
       "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
       "dev": true,
       "requires": {
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "lodash.assign": "4.2.0",
-        "os-locale": "1.4.0",
-        "read-pkg-up": "1.0.1",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "1.0.2",
-        "which-module": "1.0.0",
-        "window-size": "0.2.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "2.4.1"
+        "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+        "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+        "get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+        "lodash.assign": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+        "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+        "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+        "require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+        "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+        "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+        "which-module": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+        "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+        "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+        "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz"
       },
       "dependencies": {
         "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         },
         "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
           }
         },
         "window-size": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+          "version": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
           "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
           "dev": true
         },
         "yargs-parser": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+          "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
           "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0",
-            "lodash.assign": "4.2.0"
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+            "lodash.assign": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
           }
         }
       }
     },
     "yargs-parser": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+      "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
       "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
       "dev": true,
       "requires": {
-        "camelcase": "3.0.0"
+        "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
       },
       "dependencies": {
         "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         }
       }
     },
     "yeast": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
       "dev": true
     }

--- a/styleguide/package.json
+++ b/styleguide/package.json
@@ -1,7 +1,24 @@
 {
-  "name": "MayflowerPatternLibrary",
-  "author": "Jonathan Dallas / Mike Lambert",
-  "version": "3.2.2",
+  "name": "@massds/mayflower",
+  "description": "Open source UI components and visual style guide for Massachusetts government websites",
+  "version": "5.10.0",
+  "author": "Massachusetts Digital Services (MDS)",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/massgov/mayflower.git"
+  },
+  "contributors": [
+    "Jes Constantine <jesconstantine@gmail.com>",
+    "Isaac Chansky <ichansky@gmail.com>",
+    "Jonathan Dallas <jonathan.dallas@velir.com>",
+    "Sarena Douglass <sarena.douglass@velir.com>",
+    "Greg LeRoux <leroux@palantir.net>"
+  ],
+  "license": "SEE LICENSE IN LICENSE.md",
+  "bugs": {
+    "url": "https://github.com/massgov/mayflower/issues"
+  },
+  "homepage": "https://github.com/massgov/mayflower#readme",
   "devDependencies": {
     "babelify": "^6.4.0",
     "browser-sync": "^2.18.13",
@@ -12,6 +29,7 @@
     "eslint-plugin-react": "^5.2.2",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.1",
+    "gulp-bump": "^3.0.0",
     "gulp-cached": "^1.1.1",
     "gulp-concat": "^2.6.1",
     "gulp-copy": "^1.0.1",
@@ -24,6 +42,7 @@
     "gulp-plumber": "^1.1.0",
     "gulp-rename": "^1.2.2",
     "gulp-run": "^1.7.1",
+    "gulp-s3-upload": "^1.6.6",
     "gulp-sass": "^3.1.0",
     "gulp-sourcemaps": "^1.12.0",
     "gulp-svgmin": "^1.2.4",
@@ -39,6 +58,7 @@
     "run-sequence": "^1.2.2",
     "shrinkwrap": "^0.4.0",
     "through2": "^2.0.3",
+    "user-home": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "yargs": "^4.8.1"

--- a/styleguide/package.json
+++ b/styleguide/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@massds/mayflower",
   "description": "Open source UI components and visual style guide for Massachusetts government websites",
-  "version": "5.10.0",
+  "version": "5.12.0",
   "author": "Massachusetts Digital Services (MDS)",
   "repository": {
     "type": "git",

--- a/styleguide/source/_data/data.json
+++ b/styleguide/source/_data/data.json
@@ -1,5 +1,6 @@
 {
   "title" : "Mass Gov",
+  "version": "5.10.1",
   "htmlClass": "pl",
   "bodyClass": "",
   "directory": "assets",

--- a/styleguide/source/_data/data.json
+++ b/styleguide/source/_data/data.json
@@ -1,6 +1,6 @@
 {
   "title" : "Mass Gov",
-  "version": "5.10.1",
+  "version": "5.12.0",
   "htmlClass": "pl",
   "bodyClass": "",
   "directory": "assets",

--- a/styleguide/source/_patterns/01-atoms/04-headings/colored-heading-blue.md
+++ b/styleguide/source/_patterns/01-atoms/04-headings/colored-heading-blue.md
@@ -1,0 +1,5 @@
+### Description
+This is a variant of the [Colored Heading](./?p=atoms-colored-heading) pattern showing an example with a blue background.
+
+### How to generate
+* set the `color` variable to 'blue'

--- a/styleguide/source/_patterns/01-atoms/04-headings/colored-heading.md
+++ b/styleguide/source/_patterns/01-atoms/04-headings/colored-heading.md
@@ -7,11 +7,13 @@ An Heading element with a background color
 ### Variant options
 * With a [green](./?p=atoms-colored-heading-green) background
 * Usage [example](./?p=atoms-colored-heading-usage-example) showing green heading for Page Content and gray for Right Rail
+* With a [blue](./?p=atoms-colored-heading-blue) background
 
 ### Usage Guidelines
 * Green color would only be used at the top of the Page Content
 * Gray color would be used in the Right Rail
 * When used in the Right Rail the diagonal will automatically appear on the left
+* Blue color is only used for filter in the search application
 
 
 ### Variables
@@ -22,7 +24,7 @@ coloredHeading {
   titleContext: 
     type: string / optional
   color:
-    type: string ('','green') / optional
+    type: string ('','green','blue') / optional
   level:
     type: number / optional
 }

--- a/styleguide/source/_patterns/01-atoms/04-headings/colored-heading~blue.json
+++ b/styleguide/source/_patterns/01-atoms/04-headings/colored-heading~blue.json
@@ -1,0 +1,6 @@
+{
+  "coloredHeading": {
+    "text": "Colored Heading",
+    "color": "blue"
+  }
+}

--- a/styleguide/source/_patterns/02-molecules/callout-link-as-description.md
+++ b/styleguide/source/_patterns/02-molecules/callout-link-as-description.md
@@ -1,0 +1,5 @@
+### Description
+This is a variant of the [Callout Link](./?p=molecules-callout-link) pattern showing an example styled with description text.
+
+### How to generate
+* assign text content to the `description` variable.

--- a/styleguide/source/_patterns/02-molecules/callout-link.md
+++ b/styleguide/source/_patterns/02-molecules/callout-link.md
@@ -6,6 +6,8 @@ Description: This pattern shows a link styled as a card
 ### Pattern Contains
 * SVG Arrow atom
 
+### Variant options
+* With [description](./?p=molecules-callout-link-as-description) text.
 
 ### Variables
 ~~~
@@ -16,5 +18,7 @@ calloutLink: {
     type: string / required
   info:
     type: string (adds more description about the link) / optional
+   description:
+    type: string (adds a short description under the title text) / optional
 }
 ~~~

--- a/styleguide/source/_patterns/02-molecules/callout-link.twig
+++ b/styleguide/source/_patterns/02-molecules/callout-link.twig
@@ -1,3 +1,6 @@
 <div class="ma__callout-link" title={{ calloutLink.info }}>
   <a href="{{ calloutLink.href }}"><span class="ma__callout-link__container"><span class="ma__callout-link__text" >{{ calloutLink.text }}&nbsp;{% include "@atoms/05-icons/svg-arrow.twig" %}</span></span></a>
+  {% if calloutLink.description %}
+    <p class="ma__callout-link__description">{{ calloutLink.description }}</p>
+  {% endif %}
 </div>

--- a/styleguide/source/_patterns/02-molecules/callout-link~as-description.json
+++ b/styleguide/source/_patterns/02-molecules/callout-link~as-description.json
@@ -1,0 +1,8 @@
+{
+  "calloutLink": {
+    "text": "Link to another page",
+    "href": "#",
+    "info": "Find out more about this thing on our blah page",
+    "description": "This is some more important information about the text. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque rutrum mauris quam, et imperdiet purus pellentesque vel."
+  }
+}

--- a/styleguide/source/_patterns/05-pages/readme2.json
+++ b/styleguide/source/_patterns/05-pages/readme2.json
@@ -5,7 +5,7 @@
   },
 
   "errorPage": {
-    "type": "v5.11.0 (2/2/2018)",
+    "type": "v5.12.0 (2/8/2018)",
     "title": "Welcome to Mayflower, the Commonwealth's Design System",
     "message": "Use the navigation menu above to browse our pattern library."
   },

--- a/styleguide/source/_patterns/05-pages/readme2.json
+++ b/styleguide/source/_patterns/05-pages/readme2.json
@@ -7,7 +7,7 @@
   "errorPage": {
     "type": "v5.11.0 (2/2/2018)",
     "title": "Welcome to Mayflower, the Commonwealth's Design System",
-    "message": "Use the navigation menu above to browse our patterns."
+    "message": "Use the navigation menu above to browse our pattern library."
   },
 
   "linkList": {

--- a/styleguide/source/assets/scss/02-molecules/_callout-link.scss
+++ b/styleguide/source/assets/scss/02-molecules/_callout-link.scss
@@ -1,7 +1,8 @@
 .ma__callout-link {
   border: 3px solid;
   display: inline-flex;
-    align-items: stretch;
+        align-items: stretch;
+        flex-wrap: wrap;
 
   // .pre-content > &,
   // .post-content > &,
@@ -31,6 +32,18 @@
       padding: 20px 30px;
     }
   }
+  
+  &__description {
+    display: none;
+    padding: 0px 20px 15px;
+        @media ($bp-x-small-min) {
+          display: flex;
+              align-items: center;
+        }
+        @media ($bp-small-min) {
+          padding: 0px 30px 20px;
+        }     
+  }
 
   &__container { // .ma__decorative-link 
     display: inline-block;
@@ -55,4 +68,6 @@
       width: .6em;
     }
   }
+
+  
 }

--- a/styleguide/source/assets/scss/03-organisms/_page-banner.scss
+++ b/styleguide/source/assets/scss/03-organisms/_page-banner.scss
@@ -4,7 +4,9 @@ $page-banner-height: 330px;
 .ma__page-banner {
   background-size: cover;
   background-position: center center;
-  height: $page-banner-height;
+  height: auto;
+  max-height: 540px;
+
   margin-bottom: 20px;
   overflow: hidden;
   position: relative;
@@ -72,28 +74,27 @@ $page-banner-height: 330px;
     font-size: 1rem;
     max-width: 1050px;
     padding: 30px 25px 45px 0;
-    position: absolute;
-      top: 50%;
-    transform: translateY(-50%);
     z-index: 1;
 
     @media ($bp-x-small-min) {
       margin-right: 70px;
       padding-top: 50px;
       padding-right: 80px;
+      position: absolute;
+        top: 50%;
       transform: translateY(-50%) skew(-30deg);
     }
 
     &:before {
       content: "";
       height: 100%;
-      position: absolute;
         top: 0;
         right: 100%;
       width: 50vw;
 
       @media ($bp-x-small-min) {
         right: 99%; // weird gap when skewed is shown
+        position: absolute;
       }
     }
   }
@@ -201,6 +202,7 @@ $page-banner-height: 330px;
     line-height: 1.05;
     margin-bottom: 0;
     vertical-align: middle;
+    z-index: 1;
 
     @media ($bp-x-small-min) {
       transform: skew(30deg);

--- a/styleguide/source/assets/scss/03-organisms/_rich-text.scss
+++ b/styleguide/source/assets/scss/03-organisms/_rich-text.scss
@@ -192,7 +192,7 @@ $heading-indent: $gutter;
     overflow-wrap: break-word;
     transition: border .3s;
     word-wrap: break-word;
-    word-break: break-word;
+    word-break: normal;
   }
 
   // end link styles

--- a/styleguide/source/assets/scss/06-theme/01-atoms/_colored-heading.scss
+++ b/styleguide/source/assets/scss/06-theme/01-atoms/_colored-heading.scss
@@ -4,4 +4,8 @@
   &--green {
     background-color: $c-theme-green;
   }
+
+    &--blue {
+    background-color: $c-theme-blue;
+  }
 }

--- a/styleguide/source/assets/scss/06-theme/02-molecules/_callout-link.scss
+++ b/styleguide/source/assets/scss/06-theme/02-molecules/_callout-link.scss
@@ -12,4 +12,10 @@
       fill: rgba($c-font-link,.5);
     }
   }
+
+  &__description {
+    font-size: 1.25rem;
+    font-weight: 400;
+    color: rgba($c-font-link,1);
+  }
 }

--- a/styleguide/tools/gulp/gulpfile.js
+++ b/styleguide/tools/gulp/gulpfile.js
@@ -30,10 +30,12 @@ var defaults = {
     dest: path.resolve(__dirname, "../../public/assets"),
     patternLabRoot: path.resolve(__dirname, "../../"),
     rootSite: path.resolve(__dirname, "../../public"),
+    rootSource: path.resolve(__dirname, "../../source"),
     tasks: ["copy", "copyTwig", "js", "css", "bower", "patternlab"],
     env: "development", // "development", "production", "local"
     watch: false,
-    browserSync: false
+    browserSync: false,
+    version: "0.0.0"
 };
 
 /**
@@ -82,6 +84,18 @@ gulp.task("build", function(){
 
 });
 
+/** Deploy to s3 bucket **/
+gulp.task("s3",function(){
+  var config = Object.assign({}, defaults, {
+    env   : "production",
+    watch : false,
+    browserSync: false,
+    tasks : ["s3"]
+  });
+
+  quench.build(config);
+});
+
 /**
  * Quick tool for converting svg icons into patternLab twig files
 **/
@@ -96,6 +110,18 @@ gulp.task("svg2twig",function(){
 
     quench.build(config);
 
+});
+
+/** Bump package version **/
+gulp.task("bump",function(){
+  var config = Object.assign({}, defaults, {
+    env   : "production",
+    watch : false,
+    browserSync: false,
+    tasks : ["bump"]
+  });
+
+  quench.build(config);
 });
 
 // watch for single tasks on the command line, eg "gulp js"

--- a/styleguide/tools/gulp/tasks/bump.js
+++ b/styleguide/tools/gulp/tasks/bump.js
@@ -1,0 +1,26 @@
+var gulp   = require("gulp"),
+    bump   = require("gulp-bump"),
+    argv   = require("yargs").argv;
+
+module.exports = function bumpTask(config){
+
+    // figure out the env variable
+    // argv has precedence. (if it was passed in the command line. eg. gulp bump --version 1.2.3)
+    var version = argv.v || config.version;
+
+    // copy files settings
+    var cfg = {
+        src: [
+          config.rootSource + "/_data/data.json",
+          config.patternLabRoot + "/package.json"
+        ]
+    };
+
+    /* bump semver version in files */
+    // Set a specific version
+    gulp.task('bump', function(){
+        return gulp.src(cfg.src, {base: "./"})
+            .pipe(bump({version: version}))
+            .pipe(gulp.dest("."));
+    });
+};

--- a/styleguide/tools/gulp/tasks/s3.js
+++ b/styleguide/tools/gulp/tasks/s3.js
@@ -1,0 +1,26 @@
+var gulp        = require("gulp"),
+    userHome    = require('user-home');
+
+module.exports = function s3Task(config){
+
+    s3Config = {
+        accessKeyId: process.env.AWS_ACCESS_KEY_ID ? process.env.AWS_ACCESS_KEY_ID : config.local.s3_accessKeyId,
+        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ? process.env.AWS_SECRET_ACCESS_KEY : config.local.s3_secretAccessKey,
+        bucket: process.env.AWS_BUCKET ? process.env.AWS_BUCKET : config.local.s3_bucket,
+        src: userHome + "/tmp/mayflower/**"
+    };
+
+    var s3 = require('gulp-s3-upload')(s3Config);
+
+    /* compile application javascript */
+    gulp.task("s3", function(){
+
+        return gulp.src(s3Config.src)
+          .pipe(s3({
+            Bucket: s3Config.bucket, //  Required
+            ACL:    'public-read'    //  Needs to be user-defined
+          }, {
+            maxRetries: 5
+          }));
+    });
+};


### PR DESCRIPTION
## 5.12.0 (2/8/2018)

### Changed
- DP-7718: Adds support for Description text to [@molecules/callout-link](https://mayflower.digital.mass.gov/?p=molecules-callout-link-as-description&view=c) (e.g calls to action on a location page header).
- D-7725: Adds Support for Blue Variant of [@atoms/colored-heading](https://mayflower.digital.mass.gov/?p=atoms-colored-heading-blue&view=c) (e.g. header in the press filter organism)

## Fixed
- DP-7359: Make line breaks on word in [richtext](https://mayflower.digital.mass.gov/?p=organisms-rich-text) links compatible with non-chrome browsers.
- DP-7490: Adjust the [page banner](https://mayflower.digital.mass.gov/?p=organisms-page-banner-as-overlay) and its children for flexble height.

## Added
- (For Devs): Adds shell scripts and circle config to deploy feature branches and production tags to mayflower.digital.mass.gov [s3 bucket|https://github.com/massgov/mayflower/blob/dev/docs/s3-architecture.md] AND to publish static assets on [NPM|https://www.npmjs.com/package/@massds/mayflower]. See new [release process|https://github.com/massgov/mayflower/blob/dev/docs/release.md]