### PR TITLE
DP-8126: Avoid making multiple calls to ajax endpoint for duplicate ajax patterns on the same page

### DIFF
--- a/changelogs/DP-8126.txt
+++ b/changelogs/DP-8126.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Fixed
+Patch
+- DP-8126: Avoid making two ajax calls to the same endpoint when there are two ajax patterns on the same page.


### PR DESCRIPTION

<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
Resolves an issue where the two separate alert blocks on the Drupal site (header and above the content) were causing two ajax requests to the same endpoint on every page.  This PR implements a cache that holds promises returned by `$.ajax()` and reuses them for the second invocation.  Because promises are immutable, this works perfectly.  

## Related Issue / Ticket

- [JIRA issue](https://jira.state.ma.us/browse/DP-8126)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Visit http://localhost:3000/?p=pages-location-park-content and make sure that both the header and the content top alerts appear.
2. Temporarily edit `location-park-content.json` and set the endpoint for `ajaxEmergencyAlerts` to `../../assets/data/header-alerts.json`.  This will cause the content top alerts not to render, but they will still be fetched.  Verify that only one request to `assets/data/header-alerts.json` appears in the network tab.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
