### PR TITLE
Release 5.24.0

### DIFF
--- a/changelogs/DP-8956.txt
+++ b/changelogs/DP-8956.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Fixed
+Patch
+- DP-8956: Update contact us to provide a way to keep address above other information even if there is only two contact groups.

--- a/changelogs/DP-8956.txt
+++ b/changelogs/DP-8956.txt
@@ -1,4 +1,0 @@
-___DESCRIPTION___
-Fixed
-Patch
-- DP-8956: Update contact us to provide a way to keep address above other information even if there is only two contact groups.

--- a/release-notes.md
+++ b/release-notes.md
@@ -13,6 +13,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 **For example**
 - DP-1234: The short description text on a [service detail](http://mayflower.digital.mass.gov/?p=pages-detail-for-service-howto-location) page banner ([@organisms/by-template/page-banner](http://mayflower.digital.mass.gov/?p=organisms-page-banner)) should now render ([PR #493](https://github.com/massgov/mayflower/pull/493))
 
+## 5.24.0 (5/16/2018)
+
+### Fixed
+- DP-8956: Update contact us to provide a way to keep address above other information even if there is only two contact groups.
+
 ## 5.23.0 (5/15/2018)
 
 ### Added

--- a/styleguide/package.json
+++ b/styleguide/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@massds/mayflower",
   "description": "Open source UI components and visual style guide for Massachusetts government websites",
-  "version": "5.23.0",
+  "version": "5.24.0",
   "author": "Massachusetts Digital Services (MDS)",
   "repository": {
     "type": "git",

--- a/styleguide/source/_patterns/02-molecules/contact-us.md
+++ b/styleguide/source/_patterns/02-molecules/contact-us.md
@@ -31,6 +31,12 @@ contactUs: {
   subTitle: {
     type: columnHeading / optional
   }
+  showMore: {
+    type: boolean / optional
+  }
+  hideSecondary: {
+    type: boolean / optional
+  }
   level:
     type: number / optional
   contactName:

--- a/styleguide/source/_patterns/02-molecules/contact-us.twig
+++ b/styleguide/source/_patterns/02-molecules/contact-us.twig
@@ -40,22 +40,24 @@
         {% endfor %}
       {% endblock %}
 
-      {# Show 3rd+ contact groups inside of accordion (if they exist) #}
-      <div class="ma__contact-us__extra js-accordion-content">
-        {% block secondaryContactGroups %}
-          {% for group in contactUs.groups[2:last] %}
-            {% set contactGroup = group|merge({
-                               "level": groupHeading,
-                               "contactName": contactName })  %}
-            {% include "@molecules/contact-group.twig" %}
-          {% endfor %}
-        {% endblock %}
-      </div>
-      <div class="ma__contact-us__expand">
-        <button type="button" class="js-accordion-link">
-          <span>more</span><span>less</span> contact info
-        </button>
-      </div>
+      {% if not contactUs.hideSecondary %}
+        {# Show 3rd+ contact groups inside of accordion (if they exist) #}
+        <div class="ma__contact-us__extra js-accordion-content">
+          {% block secondaryContactGroups %}
+            {% for group in contactUs.groups[2:last] %}
+              {% set contactGroup = group|merge({
+                                 "level": groupHeading,
+                                 "contactName": contactName })  %}
+              {% include "@molecules/contact-group.twig" %}
+            {% endfor %}
+          {% endblock %}
+        </div>
+        <div class="ma__contact-us__expand">
+          <button type="button" class="js-accordion-link">
+            <span>more</span><span>less</span> contact info
+          </button>
+        </div>
+      {% endif %}
     {% else %}
       <div class="ma__contact-us__content js-accordion-content">
         <div class="ma__contact-us__content-wrap">


### PR DESCRIPTION
## 5.24.0 (5/16/2018)

### Fixed
- DP-8956: Update contact us to provide a way to keep address above other information even if there is only two contact groups.