### PR TITLE
Adjustment for longer titles in image link blocks

### DIFF
--- a/styleguide/source/_patterns/02-molecules/image-link.twig
+++ b/styleguide/source/_patterns/02-molecules/image-link.twig
@@ -3,7 +3,7 @@
     {% if imageLink.image %}
       <img class="ma__image-link__image" src="{{imageLink.image.src}}" alt="{{imageLink.image.alt}}">
     {% endif %}
-    <span class="ma__image-link__text">{{imageLink.text}}&nbsp;</span>
+    <span class="ma__image-link__text">{{imageLink.text}}&nbsp;{% include "@atoms/05-icons/svg-arrow.twig" %}</span>
   </a>
 {% else %}
   <div class="ma__image-link">

--- a/styleguide/source/_patterns/03-organisms/by-author/image-link-list~as-blocks.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/image-link-list~as-blocks.json
@@ -67,7 +67,7 @@
       }
     },{
       "href":"#",
-      "text":"Lorem ipsum dolor sit amet, consectetur.",
+      "text":"Lorem ipsum dolor sit amet, but also a very very long title with also an acronym (LIDSABAVVLTWAA).",
       "info": "",
       "image": {
         "src": "../../assets/images/placeholder/250x250.png",

--- a/styleguide/source/assets/scss/02-molecules/_image-link.scss
+++ b/styleguide/source/assets/scss/02-molecules/_image-link.scss
@@ -14,15 +14,19 @@
     display: flex;
     justify-content: flex-start;
     align-items: center;
-    height: 5rem;
+    padding: 20px;
+    height: 100%;
     .ma__image-link__image {
-        width: 5rem;
-        height: 5rem;
+        width: 6rem;
+        height: 6rem;
         margin: 0;
     }
     .ma__image-link__text {
-        padding: 1rem 1rem 1rem 2rem;
+        padding: 1rem 1rem 1rem 1.5rem;
         width: 100%;
         line-height: 1.2;
+    }
+    svg {
+        vertical-align: middle;
     }
 }

--- a/styleguide/source/assets/scss/03-organisms/_image-link-list.scss
+++ b/styleguide/source/assets/scss/03-organisms/_image-link-list.scss
@@ -28,24 +28,6 @@
       }
     }
   }
-}
-
-.ma__link-list--image-links {
-  .ma__link-list__item {
-    &.ma__link-list__item--secondary,
-    &.ma__link-list__item--tertiary {
-      display: none;
-    }
-  }
-  .ma__link-list__item .ma__image-link {
-    padding: 10px 0;
-  }
-  .ma__link-list__toggle {
-    margin-top: 20px;
-  }
-}
-
-.ma__link-list--image-blocks {
   .ma__link-list__toggle {
     display: none;
     // show on small if has secondary or tertiary links
@@ -72,6 +54,22 @@
     }
   }
 }
+
+.ma__link-list--image-links {
+  .ma__link-list__item {
+    &.ma__link-list__item--secondary,
+    &.ma__link-list__item--tertiary {
+      display: none;
+    }
+  }
+  .ma__link-list__item .ma__image-link {
+    padding: 10px 0;
+  }
+  .ma__link-list__toggle {
+    margin-top: 20px;
+  }
+}
+
 
 .ma__link-list--image-links,
 .ma__link-list--image-blocks {

--- a/styleguide/source/assets/scss/06-theme/02-molecules/_image-link.scss
+++ b/styleguide/source/assets/scss/06-theme/02-molecules/_image-link.scss
@@ -4,4 +4,7 @@
     .ma__image-link__text {
         color: $c-theme-gray;
     }
+    svg {
+        fill: $c-theme-gray;
+    }
 }


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
Apply a padding & flexbox adjustment to maintain height and account for longer titles.

## Related Issue / Ticket

- https://jira.state.ma.us/browse/DP-7483

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Ensure organism: http://localhost:3000/?p=organisms-image-link-list-as-blocks matches invision: https://projects.invisionapp.com/share/VYF2N5JX2#/screens

## Screenshots
<img width="1240" alt="screen shot 2018-02-09 at 1 04 10 pm" src="https://user-images.githubusercontent.com/1397914/36042466-e9dfbcac-0d99-11e8-8565-3e3e3586e234.png">



## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
