### PR TITLE
DP-7907: [Search] Updated css/twig for CalloutLink as Details variant --> whole card is clickable

### DIFF
--- a/styleguide/source/_patterns/02-molecules/callout-link.twig
+++ b/styleguide/source/_patterns/02-molecules/callout-link.twig
@@ -1,25 +1,25 @@
 {% set calloutLinkTheme = calloutLink.theme ? "ma__callout-link--" ~ calloutLink.theme : "" %}
 
 <div class="ma__callout-link {{calloutLinkTheme}}" title={{ calloutLink.info }}>
-  {% if calloutLink.eyebrow or calloutLink.time %}
-  <div class="ma__callout-link__header">
-    {% if calloutLink.eyebrow %}
-      <span class="ma__callout-link__eyebrow">{{ calloutLink.eyebrow }}</span>
-    {% endif %}
-    {% if calloutLink.time %}
-      <span class="ma__callout-link__time">{{ calloutLink.time }}</span>
-    {% endif %}
-  </div>
- {% endif %}
   <a href="{{ calloutLink.href }}">
-  	<span class="ma__callout-link__container">
-  		<span class="ma__callout-link__text" >{{ calloutLink.text }}&nbsp;{% include "@atoms/05-icons/svg-arrow.twig" %}</span>
-  	</span>
+    {% if calloutLink.eyebrow or calloutLink.time %}
+    <div class="ma__callout-link__header">
+      {% if calloutLink.eyebrow %}
+        <span class="ma__callout-link__eyebrow">{{ calloutLink.eyebrow }}</span>
+      {% endif %}
+      {% if calloutLink.time %}
+        <span class="ma__callout-link__time">{{ calloutLink.time }}</span>
+      {% endif %}
+    </div>
+   {% endif %}
+    	<span class="ma__callout-link__container">
+    		<span class="ma__callout-link__text" >{{ calloutLink.text }}&nbsp;{% include "@atoms/05-icons/svg-arrow.twig" %}</span>
+    	</span>
+    {% if calloutLink.emphasized %}
+      <span class="ma__callout-link__emphasized">{{ calloutLink.emphasized }}</span>
+    {% endif %}
+    {% if calloutLink.description %}
+      <p class="ma__callout-link__description">{{ calloutLink.description }}</p>
+    {% endif %}
   </a>
-  {% if calloutLink.emphasized %}
-    <span class="ma__callout-link__emphasized">{{ calloutLink.emphasized }}</span>
-  {% endif %}
-  {% if calloutLink.description %}
-    <p class="ma__callout-link__description">{{ calloutLink.description }}</p>
-  {% endif %}
 </div>

--- a/styleguide/source/_patterns/02-molecules/callout-link~with-details.json
+++ b/styleguide/source/_patterns/02-molecules/callout-link~with-details.json
@@ -6,7 +6,6 @@
     "eyebrow": "Press Release",
     "emphasized": "Office of the Attorney General",
     "time": "30 Mins Ago",
-    "theme": "white",
-    "description": "ajhgkajdfngkjanfkgjnadfjkbnadfkjbg"
+    "theme": "white"
   }
 }

--- a/styleguide/source/assets/scss/02-molecules/_callout-link.scss
+++ b/styleguide/source/assets/scss/02-molecules/_callout-link.scss
@@ -18,8 +18,9 @@
   }
 
   a {
+  width: 100%;
   display:flex;
-  flex-flow: column wrap;
+      flex-flow: column wrap;
       justify-content: center;
     padding: 15px 20px;
     @media ($bp-small-min) {
@@ -51,20 +52,20 @@
     padding-top: 10px;
         @media ($bp-x-small-min) {
           display: flex;
-          align-content: stretch;
+            align-content: stretch;
               align-items: center;
         }   
   }
 
   &__header{
-      align-content: stretch;
-      width: 100%;
-      display: inline-flex;
+    align-content: stretch;
+    width: 100%;
+    display: inline-flex;
       justify-content: space-between;
       margin-bottom: 10px;
-      @media ($bp-small-min) {
-          margin-bottom: 15px;
-      }
+        @media ($bp-small-min) {
+            margin-bottom: 15px;
+        }
   }
   &__eyebrow, &__time {
       font-size: 0.813rem;

--- a/styleguide/source/assets/scss/02-molecules/_callout-link.scss
+++ b/styleguide/source/assets/scss/02-molecules/_callout-link.scss
@@ -1,14 +1,6 @@
 .ma__callout-link {
   border: 3px solid;
-  padding: 15px 20px;
   display: inline-flex;
-        align-items: stretch;
-        flex-wrap: wrap;
-
-    @media ($bp-small-min) {
-      padding: 20px 30px;
-    }
-
   // .pre-content > &,
   // .post-content > &,
   // .main-content--full .page-content > & {
@@ -26,69 +18,71 @@
   }
 
   a {
-    display: flex;
-      align-items: center;
-    font-size: 1.625rem;
-    line-height: 1.3;
-    width: 100%;
+  display:flex;
+  flex-flow: column wrap;
+      justify-content: center;
+    padding: 15px 20px;
+    @media ($bp-small-min) {
+      padding: 20px 30px;
+    }
   }
   
-  &__description {
-    display: none;
-    padding-top: 10px;
-        @media ($bp-x-small-min) {
-          display: flex;
-              align-items: center;
-        }   
-  }
-
-  &__header{
-      width: 100%;
-      padding: 15px 0px;
-  }
-  &__eyebrow {
-      font-size: 0.813rem;
-      letter-spacing: .1em;
-      text-transform: uppercase;
-      float: left;
-      padding: 5px 7px;
-  }
-
-  &__time {
-      font-size: 0.813rem;
-      letter-spacing: .1em;
-      text-transform: uppercase;
-      float: right;
-  }
-
-  &__emphasized {
-    font-size: 18px;
-    line-height: 1;
-    padding-top: 15px;
-  }
-
   &__container { // .ma__decorative-link 
-    display: inline-block;
+    font-size: 1.625rem;
+    line-height: 1.3;
     vertical-align: middle;
     padding-right: .8em;
     width: 100%;
   }
 
-  // removed after version 5.5.0
-  &__info {
-    @include ma-visually-hidden;
-  }
-
   &__text {
     @include ma-link-underline;
     display: inline;
-
     svg {
       display: inline-block;
       height: .6em;
       margin-right: -.8em;
       width: .6em;
     }
+  }
+
+  &__description {
+    display: none;
+    padding-top: 10px;
+        @media ($bp-x-small-min) {
+          display: flex;
+          align-content: stretch;
+              align-items: center;
+        }   
+  }
+
+  &__header{
+      align-content: stretch;
+      width: 100%;
+      display: inline-flex;
+      justify-content: space-between;
+      margin-bottom: 10px;
+      @media ($bp-small-min) {
+          margin-bottom: 15px;
+      }
+  }
+  &__eyebrow, &__time {
+      font-size: 0.813rem;
+      letter-spacing: .1em;
+      text-transform: uppercase;
+      padding: 5px 7px;
+  }
+
+  &__emphasized {
+    font-size: 18px;
+    line-height: 1;
+    padding-top: 15px;
+    display: flex;
+  }
+
+  // removed after version 5.5.0
+  &__info {
+    @include ma-visually-hidden;
   }
 
   

--- a/styleguide/source/assets/scss/06-theme/02-molecules/_callout-link.scss
+++ b/styleguide/source/assets/scss/06-theme/02-molecules/_callout-link.scss
@@ -24,6 +24,10 @@
     font-weight: 700;
   }
 
+  &__header {
+    color: $c-theme-gray;
+  }
+
   &__emphasized{
     color: $c-font-dark;
     font-weight: 700;


### PR DESCRIPTION
Note: This is an update to a previous PR that was a merged (704) that updates the callout link variants of description, white, and details, so that no the a tag wraps all the contents of the card. This makes the whole card a clickable href regardless of the variant being used.

Review the branch here: https://mayflower.digital.mass.gov/DP-7907--Add-CalloutLink-Variant-with-Card-Details/index.html

The search application requires, based on the recent news item results designs, a variant of the Callout Link molecule that includes an eyebrow, time details, publishing source and white background color variant.

## Description
Adds 'details' support for the Callout Link Molecule in Mayflower and a white theme variant. The aim of adding details support to the callout link molecule is to be able to meet the requirements of the search application for [recent news items](https://projects.invisionapp.com/d/#/console/13018647/274463413/preview).
<img width="312" alt="screen shot 2018-02-13 at 9 24 01 pm" src="https://user-images.githubusercontent.com/9359261/36184999-fe99090a-1104-11e8-8ae6-be1ad6bfc361.png">

## Related Issue / Ticket
- [DP-7907](https://jira.state.ma.us/browse/DP-7907)

## Steps to Test
1. Compile Mayflower branch and view in browser
2. Check template at Molecules > Callout Link with Details
3. Confirm that the variant Callout Link molecule displays with an eyebrow, time since published and source organization as shown in the screenshot below. Further, confirm that the layout is consistent on a mobile screen, as in the screenshot shown below. Confirm that the readme links to the Callout Link molecule and provides information on how to create this variant
4. Check template at Molecules > Callout Link
5. Confirm that the json variable includes eyebrow, theme, time, and source as optional. Confirm that that twig template includes conditional rendering of all of these new properties. Confirm that the readme mentions the new details variant. 
6. Check template at Molecules > Callout Link as White
7. Confirm that this variant of the Callout Link has a with background.

## Screenshots
<img width="306" alt="screen shot 2018-02-13 at 9 23 38 pm" src="https://user-images.githubusercontent.com/9359261/36185011-0dc302c8-1105-11e8-9eda-b96ea30ab653.png">

## Additional Notes:

Confirm that this does not break the already used functionality of Callout Link vanilla in higher order components (organisms and templates).
