### PR TITLE
Fix for regression in contact list accordion indicator

### DIFF
--- a/styleguide/source/_patterns/02-molecules/contact-us.twig
+++ b/styleguide/source/_patterns/02-molecules/contact-us.twig
@@ -20,6 +20,7 @@
     {% endif %}
       {% set columnHeading = contactUs.subTitle|merge({"level": contactUs.level}) %}
       {% include "@atoms/04-headings/column-heading.twig" %}
+      <span class="ma__contact-us--accordion__status js-accordion-status" aria-label="click to show info">+</span>
     {% if outerAccordion %}
       </button>
     {% endif %}


### PR DESCRIPTION
This is a tiny fix for a regression introduced in https://github.com/massgov/mayflower/pull/726 which I failed to catch in my review.

Just adding back in the `span` that is the accordion indicator. 