### PR TITLE
Resolve artifact push being skipped in the case where there are only added files

### DIFF
--- a/styleguide/tools/gulp/Artifacts.js
+++ b/styleguide/tools/gulp/Artifacts.js
@@ -44,8 +44,12 @@ class ArtifactRegistry extends MayflowerRegistry {
 
         const commit = function() {
             // We only need to run a commit if the working copy is dirty.
-            return exec("git diff --exit-code", {cwd: self.resolveDest()})
-                .catch(() => exec(`git add . && git commit -m ${e(self.getCommitMessage())}`, {cwd: self.resolveDest()}));
+            return exec("git status --porcelain", {cwd: self.resolveDest()})
+                .then((res) => {
+                    if(res.stdout.trim().length > 0) {
+                        return exec(`git add . && git commit -m ${e(self.getCommitMessage())}`, {cwd: self.resolveDest()});
+                    }
+                });
         };
         const pushBranch = function() {
             return exec(`git push origin ${e(self.getBranch())}`, {cwd: self.resolveDest()});


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
`gulp artifacts:publish` was failing to detect changes to the artifacts repository (and therefore failing to commit and push) when a commit only adds new files and doesn't change or delete any files.  For example, [this commit](https://github.com/massgov/mayflower/pull/764/commits/a92a3ad55f99ffe4932727910b39da3f19e6d1fb) failed to push to the mayflower-artifacts repo.  This PR adjusts the artifacts release script so newly added files are detected as a valid change.  After this change, I ran `gulp artifacts:publish` locally, which resulted in [this commit](https://github.com/massgov/mayflower-artifacts/commit/2cf7b6a798b65198bffe3b4a0bba0d7232d42000) on the artifacts side.

## Related Issue / Ticket

- [JIRA issue]()
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. 

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
