### PR TITLE
Changelog link update

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
-Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](/docs/change-log-instructions.md)
+Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/changelog-log-instructions.md)
 
 
 ## Description

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
-Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/changelog-log-instructions.md)
+Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)
 
 
 ## Description

--- a/docs/release.md
+++ b/docs/release.md
@@ -6,7 +6,7 @@ Mayflower release managers with the necessary repo permissions can follow these 
 1. If there is new code to be delivered, notify the team at least two hours ahead of time that a release is coming. Follow the [Communicate Releases](https://wiki.state.ma.us/display/massgovredesign/Communicating+Releases) instructions for Upcoming Deployments.
 1. Check out the [massgov/mayflower `dev` branch](https://github.com/massgov/mayflower/commits/dev): `git checkout dev` and pull the latest from upstream `git pull upstream dev`. (This assumes that your massgov/mayflower remote repo is named `upstream`)
 1. Create a release branch `git checkout -b release-#.#.#` where `#.#.#` is the next version (i.e. `5.0.0`).  Read more about [Mayflower and semantic versioning](docs/versioning.md) to ensure that your are creating the right type of version.
-1. Add [release notes](/docs/Change Log Instructions.md) to the top of [release-notes.md](/release-notes.md) based on the "changelog.txt" files, and then commit.
+1. Add [release notes](https://github.com/massgov/mayflower/blob/dev/docs/changelog-log-instructions.md) to the top of [release notes](/release-notes.md) based on the "changelog.txt" files, and then commit.
 1. Move into the `stylguide` directory `cd styleguide` (may be a good idea to run `npm install` in case the release includes new packages).
 1. Bump the version on the homepage - `@pages/readme2.json` - by updating the version and date text in `errorPage.type`
 1. Bump the version of the npm package by running `gulp bump -v=#.#.#` where `#.#.#` is the version you are releasing.

--- a/docs/release.md
+++ b/docs/release.md
@@ -6,7 +6,7 @@ Mayflower release managers with the necessary repo permissions can follow these 
 1. If there is new code to be delivered, notify the team at least two hours ahead of time that a release is coming. Follow the [Communicate Releases](https://wiki.state.ma.us/display/massgovredesign/Communicating+Releases) instructions for Upcoming Deployments.
 1. Check out the [massgov/mayflower `dev` branch](https://github.com/massgov/mayflower/commits/dev): `git checkout dev` and pull the latest from upstream `git pull upstream dev`. (This assumes that your massgov/mayflower remote repo is named `upstream`)
 1. Create a release branch `git checkout -b release-#.#.#` where `#.#.#` is the next version (i.e. `5.0.0`).  Read more about [Mayflower and semantic versioning](docs/versioning.md) to ensure that your are creating the right type of version.
-1. Add [release notes](https://github.com/massgov/mayflower/blob/dev/docs/changelog-log-instructions.md) to the top of [release notes](/release-notes.md) based on the "changelog.txt" files, and then commit.
+1. Add [release notes](https://github.com/massgov/mayflower/blob/dev/docs/changelog-log-instructions.md) to the top of [release notes](/release-notes.md) based on the "changelog.txt" files, remove all the "changelog.txt" files and then commit.
 1. Move into the `stylguide` directory `cd styleguide` (may be a good idea to run `npm install` in case the release includes new packages).
 1. Bump the version on the homepage - `@pages/readme2.json` - by updating the version and date text in `errorPage.type`
 1. Bump the version of the npm package by running `gulp bump -v=#.#.#` where `#.#.#` is the version you are releasing.

--- a/docs/release.md
+++ b/docs/release.md
@@ -6,7 +6,7 @@ Mayflower release managers with the necessary repo permissions can follow these 
 1. If there is new code to be delivered, notify the team at least two hours ahead of time that a release is coming. Follow the [Communicate Releases](https://wiki.state.ma.us/display/massgovredesign/Communicating+Releases) instructions for Upcoming Deployments.
 1. Check out the [massgov/mayflower `dev` branch](https://github.com/massgov/mayflower/commits/dev): `git checkout dev` and pull the latest from upstream `git pull upstream dev`. (This assumes that your massgov/mayflower remote repo is named `upstream`)
 1. Create a release branch `git checkout -b release-#.#.#` where `#.#.#` is the next version (i.e. `5.0.0`).  Read more about [Mayflower and semantic versioning](docs/versioning.md) to ensure that your are creating the right type of version.
-1. Add [release notes](https://github.com/massgov/mayflower/blob/dev/docs/changelog-log-instructions.md) to the top of [release notes](/release-notes.md) based on the "changelog.txt" files, remove all the "changelog.txt" files and then commit.
+1. Add [release notes](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md) to the top of [release notes](/release-notes.md) based on the "changelog.txt" files, remove all the "changelog.txt" files and then commit.
 1. Move into the `stylguide` directory `cd styleguide` (may be a good idea to run `npm install` in case the release includes new packages).
 1. Bump the version on the homepage - `@pages/readme2.json` - by updating the version and date text in `errorPage.type`
 1. Bump the version of the npm package by running `gulp bump -v=#.#.#` where `#.#.#` is the version you are releasing.

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-See [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/changelog-log-instructions.md) for directions on updating this file.
+See [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md) for directions on updating this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-See [Change Log Instructions](docs/changelog-log-instructions.md) for directions on updating this file.
+See [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/changelog-log-instructions.md) for directions on updating this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 


### PR DESCRIPTION
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](/docs/change-log-instructions.md)


## Description
See the issue with the link in this pull request template it giving a 404 page not found. So I updated the release notes.md and release.md as well for these are not working either.

## Related Issue / Ticket

- [JIRA issue]()
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. 

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
