### PR TITLE
DP-8880: Allow sidebar of stacked row to be overridden

### DIFF
--- a/changelogs/DP-8880.txt
+++ b/changelogs/DP-8880.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Changed
+Patch
+- DP-8880: Allow a block to be overridden for the sidebar of the stacked row section pattern.

--- a/styleguide/source/_patterns/03-organisms/by-author/stacked-row-section.twig
+++ b/styleguide/source/_patterns/03-organisms/by-author/stacked-row-section.twig
@@ -24,11 +24,13 @@
         {% endfor %}
       {% endblock %}
     </div>
-    {% if stackedRowSection.sideBar|length %}
+    {% if stackedRowSection.sideBar|length or stackedRowSection.overrideSideBar %}
       <aside class="sidebar">
-        {% for sidebar in stackedRowSection.sideBar %}
-          {% include sidebar.path with sidebar.data %}
-        {% endfor %}
+        {% block sidebar %}
+          {% for sidebar in stackedRowSection.sideBar %}
+            {% include sidebar.path with sidebar.data %}
+          {% endfor %}
+        {% endblock %}
       </aside>
     {% endif %}
   </div>


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
This does not change mayflower markup or functionality.  It only allows for the sidebar of the stacked row section to be overridden.

## Related Issue / Ticket

- [DP-8880](https://jira.state.ma.us/browse/DP-8880)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Check the stacked row section organism (by author) to confirm it has not changed.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
