### PR TITLE
Allow a separte title to be supplied to map markers

### DIFF
--- a/changelogs/DP-7761.txt
+++ b/changelogs/DP-7761.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Changed
+Patch
+- DP-7761: Allows the title / hover of a map marker to be passed in separate from the name within the window info.

--- a/styleguide/source/_patterns/02-molecules/google-map.json
+++ b/styleguide/source/_patterns/02-molecules/google-map.json
@@ -10,7 +10,7 @@
     "markers": [{
       "position": {
         "lat": 42.366565,
-        "lng": -71.058940 
+        "lng": -71.058940
       },
       "label": "A",
       "infoWindow": {
@@ -24,16 +24,17 @@
     },{
       "position": {
         "lat": 42.358795,
-        "lng": -71.063858 
+        "lng": -71.063858
       },
       "label": "B",
       "infoWindow": {
-        "name": "Department of Recreation and Fun",
+        "name": "<a href=\"#\">Department of Recreation and Fun</a>",
         "phone": "16176261250",
         "fax": "",
         "email": "mass.parks@state.ma.us",
         "address": "24 Beacon St\nBoston, MA 02133"
-      }
+      },
+      "title": "Department of Recreation and Fun"
     }]
   }
 }

--- a/styleguide/source/assets/js/modules/googleMap.js
+++ b/styleguide/source/assets/js/modules/googleMap.js
@@ -154,7 +154,7 @@ export default function (window,document,$,undefined) {
    */
   function initMarkers(map, markers) {
     let initializedMarkers = [];
-    markers.forEach(function(data) {
+    markers.forEach((data) => {
       let markerData = {
         position: new google.maps.LatLng({
           lat: data.position.lat,
@@ -162,7 +162,7 @@ export default function (window,document,$,undefined) {
         }),
         label: data.label,
         infoWindow: data.infoWindow,
-        title: 'Marker: ' + data.infoWindow.name
+        title: 'Marker: ' + (data.hasOwnProperty('title') ? data.title : data.infoWindow.name)
       };
       let marker =  new google.maps.Marker(markerData);
       let infoData = infoTransform(markerData.infoWindow);


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
I have updated the map component to allow for the title text of markers to be sent in separately.  It does still fallback to the windowInfo.name field if the text is not passed in.

## Related Issue / Ticket

- [DP-7761](https://jira.state.ma.us/browse/DP-7761)
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Checkout the branch and build Mayflower.
1. Load the Google Map Molecule.
1. Hover over the markers to confirm that you see "Marker: <plain text title>" when hovering.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
