### PR TITLE
fix 'our organizations' and 'mosaic' layouts on IE11

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_featured-item-mosaic.scss
+++ b/styleguide/source/assets/scss/03-organisms/_featured-item-mosaic.scss
@@ -56,6 +56,7 @@
         display: flex;
         flex-wrap: wrap;
         flex-direction: row;
+        justify-content: space-between;
     }
 
     .ma__divider {
@@ -81,10 +82,12 @@
     @media ($bp-small-min) {
       display: flex !important; // override JS-hidden accordion behavior on non-mobile
       flex-basis: 50%;
+      max-width: 50%;
       flex-direction: row;
     }
     @media ($bp-large-min) {
       flex-basis: 33%;
+      max-width: 33%;
     }
 
 
@@ -92,6 +95,7 @@
     //       last odd child gets flowed
       &:last-child:nth-child(odd) {
         flex-basis: 100%;
+        max-width: 100%;
         justify-content: space-between;
 
         .ma__featured-item {

--- a/styleguide/source/assets/scss/03-organisms/_image-link-list.scss
+++ b/styleguide/source/assets/scss/03-organisms/_image-link-list.scss
@@ -16,14 +16,14 @@
       @media($bp-medium-min) {
         flex-basis: calc(50% - 0.5rem);
         &.ma__link-list__item--secondary {
-          display: initial !important;
+          display: block !important;
         }
       }
       @media($bp-x-large-min) {
         flex-basis: calc(33% - 1rem);
         &.ma__link-list__item--secondary,
         &.ma__link-list__item--tertiary {
-          display: initial !important;
+          display: block !important;
         }
       }
     }
@@ -51,7 +51,7 @@
     // show on small if has secondary or tertiary links
     &.has-secondary,
     &.has-tertiary {
-      display: initial;
+      display: inline-block;
     }
     // if has tertiary links, show on mid
     @media($bp-medium-min) {
@@ -59,7 +59,7 @@
         display: none;
       }
       &.has-tertiary {
-        display: initial;
+        display: inline-block;
       }
     }
     // Never show on full width


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
This fixes the layout for the Mosaic and image block listing sections on the Organization Elected Officials page in IE11.


## Related Issue / Ticket
https://jira.state.ma.us/browse/DP-7483

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. View http://localhost:3000/patterns/05-pages-organization-elected-official/05-pages-organization-elected-official.html in IE11 at all viewport widths. 
2. Ensure that hiding/showing more items works as expected on mobile, and that the layout remains intact at all widths.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
