### PR TITLE
TOC block to override and js limit scope

### DIFF
--- a/styleguide/source/_patterns/03-organisms/by-template/table-of-contents-overlay.twig
+++ b/styleguide/source/_patterns/03-organisms/by-template/table-of-contents-overlay.twig
@@ -1,4 +1,4 @@
-<div class="ma__toc--overlay" id="{{tableOfContentsOverlay.id}}">
+<div class="ma__toc--overlay js-toc-container" id="{{tableOfContentsOverlay.id}}">
   <div class="ma__toc__toc__title js-inline-overlay-title" tab-index="-1">
     <span class="ma__toc__subtitle">This is a part of:</span>
     {% set decorativeLink = tableOfContentsOverlay.title %}
@@ -23,10 +23,12 @@
       </button>
     </div>
     <div class="ma__toc--overlay__content">
-      {% for tocSection in tableOfContentsOverlay.tocSections %}
-        {% set tableOfContentsHierarchy = tocSection %}
-        {% include "@organisms/by-template/table-of-contents-hierarchy.twig" %}
-      {% endfor %}
+      {% block tableOfContentsOverlaySections %}
+        {% for tocSection in tableOfContentsOverlay.tocSections %}
+          {% set tableOfContentsHierarchy = tocSection %}
+          {% include "@organisms/by-template/table-of-contents-hierarchy.twig" %}
+        {% endfor %}
+      {% endblock %}
     </div>
   </div>
 </div>

--- a/styleguide/source/assets/js/modules/inlineOverlay.js
+++ b/styleguide/source/assets/js/modules/inlineOverlay.js
@@ -1,6 +1,7 @@
 import throttle from "../helpers/throttle.js";
 
 export default function (window,document,$,undefined) {
+  let tocContainerClass = '.js-toc-container';
   let containerClass = '.js-inline-overlay';
   let contentClass = '.js-inline-overlay-content';
   let toggleClass = '.js-inline-overlay-toggle';
@@ -17,8 +18,7 @@ export default function (window,document,$,undefined) {
   }
 
   function toggleOverlay() {
-    let $containerEl = $(containerClass);
-    let $contentEl = $(contentClass);
+    let $containerEl = $(this).closest(tocContainerClass).find(containerClass);
     let isOpen = $containerEl.hasClass('is-open');
     $('body').toggleClass('scroll-disabled', !isOpen);
     $containerEl.toggleClass('is-open', !isOpen);


### PR DESCRIPTION
The implementation of the TOC Overlay needed a block to be
overridden so that we could use the same variable mapping as the
normal display of the TOC. Because multiple navigation components
may be implemented, the overlay block needed to be limited to the
closest implementation instead of the first.

<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->

## Related Issue / Ticket

- [JIRA issue]()
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. 

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
