### PR TITLE
add block for expandable section links

### DIFF
--- a/styleguide/source/_patterns/02-molecules/expandable-section.twig
+++ b/styleguide/source/_patterns/02-molecules/expandable-section.twig
@@ -3,16 +3,18 @@
     {{expandableSection.text}}
   </button>
   <ul class="ma__toc--hierarchy__accordion-content js-accordion-content">
-    {% for link in expandableSection.linkItems %}
-      <li>
-        {% if link.icon %}
-          {% set downloadLink = link %}
-          {% include "@molecules/download-link.twig" %}
-        {% else %}
-          {% set decorativeLink = link %}
-          {% include "@atoms/decorative-link.twig" %}
-        {% endif %}
-      </li>
-    {% endfor %}
+    {% block expandableSectionLinks %}
+      {% for link in expandableSection.linkItems %}
+        <li>
+          {% if link.icon %}
+            {% set downloadLink = link %}
+            {% include "@molecules/download-link.twig" %}
+          {% else %}
+            {% set decorativeLink = link %}
+            {% include "@atoms/decorative-link.twig" %}
+          {% endif %}
+        </li>
+      {% endfor %}
+    {% endblock %}
   </ul>
 </li>


### PR DESCRIPTION

## Description
This will allow to override the links section.  I need this for DP8000 so we can correctly render the toc children links.

## Related Issue / Ticket

- [JIRA issue](https://jira.state.ma.us/browse/DP-8000)

