### PR TITLE
DP-7564  Org Page Mosaic component changes

### DIFF
--- a/changelogs/DP-7564.txt
+++ b/changelogs/DP-7564.txt
@@ -1,0 +1,8 @@
+Changed
+Minor
+- DP-7564: Changed Mayflower templates used for the Featured Items Mosaic
+  component on Organization Landing Pages. This change should not impact any
+  existing functionality, since the related component is not yet in use.
+
+___POST DEPLOY STEPS___
+N/A

--- a/styleguide/source/_patterns/03-organisms/by-author/featured-item-mosaic.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/featured-item-mosaic.twig
@@ -4,36 +4,35 @@
     {% include "@atoms/04-headings/comp-heading.twig" %}
   {% endif %}
   <div class="ma__featured-item-mosaic__container">
-    {% if featuredItemMosaic.columns %}
-      {% for column in featuredItemMosaic.columns|slice(0,2) %}
-        <div class="ma__featured-item-mosaic__column">
-          {% for item in column %}
-            {% set featuredItem = item %}
-            {% if column|length == 1 %}
-              {% set featuredItem = featuredItem|merge({'variation': 'tall'}) %}
-            {% endif %}
-            {% include "@molecules/featured-item.twig" %}
-          {% endfor %}
-        </div>
-      {% endfor %}
-      {% for column in featuredItemMosaic.columns|slice(2) %}
-        <div class="ma__featured-item-mosaic__column js-accordion-content">
-          {% for item in column %}
-            {% set featuredItem = item %}
-            {% if column|length == 1 %}
-              {% set featuredItem = featuredItem|merge({'variation': 'tall'}) %}
-            {% endif %}
-            {% include "@molecules/featured-item.twig" %}
-          {% endfor %}
-        </div>
-      {% endfor %}
-    {% endif %}
+    {% block featuredItemMosaicColumns %}
+      {% if featuredItemMosaic.columns %}
+        {% for column in featuredItemMosaic.columns|slice(0,2) %}
+          <div class="ma__featured-item-mosaic__column">
+            {% for item in column %}
+              {% set featuredItem = item %}
+              {% if column|length == 1 %}
+                {% set featuredItem = featuredItem|merge({'variation': 'tall'}) %}
+              {% endif %}
+              {% include "@molecules/featured-item.twig" %}
+            {% endfor %}
+          </div>
+        {% endfor %}
+        {% for column in featuredItemMosaic.columns|slice(2) %}
+          <div class="ma__featured-item-mosaic__column js-accordion-content">
+            {% for item in column %}
+              {% set featuredItem = item %}
+              {% if column|length == 1 %}
+                {% set featuredItem = featuredItem|merge({'variation': 'tall'}) %}
+              {% endif %}
+              {% include "@molecules/featured-item.twig" %}
+            {% endfor %}
+          </div>
+        {% endfor %}
+      {% endif %}
+    {% endblock %}
   </div>
   <button type="button" class="ma__featured-item-mosaic__toggle js-accordion-link" aria-expanded="false">
     <span class="more">More</span><span class="less">Less</span> featured items
   </button>
 </section>
 <div class="ma__divider"></div>
-
-
-

--- a/styleguide/source/_patterns/03-organisms/by-author/stacked-row-section.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/stacked-row-section.twig
@@ -18,9 +18,11 @@
   {% endif %}
   <div class="main-content {{ stackedRowSection.sideBar|length ? 'main-content--two' : 'main-content--full' }}">
     <div class="page-content">
-      {% for content in stackedRowSection.pageContent %}
-        {% include content.path with content.data %}
-      {% endfor %}
+      {% block stackedRowContentOverride %}
+        {% for content in stackedRowSection.pageContent %}
+          {% include content.path with content.data %}
+        {% endfor %}
+      {% endblock %}
     </div>
     {% if stackedRowSection.sideBar|length %}
       <aside class="sidebar">


### PR DESCRIPTION
## Description
Added blocks to two Mayflower templates so that certain sections can be overridden from Drupal template files. This is needed for integrating the Organization Landing Page Featured Item Mosaic component in such a way that the Drupal caching mechanism will be preserved.

## Related Issue / Ticket
https://jira.state.ma.us/browse/DP-7564

## Steps to Test
**Test for Featured Items Mosaic Component**
1. Go Here - 
    * As an admin user, the Content overview page, Manage -> Content
1. Do This - 
    1. Click the Add Content button and create a new Organization Landing Page.
    1. On the Title Banner tab, add the required content and select 'Elected Official' in the Subtype field.
    1. On the Overview tab add the required content.
    1. On the Services Offered tab, add the required content.
    1. On the Featured tab:
        1. Add heading text in the Heading field.
        1. The Featured Items field is a paragraphs field and multiple items can be added. Add 5 featured items here with all required fields filled in. Also include Link Text for the links. The first featured item must include a Highlight Image in addition to the required Image.
    1. Click the Save dropdown and select Save and Publish.
1. See This - 
    * Your new Organization Page is displayed and the Featured Items are displayed in a grid similar to the design (https://projects.invisionapp.com/share/VYF2N5JX2#/screens/270254619).

## Screenshots
N/A


## Additional Notes:
This PR is related to another PR which has the corresponding Drupal changes: https://github.com/massgov/mass/pull/1986

#### Impacted Areas in Application
The Organization Landing Page Featured Item Mosaic component, which is a new feature.

#### @TODO
N/A

#### Today I learned...
In order to integrate Mayflower components via the new method (overriding twig blocks instead of preprocessing in Drupal) we sometimes have to add twig blocks to the Mayflower pattern templates. This gives us sections we can override.
