### PR TITLE
Dp 8221  featured item link functionality  rebuilt

### DIFF
--- a/changelogs/DP-8221.txt
+++ b/changelogs/DP-8221.txt
@@ -1,4 +1,4 @@
 ___DESCRIPTION___
-Change_type (Changed)
-Change_impact (Minor)
+Changed
+Patch
 - DP-8221: Truncates featured item titles past character limit.

--- a/changelogs/DP-8221.txt
+++ b/changelogs/DP-8221.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Change_type (Changed)
+Change_impact (Minor)
+- DP-8221: Truncates featured item titles past character limit.

--- a/styleguide/source/_patterns/02-molecules/featured-item.twig
+++ b/styleguide/source/_patterns/02-molecules/featured-item.twig
@@ -15,9 +15,9 @@
       {% include "@atoms/09-media/image.twig" %}
     </div>
   {% endif %}
-<div class="ma__featured-item__title-container">
-  <div class="ma__featured-item__title">
-    <span>{{featuredItem.text}}</span>&nbsp;{% include "@atoms/05-icons/svg-arrow.twig" %}
+  <div class="ma__featured-item__title-container">
+    <div class="ma__featured-item__title">
+      <span>{{featuredItem.text}}</span>&nbsp;{% include "@atoms/05-icons/svg-arrow.twig" %}
+    </div>
   </div>
-</div>
 </a>

--- a/styleguide/source/_patterns/03-organisms/by-author/featured-item-mosaic.json
+++ b/styleguide/source/_patterns/03-organisms/by-author/featured-item-mosaic.json
@@ -38,7 +38,7 @@
           }
         },
         {
-          "href": "#",
+          "href": "",
           "text": "Third action",
           "image": {
             "alt": "alt text",
@@ -61,7 +61,7 @@
         },
         {
           "href": "#",
-          "text": "Fifth action is truncated because it's over 60 characters...",
+          "text": "The 60th character in this title is in a word past this point",
           "image": {
             "alt": "alt text",
             "src": "../../assets/images/placeholder/400x300.png",

--- a/styleguide/source/assets/js/index.js
+++ b/styleguide/source/assets/js/index.js
@@ -28,6 +28,7 @@ import responsiveVideo            from "./modules/responsiveVideo.js";
 import resultsHeading             from "./modules/resultsHeading.js";
 import richText                   from "./modules/richText.js";
 import scrollAnchors              from "./modules/scrollAnchors.js";
+import truncateTitle              from "./modules/truncateTitle.js";
 import formInputs                 from "./modules/formInputs.js";
 import utilNav                    from "./modules/utilNav.js";
 import stickyTOC                  from "./modules/stickyTOC.js";

--- a/styleguide/source/assets/js/modules/truncateTitle.js
+++ b/styleguide/source/assets/js/modules/truncateTitle.js
@@ -1,26 +1,25 @@
 export default function (window,document,$,undefined) {
 
-$('.ma__featured-item .ma__featured-item__title span').each(function() {
-  var $this = $(this);
-  var $thisParent = $this.parent();
-  var $thisWrapper = $thisParent.closest('.ma__featured-item');
-  var thisTitle = $this.text();
+  $('.ma__featured-item .ma__featured-item__title span').each(function() {
+    const $this = $(this);
+    const $thisParent = $this.parent();
+    const $thisWrapper = $thisParent.closest('.ma__featured-item');
+    let thisTitle = $this.text();
 
-  // Links are truncated to 60 characters
-  // The wrappers only accommodate 50 with ellipses and the icon
-  if (thisTitle.length > 50) {
-    // Add a class for styling.
-    $thisParent.addClass('truncated');
-    // Add the full title to the aria label to keep value
-    $thisWrapper.attr('aria-label', thisTitle);
+    // Links are truncated to 60 characters
+    // The wrappers only accommodate 50 with ellipses and the icon
+    if (thisTitle.length > 50) {
+      // Add a class for styling.
+      $thisParent.addClass('truncated');
+      // Add the full title to the aria label to keep value
+      $thisWrapper.attr('aria-label', thisTitle);
 
-    // Truncate title at last full word before 50th character
-    var truncatedTitle = thisTitle.substring(0, 50);
-    truncatedTitle = truncatedTitle.substr(0, Math.min(truncatedTitle.length, truncatedTitle.lastIndexOf(" ")));
-    thisTitle = truncatedTitle;
-  }
-  $this.text(thisTitle);
-
-});
+      // Truncate title at last full word before 50th character
+      var truncatedTitle = thisTitle.substring(0, 50);
+      truncatedTitle = truncatedTitle.substr(0, Math.min(truncatedTitle.length, truncatedTitle.lastIndexOf(" ")));
+      thisTitle = truncatedTitle;
+    }
+    $this.text(thisTitle);
+  });
 
 }(window,document,jQuery);

--- a/styleguide/source/assets/js/modules/truncateTitle.js
+++ b/styleguide/source/assets/js/modules/truncateTitle.js
@@ -1,0 +1,26 @@
+export default function (window,document,$,undefined) {
+
+$('.ma__featured-item .ma__featured-item__title span').each(function() {
+  var $this = $(this);
+  var $thisParent = $this.parent();
+  var $thisWrapper = $thisParent.closest('.ma__featured-item');
+  var thisTitle = $this.text();
+
+  // Links are truncated to 60 characters
+  // The wrappers only accommodate 50 with ellipses and the icon
+  if (thisTitle.length > 50) {
+    // Add a class for styling.
+    $thisParent.addClass('truncated');
+    // Add the full title to the aria label to keep value
+    $thisWrapper.attr('aria-label', thisTitle);
+
+    // Truncate title at last full word before 50th character
+    var truncatedTitle = thisTitle.substring(0, 50);
+    truncatedTitle = truncatedTitle.substr(0, Math.min(truncatedTitle.length, truncatedTitle.lastIndexOf(" ")));
+    thisTitle = truncatedTitle;
+  }
+  $this.text(thisTitle);
+
+});
+
+}(window,document,jQuery);

--- a/styleguide/source/assets/scss/02-molecules/_featured-item.scss
+++ b/styleguide/source/assets/scss/02-molecules/_featured-item.scss
@@ -54,9 +54,9 @@
   display: flex;
   align-items: center;
   position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
   z-index: 2; // above the dimmer (:before)
   height: 4rem;
   padding: 5px 15px;
@@ -68,3 +68,13 @@
   }
 }
 
+.ma__featured-item__title.truncated {
+
+  span {
+    white-space: nowrap;
+
+    &::after {
+      content: ' . . . ';
+    }
+  }
+}

--- a/styleguide/source/assets/scss/02-molecules/_featured-item.scss
+++ b/styleguide/source/assets/scss/02-molecules/_featured-item.scss
@@ -69,12 +69,8 @@
 }
 
 .ma__featured-item__title.truncated {
-
-  span {
+  span::after {
+    content: ' . . . ';
     white-space: nowrap;
-
-    &::after {
-      content: ' . . . ';
-    }
   }
 }


### PR DESCRIPTION
## Description
Truncates featured item titles past character limit.

## Related Issue / Ticket

- [JIRA issue](https://jira.state.ma.us/browse/DP-7564)

## Steps to Test
1. in the featured item mosaic component (/?p=organisms-featured-item-mosaic) the last featured item title is longer than 60 characters. You should see that long titles are truncated with ellipses
Inspecting the span will show you the aria-label containing the entire title, in this case: "The 60th character in this title is in a word past this point"
## Screenshots
<img width="556" alt="screen shot 2018-03-15 at 6 00 43 pm" src="https://user-images.githubusercontent.com/18662734/37493966-39e20fc2-287d-11e8-9b50-b7125441117a.png">


## Additional Notes:
The original PR for this work was here and approved: https://github.com/massgov/mayflower/pull/733
There are no visual regression testing files because this work was functional and did not change anything visually.
 
#### Impacted Areas in Application
* Featured Items
* Featured Item Mosaic
