### PR TITLE
reduce min height on about section

### DIFF
--- a/changelogs/DP-8586.txt
+++ b/changelogs/DP-8586.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Changed
+Minor
+- DP-8586: Reduce minimum spacing for about section.

--- a/styleguide/source/assets/scss/06-theme/03-organisms/_about-section.scss
+++ b/styleguide/source/assets/scss/06-theme/03-organisms/_about-section.scss
@@ -3,7 +3,7 @@
 
   @media ($bp-x-large-min) {
     max-width: none;
-    min-height: 620px;
+    min-height: 500px;
   }
 
   &__title {


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
Reduce the minimum height on the about section for elected official page to avoid awkward spacing. 

## Related Issue / Ticket

- [JIRA issue](https://jira.state.ma.us/browse/DP-8586)
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Run mayflower locally, view http://localhost:3000/?p=pages-organization-elected-official
2. Ensure that the space between 'About the Treasury' and 'Our Organizations' looks consistent with the rest of the page spacing.

## Screenshots
<img width="1260" alt="screen shot 2018-04-12 at 12 11 23 pm" src="https://user-images.githubusercontent.com/1397914/38689863-a6c726f8-3e4a-11e8-902d-5f672d9a58a5.png">



## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
