### PR TITLE
DP-7758  mayflower create patterns for org details page

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-template/page-banner.json
+++ b/styleguide/source/_patterns/03-organisms/by-template/page-banner.json
@@ -6,8 +6,8 @@
     "icon": "@atoms/05-icons/svg-lg-park.twig",
     "title": "Visiting & Exploring",
     "titleSubText": "",
-    "description": "this is a description",
-    "descriptionSubText": "and some subtext",
+    "description": "",
+    "descriptionSubText": "",
     "color": null
   }
 }

--- a/styleguide/source/_patterns/03-organisms/by-template/page-banner.json
+++ b/styleguide/source/_patterns/03-organisms/by-template/page-banner.json
@@ -6,8 +6,8 @@
     "icon": "@atoms/05-icons/svg-lg-park.twig",
     "title": "Visiting & Exploring",
     "titleSubText": "",
-    "description": "",
-    "descriptionSubText": "",
+    "description": "this is a description",
+    "descriptionSubText": "and some subtext",
     "color": null
   }
 }

--- a/styleguide/source/_patterns/03-organisms/by-template/page-banner.json
+++ b/styleguide/source/_patterns/03-organisms/by-template/page-banner.json
@@ -7,6 +7,7 @@
     "title": "Visiting & Exploring",
     "titleSubText": "",
     "description": "",
+    "descriptionSubText": "",
     "color": null
   }
 }

--- a/styleguide/source/_patterns/03-organisms/by-template/page-banner.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/page-banner.twig
@@ -47,6 +47,11 @@
       {% if pageBanner.description and not (pageBanner.size == "columns") %}
         <p class="ma__page-banner__description">
           {{ pageBanner.description }}
+          {% if pageBanner.descriptionSubText %}
+            <span class="ma__page-banner__descriptionSubText">
+              {{ pageBanner.descriptionSubText }}
+            </span>
+          {% endif %}
         </p>
       {% endif %}
     </div>

--- a/styleguide/source/_patterns/03-organisms/by-template/page-banner.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/page-banner.twig
@@ -33,27 +33,29 @@
       <div class="ma__page-banner__image"></div>
     {% endif %}
     <div class="ma__page-banner__content" property="mainEntityOfPage">
-      {% if pageBanner.icon %}
-        <div class="ma__page-banner__icon">
-          {% include pageBanner.icon %}
-        </div>
-      {% endif %}
-      <h1 class="ma__page-banner__title">
-        {{ pageBanner.title }}
-        {% if pageBanner.titleSubText %}
-          <abbr title="{{ pageBanner.title }}"> {{ pageBanner.titleSubText }}</abbr>
+      <div class="ma__page-banner__content-wrapper">
+        {% if pageBanner.icon %}
+          <div class="ma__page-banner__icon">
+            {% include pageBanner.icon %}
+          </div>
         {% endif %}
-      </h1>
-      {% if pageBanner.description and not (pageBanner.size == "columns") %}
-        <p class="ma__page-banner__description">
-          {{ pageBanner.description }}
-          {% if pageBanner.descriptionSubText %}
-            <span class="ma__page-banner__descriptionSubText">
-              {{ pageBanner.descriptionSubText }}
-            </span>
+        <h1 class="ma__page-banner__title">
+          {{ pageBanner.title }}
+          {% if pageBanner.titleSubText %}
+            <abbr title="{{ pageBanner.title }}"> {{ pageBanner.titleSubText }}</abbr>
           {% endif %}
-        </p>
-      {% endif %}
+        </h1>
+        {% if pageBanner.description and not (pageBanner.size == "columns") %}
+          <p class="ma__page-banner__description">
+            {{ pageBanner.description }}
+            {% if pageBanner.descriptionSubText %}
+              <span class="ma__page-banner__descriptionSubText">
+                {{ pageBanner.descriptionSubText }}
+              </span>
+            {% endif %}
+          </p>
+        {% endif %}
+      </div>
     </div>
     {% if pageBanner.description and pageBanner.size == "columns" %}
       <p class="ma__page-banner__description">

--- a/styleguide/source/_patterns/04-templates/01-content-types/organization-detail.json
+++ b/styleguide/source/_patterns/04-templates/01-content-types/organization-detail.json
@@ -1,0 +1,44 @@
+{
+  "pageBanner": {
+    "bgWide": "../../assets/images/placeholder/1600x400.png",
+    "bgNarrow": "../../assets/images/placeholder/800x400.png",
+    "size": "large",
+    "icon": null,
+    "title": "Organization Detail Banner",
+    "titleSubText": ""
+  },
+  "stackedRows": [{
+    "title": "Row with image",
+    "id": "row-with-sidebar",
+    "pageContent": [{
+      "path": "@base/placeholder.twig",
+      "data": {
+        "placeholder": {
+          "text":"Section Content"
+        }
+      }
+    }],
+
+    "sideBar": [{
+      "path": "@base/placeholder.twig",
+      "data": {
+        "placeholder": {
+          "text":"Optional Image"
+        }
+      }
+    }]
+  },{
+    "title": "Row with no image",
+    "id": "full-width-row",
+    "pageContent": [{
+      "path": "@base/placeholder.twig",
+      "data": {
+        "placeholder": {
+          "text":"Section content"
+        }
+      }
+    }],
+
+    "sideBar": []
+  }]
+}

--- a/styleguide/source/_patterns/04-templates/01-content-types/organization-detail.md
+++ b/styleguide/source/_patterns/04-templates/01-content-types/organization-detail.md
@@ -1,5 +1,5 @@
 ### Description
-This template is for the Organization Detail contnet type rail.
+This template is for the Organization Detail content type based on the stacked row template
 
 ### Status
 * Stable as of 5.0.0
@@ -20,12 +20,8 @@ This template is for the Organization Detail contnet type rail.
 ### Variables
 ~~~
 stackedRows: [{
-  borderless:
-    type: boolean / optional (defaults to false),
   title:
     type: string / optional,
-  id:
-    type: string (unique per page) / optional
   pageContent: [{
     path:
       type: string / required,

--- a/styleguide/source/_patterns/04-templates/01-content-types/organization-detail.md
+++ b/styleguide/source/_patterns/04-templates/01-content-types/organization-detail.md
@@ -1,0 +1,44 @@
+### Description
+This template is for the Organization Detail contnet type rail.
+
+### Status
+* Stable as of 5.0.0
+
+### Pattern Contains
+* Emergency Alerts
+* Header
+* Footer
+* Stacked Row Section
+* This template contains [Twig Blocks](https://twig.symfony.com/doc/2.x/tags/extends.html) that can be used to populated the Header, Pre-Content, Post Content, and Footer sections with patterns found in Mayflower
+
+### Usage Guidelines
+* The Stacked Row Sections are used to populate the Page Content and Right Rail areas shown.
+
+### JavaScript Used
+* Emergency Alerts (js/modules/emergencyAlerts.js)
+
+### Variables
+~~~
+stackedRows: [{
+  borderless:
+    type: boolean / optional (defaults to false),
+  title:
+    type: string / optional,
+  id:
+    type: string (unique per page) / optional
+  pageContent: [{
+    path:
+      type: string / required,
+    data: {
+      type: object / required
+    }
+  }],
+  sideBar: (optional) [{
+    path:
+      type: string / required,
+    data: {
+      type: object / required
+    }
+  }]
+}]
+~~~

--- a/styleguide/source/_patterns/04-templates/01-content-types/organization-detail.twig
+++ b/styleguide/source/_patterns/04-templates/01-content-types/organization-detail.twig
@@ -12,10 +12,13 @@
       {% include "@organisms/by-template/page-banner.twig" %}
     {% endblock %}
   </div>
-  <div class="ma__organization-detail">
+  <div class="ma__organization-detail--sections">
     {% block organizationDetailContent %}
       {% for stackedRow in stackedRows %}
-        <section class="ma__organization-detail">
+        <section class="ma__organization-detail--section">
+          {% if loop.first != true %}
+            {% include "@atoms/divider.twig" %}
+          {% endif %}
           <div class="main-content main-content--two">
             <div class="ma__organization-detail__title">
               {% set compHeading = {

--- a/styleguide/source/_patterns/04-templates/01-content-types/organization-detail.twig
+++ b/styleguide/source/_patterns/04-templates/01-content-types/organization-detail.twig
@@ -6,16 +6,16 @@
   {% include "@organisms/by-template/header.twig" %}
 {% endblock %}
 
-<main id="main-content" tabindex="-1">
+<main id="main-content" class="ma__organization-detail" tabindex="-1">
   <div class="pre-content">
     {% block preContent %}
       {% include "@organisms/by-template/page-banner.twig" %}
     {% endblock %}
   </div>
-  <div class="ma__organization-detail--sections">
+  <div class="ma__organization-detail__sections">
     {% block organizationDetailContent %}
       {% for stackedRow in stackedRows %}
-        <section class="ma__organization-detail--section">
+        <section class="ma__organization-detail__section">
           {% if loop.first != true %}
             {% include "@atoms/divider.twig" %}
           {% endif %}

--- a/styleguide/source/_patterns/04-templates/01-content-types/organization-detail.twig
+++ b/styleguide/source/_patterns/04-templates/01-content-types/organization-detail.twig
@@ -1,0 +1,55 @@
+{% block header %}
+  {% if ajaxEmergencyAlerts %}
+    {% set ajaxPattern = ajaxEmergencyAlerts %}
+    {% include "@organisms/by-template/ajax-pattern.twig" %}
+  {% endif %}
+  {% include "@organisms/by-template/header.twig" %}
+{% endblock %}
+
+<main id="main-content" tabindex="-1">
+  <div class="pre-content">
+    {% block preContent %}
+      {% include "@organisms/by-template/page-banner.twig" %}
+    {% endblock %}
+  </div>
+  <div class="ma__organization-detail">
+    {% block organizationDetailContent %}
+      {% for stackedRow in stackedRows %}
+        <section class="ma__organization-detail">
+          <div class="main-content main-content--two">
+            <div class="ma__organization-detail__title">
+              {% set compHeading = {
+                  "title": stackedRow.title,
+                }
+              %}
+              {% include "@atoms/04-headings/comp-heading.twig" %}
+            </div>
+            <div class="page-content">
+              {% for content in stackedRow.pageContent %}
+                {% include content.path with content.data %}
+              {% endfor %}
+            </div>
+            {% if stackedRow.sideBar|length %}
+            <aside class="sidebar">
+              {% for sidebar in stackedRow.sideBar %}
+                {% include sidebar.path with sidebar.data %}
+              {% endfor %}
+            </aside>
+            {% endif %}
+          </div>
+        </section>
+      {% endfor %}
+    {% endblock %}
+  </div>
+  <div class="post-content">
+    {% block postContent %}
+      {% include "@base/placeholder.twig" with {'placeholder':{'text':'Post Content'}} %}
+    {% endblock %}
+  </div>
+  {% block schemaContent %}
+  {% endblock %}
+</main>
+
+{% block footer %}
+  {% include "@organisms/by-template/footer.twig" %}
+{% endblock %}

--- a/styleguide/source/_patterns/05-pages/organization-detail.json
+++ b/styleguide/source/_patterns/05-pages/organization-detail.json
@@ -1,11 +1,13 @@
 {
   "pageBanner": {
-    "bgWide": "../../assets/images/placeholder/1600x400.png",
+    "bgWide": "../../assets/images/placeholder/1600x600.png",
     "bgNarrow": "../../assets/images/placeholder/800x400.png",
     "size": "large",
     "icon": null,
     "title": "Office if the Treasurer & Receiver General",
-    "titleSubText": "(TRE)"
+    "titleSubText": "(TRE)",
+    "description": "Banner Description",
+    "descriptionSubText": "Banner description subtext"
   },
   "stackedRows": [
     {
@@ -16,7 +18,7 @@
           "path": "@atoms/11-text/raw-html.twig",
           "data": {
             "rawHtml": {
-              "content": "<p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.</p><h3>WYSIWYG h3s get comp heading styles</h3><p>Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur</p><h3>Et harum quidem rerum</h3><p>At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae.</p>"
+              "content": "<p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.</p><h3>wysiwyg h3s get comp heading styles</h3><p>Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur</p><h3>Et harum quidem rerum</h3><p>At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae.</p>"
             }
           }
         }
@@ -26,7 +28,7 @@
           "path": "@atoms/09-media/image.twig",
           "data": {
             "image": {
-              "alt": "eohhs logo",
+              "alt": "alt text",
               "src": "../../assets/images/placeholder/250x250.png",
               "height": "250",
               "width": "250"

--- a/styleguide/source/_patterns/05-pages/organization-detail.json
+++ b/styleguide/source/_patterns/05-pages/organization-detail.json
@@ -1,0 +1,88 @@
+{
+  "pageBanner": {
+    "bgWide": "../../assets/images/placeholder/1600x400.png",
+    "bgNarrow": "../../assets/images/placeholder/800x400.png",
+    "size": "large",
+    "icon": null,
+    "title": "Office if the Treasurer & Receiver General",
+    "titleSubText": "(TRE)"
+  },
+  "stackedRows": [
+    {
+      "title": "About the Treasury",
+      "id": "",
+      "pageContent": [
+        {
+          "path": "@atoms/11-text/raw-html.twig",
+          "data": {
+            "rawHtml": {
+              "content": "stuff"
+            }
+          }
+        }
+      ],
+      "sideBar": [
+        {
+          "path": "@atoms/09-media/image.twig",
+          "data": {
+            "image": {
+              "alt": "eohhs logo",
+              "src": "../../assets/images/placeholder/250x250.png",
+              "height": "250",
+              "width": "250"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "title": "Middle Section with no image",
+      "id": "",
+      "pageContent": [
+        {
+          "path": "@atoms/11-text/raw-html.twig",
+          "data": {
+            "rawHtml": {
+              "content": "stuff"
+            }
+          }
+        }
+      ],
+      "sideBar": [
+        {
+          "path": "@atoms/09-media/image.twig",
+          "data": {
+
+          }
+        }
+      ]
+    },
+    {
+      "title": "About Deborah Goldberg",
+      "id": "",
+      "pageContent": [
+        {
+          "path": "@atoms/11-text/raw-html.twig",
+          "data": {
+            "rawHtml": {
+              "content": "stuff"
+            }
+          }
+        }
+      ],
+      "sideBar": [
+        {
+          "path": "@atoms/09-media/image.twig",
+          "data": {
+            "image": {
+              "alt": "alt text",
+              "src": "../../assets/images/placeholder/300x500.png",
+              "height": "500",
+              "width": "300"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/styleguide/source/_patterns/05-pages/organization-detail.json
+++ b/styleguide/source/_patterns/05-pages/organization-detail.json
@@ -9,14 +9,14 @@
   },
   "stackedRows": [
     {
-      "title": "About the Treasury",
+      "title": "Section with Optional Image",
       "id": "",
       "pageContent": [
         {
           "path": "@atoms/11-text/raw-html.twig",
           "data": {
             "rawHtml": {
-              "content": "stuff"
+              "content": "<p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.</p><h3>WYSIWYG h3s get comp heading styles</h3><p>Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur</p><h3>Et harum quidem rerum</h3><p>At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae.</p>"
             }
           }
         }
@@ -36,14 +36,14 @@
       ]
     },
     {
-      "title": "Middle Section with no image",
+      "title": "Section with No Image",
       "id": "",
       "pageContent": [
         {
           "path": "@atoms/11-text/raw-html.twig",
           "data": {
             "rawHtml": {
-              "content": "stuff"
+              "content": "<p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.</p><h3>At vero eos et</h3><p>Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur</p><p>At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae.</p>"
             }
           }
         }
@@ -58,14 +58,14 @@
       ]
     },
     {
-      "title": "About Deborah Goldberg",
+      "title": "This is an H2",
       "id": "",
       "pageContent": [
         {
           "path": "@atoms/11-text/raw-html.twig",
           "data": {
             "rawHtml": {
-              "content": "stuff"
+              "content": "<p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.</p><p>Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur</p><p>At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae.</p>Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur</p>"
             }
           }
         }

--- a/styleguide/source/_patterns/05-pages/organization-detail.json
+++ b/styleguide/source/_patterns/05-pages/organization-detail.json
@@ -49,14 +49,6 @@
             }
           }
         }
-      ],
-      "sideBar": [
-        {
-          "path": "@atoms/09-media/image.twig",
-          "data": {
-
-          }
-        }
       ]
     },
     {

--- a/styleguide/source/_patterns/05-pages/organization-detail.md
+++ b/styleguide/source/_patterns/05-pages/organization-detail.md
@@ -1,0 +1,27 @@
+### Description
+This is an example of an Organization Detail page for Mass.gov using a stacked row template
+
+### Status
+* Stable as of 5.0.0
+
+### Pattern Contains
+* Header
+* Footer
+* Stacked Row (template)
+* Page Banner - large
+* Raw HTML
+* Image
+* Divider
+
+
+### Variables
+See Patterns above
+~~~
+pageBanner: {
+  type: pageBanner / required
+},
+
+stackedRowSections: [{
+  type: array of stackedRowSections / required
+}]
+~~~

--- a/styleguide/source/_patterns/05-pages/organization-detail.md
+++ b/styleguide/source/_patterns/05-pages/organization-detail.md
@@ -1,5 +1,5 @@
 ### Description
-This is an example of an Organization Detail page for Mass.gov using a stacked row template
+This is an example of an Organization Detail page for Mass.gov using the organization details template
 
 ### Status
 * Stable as of 5.0.0
@@ -7,7 +7,7 @@ This is an example of an Organization Detail page for Mass.gov using a stacked r
 ### Pattern Contains
 * Header
 * Footer
-* Stacked Row (template)
+* Stacked Row
 * Page Banner - large
 * Raw HTML
 * Image

--- a/styleguide/source/_patterns/05-pages/organization-detail.twig
+++ b/styleguide/source/_patterns/05-pages/organization-detail.twig
@@ -1,0 +1,14 @@
+{% extends '@templates/01-content-types/organization-detail.twig' %}
+
+{% block preContent %}
+  {% include "@organisms/by-template/page-banner.twig" %}
+{% endblock %}
+
+{% block postContent %}{% endblock %}
+
+{% block schemaContent %}
+  {% if schema.governmentOrganization %}
+    {% set governmentOrganization = schema.governmentOrganization %}
+    {% include "@meta/schema/government-organization.twig" %}
+  {% endif %}
+{% endblock %}

--- a/styleguide/source/assets/scss/03-organisms/_page-banner.scss
+++ b/styleguide/source/assets/scss/03-organisms/_page-banner.scss
@@ -332,3 +332,31 @@ $page-banner-height: 330px;
     }
   }
 }
+
+.ma__page-banner:not(.ma__page-banner--overlay) {
+
+.ma__page-banner__content-wrapper {
+
+  @media ($bp-x-small-min) {
+  transform: skew(30deg);
+  width: 55vw;
+  display: flex;
+  flex-wrap: wrap;
+
+  .ma__page-banner__icon {
+    transform: none;
+  }
+
+  .ma__page-banner__title {
+    flex:1;
+    transform: none;
+  }
+
+  .ma__page-banner__description {
+    width: 100%;
+    transform: none;
+  }
+
+}
+}
+}

--- a/styleguide/source/assets/scss/03-organisms/_page-banner.scss
+++ b/styleguide/source/assets/scss/03-organisms/_page-banner.scss
@@ -27,6 +27,10 @@ $page-banner-height: 330px;
     @media ($bp-large-min) {
       height: 400px;
     }
+
+    .ma__page-banner__content-wrapper {
+      transform: none;
+    }
   }
 
   &--columns {
@@ -69,8 +73,8 @@ $page-banner-height: 330px;
 
   &__content {
     display: flex;
-      align-items: center;
-      flex-wrap: wrap;
+    align-items: center;
+    flex-wrap: wrap;
     font-size: 1rem;
     max-width: 1050px;
     padding: 30px 25px 45px 0;
@@ -81,21 +85,31 @@ $page-banner-height: 330px;
       padding-top: 50px;
       padding-right: 80px;
       position: absolute;
-        top: 50%;
+      top: 50%;
       transform: translateY(-50%) skew(-30deg);
     }
 
     &:before {
       content: "";
       height: 100%;
-        top: 0;
-        right: 100%;
+      top: 0;
+      right: 100%;
       width: 50vw;
 
       @media ($bp-x-small-min) {
         right: 99%; // weird gap when skewed is shown
         position: absolute;
       }
+    }
+  }
+
+  &__content-wrapper {
+
+     @media ($bp-x-small-min) {
+      transform: skew(30deg);
+      width: 55vw;
+      display: flex;
+      flex-wrap: wrap;
     }
   }
 
@@ -111,7 +125,7 @@ $page-banner-height: 330px;
 
   &--large &__content {
     display: flex;
-      align-items: center;
+    align-items: center;
     height: 100%;
     max-width: 640px;
 
@@ -139,7 +153,7 @@ $page-banner-height: 330px;
     height: $page-banner-height;
     max-width: 640px;
     position: relative;
-      top: calc(#{$page-banner-height}/2);
+    top: calc(#{$page-banner-height}/2);
 
     @media ($bp-medium-min) {
       height: 100%;
@@ -153,10 +167,6 @@ $page-banner-height: 330px;
     padding-right: 30px;
     width: 75px;
     display: none;
-
-    @media ($bp-x-small-min) {
-      transform: skew(30deg);
-    }
 
     @media ($bp-medium-min) {
       width: $page-banner-icon-width;
@@ -192,10 +202,6 @@ $page-banner-height: 330px;
     }
   }
 
-  &--overlay &__icon {
-    transform: skew(0);
-  }
-
   &__title {
     flex-grow: 1;
     font-size: 3rem;
@@ -203,10 +209,6 @@ $page-banner-height: 330px;
     margin-bottom: 0;
     vertical-align: middle;
     z-index: 1;
-
-    @media ($bp-x-small-min) {
-      transform: skew(30deg);
-    }
 
     @media ($bp-x-small-min) {
       font-size: 3.25rem;
@@ -254,7 +256,6 @@ $page-banner-height: 330px;
 
   &--overlay &__title {
     @media ($bp-x-small-min) {
-      transform: skew(0);
       width: calc(100% - 75px);
     }
   }
@@ -283,25 +284,17 @@ $page-banner-height: 330px;
     line-height: 2.188rem;
     margin-bottom: 0;
     margin-top: .8em;
-
-    @media ($bp-x-small-min) {
-      transform: skew(30deg);
-    }
+    width: 100%;
 
     @media ($bp-large-min){
       max-width: 820px;
     }
   }
 
-  &--overlay &__description {
-    transform: skew(0);
-  }
-
   &--columns &__description {
     font-size: 1.5rem;
     margin-top: 0;
     padding: 25px 0 20px;
-    transform: skew(0);
     width: 100%;
     z-index: 1;
 
@@ -320,8 +313,8 @@ $page-banner-height: 330px;
     background-size: cover;
     height: $page-banner-height;
     position: absolute;
-      right: 0;
-      top: 0;
+    right: 0;
+    top: 0;
     width: 100%;
 
     @media ($bp-medium-min) {
@@ -331,32 +324,4 @@ $page-banner-height: 330px;
       width: 62.12903%; // @include span(8 of 12) was too big
     }
   }
-}
-
-.ma__page-banner:not(.ma__page-banner--overlay) {
-
-.ma__page-banner__content-wrapper {
-
-  @media ($bp-x-small-min) {
-  transform: skew(30deg);
-  width: 55vw;
-  display: flex;
-  flex-wrap: wrap;
-
-  .ma__page-banner__icon {
-    transform: none;
-  }
-
-  .ma__page-banner__title {
-    flex:1;
-    transform: none;
-  }
-
-  .ma__page-banner__description {
-    width: 100%;
-    transform: none;
-  }
-
-}
-}
 }

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_page-banner.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_page-banner.scss
@@ -64,6 +64,7 @@ $page-banner-inner-width: 612px;
     font-weight: 500;
 
     .ma__page-banner__descriptionSubText {
+      display: block;
       font-weight: 300;
     }
   }

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_page-banner.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_page-banner.scss
@@ -21,7 +21,7 @@ $page-banner-inner-width: 612px;
       background-color: $c-theme-secondary;
     }
   }
-    
+
   &--blue &__content {
     background-image: linear-gradient(-90deg, rgba($c-theme-blue, .7), $c-theme-blue 95%);
 
@@ -62,6 +62,10 @@ $page-banner-inner-width: 612px;
   &__description {
     color: $c-font-inverse;
     font-weight: 500;
+
+    .ma__page-banner__descriptionSubText {
+      font-weight: 300;
+    }
   }
 
   &--columns &__description {

--- a/styleguide/source/assets/scss/06-theme/04-templates/_organization-details.scss
+++ b/styleguide/source/assets/scss/06-theme/04-templates/_organization-details.scss
@@ -1,0 +1,52 @@
+.ma__organization-detail {
+
+  .ma__page-banner {
+
+    .ma__page-banner__container {
+      padding: 0;
+    }
+
+    .ma__page-banner__content {
+      padding: 30px 25px 45px 25px;
+    }
+
+    .ma__page-banner__description {
+
+      span {
+        display: block;
+      }
+    }
+  }
+
+  .ma__divider {
+    padding-bottom: 30px;
+
+    @media ($bp-large-min) {
+      padding-bottom: 50px;
+    }
+  }
+
+  .page-content {
+
+    h3 {
+      position: relative;
+      padding-bottom: 15px;
+      margin-top: 25px;
+
+      &::after {
+        content: '';
+        height: 3px;
+        position: absolute;
+        bottom: 0;
+        left: 0.075rem;
+        transform: skew(-30deg);
+        width: 1.85em;
+        background-color: rgba($c-theme-green, 0.5);
+      }
+    }
+
+    p {
+      margin-top: 0;
+    }
+  }
+}

--- a/styleguide/source/assets/scss/base-theme.scss
+++ b/styleguide/source/assets/scss/base-theme.scss
@@ -154,6 +154,7 @@
 @import "06-theme/04-templates/details";
 @import "06-theme/04-templates/information-details";
 @import "06-theme/04-templates/general";
+@import "06-theme/04-templates/organization-details";
 @import "06-theme/04-templates/stacked-row";
 
 // Print styles


### PR DESCRIPTION
## Description
Adds the template and Mayflower page view for the Organization Detail content type

## Related Issue / Ticket

- [DP-7758 -- Create patterns for the Org Details Page](https://jira.state.ma.us/browse/DP-7758)

## Steps to Test
1. The template can be viewed here: https://clair0917.github.io/mayflower/?p=templates-organization-detail
2. The page view can be seen here: https://clair0917.github.io/mayflower/?p=pages-organization-detail

## Screenshots
<img width="710" alt="screen shot 2018-03-14 at 12 59 46 pm" src="https://user-images.githubusercontent.com/18662734/37417832-a3155bda-2787-11e8-9351-91004f112a9f.png">

## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
