### PR TITLE
DP-1553 [a11y] Correct aria role value

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-template/illustrated-header.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/illustrated-header.twig
@@ -17,10 +17,10 @@
     </div>
   </div>
   {% if illustratedHeader.bgImage %}
-    <div 
-      style="background-image: url('{{ illustratedHeader.bgImage }}')" 
+    <div
+      style="background-image: url('{{ illustratedHeader.bgImage }}')"
       class="ma__illustrated-header__image"
-      role="image"
+      role="img"
       aria-label="{{ imageAlt }}">
     </div>
   {% else %}


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
`div.ma__illustrated-header__image` had the incorrect value for its aria role, and it's corrected to `img`.

## Related Issue / Ticket

- [DP-1553 A \<div\> cannot have "image" as a role attribute value](https://jira.state.ma.us/browse/DP-1553)


## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Go to guide page.
2. Check the header banner background in the source and find `div.ma__illustrated-header__image` has `role="img"`.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
