### PR TITLE
DP-8516 - Add flex basis style to CSS that was applied inline.

### DIFF
--- a/changelogs/DP-8516.txt
+++ b/changelogs/DP-8516.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Changed
+Minor
+- DP-8516: Moved inline style to SCSS file.

--- a/styleguide/source/_patterns/02-molecules/image-promo.twig
+++ b/styleguide/source/_patterns/02-molecules/image-promo.twig
@@ -1,9 +1,6 @@
 <section class="ma__image-promo{{ imagePromo.location.map ? ' js-location-listing-link' : '' }}">
   {% if imagePromo.image %}
-    <div class="ma__image-promo__image"
-      {% if imagePromo.image.width %}
-        style="flex-basis: {{ imagePromo.image.width }}px"
-      {% endif %}>
+    <div class="ma__image-promo__image">
       {% if imagePromo.image.href %}
         <a href="{{ imagePromo.image.href }}">
       {% endif %}

--- a/styleguide/source/assets/scss/02-molecules/_image-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_image-promo.scss
@@ -24,7 +24,6 @@ $image-promo-bp-x-large-min: "min-width: 1160px";
   &__image {
     flex-shrink: 0;
     flex-grow: 0;
-    flex-basis: 190px;
     font-size: 0;
     margin-right: 30px;
     margin-bottom: 10px;

--- a/styleguide/source/assets/scss/04-templates/_bio.scss
+++ b/styleguide/source/assets/scss/04-templates/_bio.scss
@@ -19,4 +19,8 @@
       display: block;
     }
   }
+
+  .ma__image-promo__image {
+    flex-basis: 100px;
+  }
 }


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
Added the `flex-basis: 100px` style to the CSS for the bio pages that was previously only added as inline styles in the page pattern. This update should have that style applied to the integration piece in DP-8516.

## Related Issue / Ticket
https://jira.state.ma.us/browse/DP-8516

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

[ ] Go to view the bio page - /?p=pages-bio-page.
[ ] Inspect element on the organization image. You should see that the `flex-basis: 100px` style is added and applied to the image:
![image](https://user-images.githubusercontent.com/1103479/38837619-9e1f2a38-41a0-11e8-9a2e-c7f60c06a49d.png)
 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
