### PR TITLE
add more verbosity to the pattern lab php command

### DIFF
--- a/styleguide/tools/gulp/tasks/patternlab.js
+++ b/styleguide/tools/gulp/tasks/patternlab.js
@@ -16,7 +16,7 @@ module.exports = function patternLabTask(config, env){
     }
 
     gulp.task("patternlab", function() {
-        run(command).exec();
+        run(command, {verbosity: 3}).exec();
     });
 
     // register the watch


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
Simply put, this makes the terminal show errors and files names for php pattern lab generation errors. Previously, if you had an error like malformed JSON, you got a generic build error - now, you'll get a malformed JSON error with a file name.

## Related Issue / Ticket

N/A


## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Mess up some JSON or Twig
2. Try to build
3. Easily fix your error because it tells you where it is

## Screenshots

Before:
<img width="1203" alt="screen shot 2018-02-16 at 10 33 58 am" src="https://user-images.githubusercontent.com/1397914/36315320-5c9b2cc0-1305-11e8-88b0-a6d39985d1ea.png">

---

After:
<img width="1200" alt="screen shot 2018-02-16 at 10 34 20 am" src="https://user-images.githubusercontent.com/1397914/36315338-6656a0f0-1305-11e8-877e-6500f44242ae.png">



