### PR TITLE
DP-9146  style adjustments to boards

### DIFF
--- a/changelogs/DP-8825.txt
+++ b/changelogs/DP-8825.txt
@@ -1,0 +1,3 @@
+Added
+Minor
+- DP-8825: Adds teaser listing group organism to apply accordion behavior to multiple teaser listings at once.

--- a/styleguide/source/_patterns/02-molecules/general-teaser.twig
+++ b/styleguide/source/_patterns/02-molecules/general-teaser.twig
@@ -3,7 +3,7 @@
 
 <section class="ma__general-teaser {{ imageClass }} {{ layout }}">
   {% block teaserImage %}
-    {% if generalTeaser.image %}
+    {% if generalTeaser.image.src %}
 
       {% if generalTeaser.title.href %}
         <a

--- a/styleguide/source/_patterns/05-pages/organization~boards.json
+++ b/styleguide/source/_patterns/05-pages/organization~boards.json
@@ -10,15 +10,17 @@
     "titleSubText": "(FLB)"
   },
   "short_description": {
-     "richText": {
-      "rteElements": [{
-        "path": "@atoms/04-headings/heading-4.twig",
-        "data": {
-           "heading4" : {
-            "text": "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. "
+    "richText": {
+      "rteElements": [
+        {
+          "path": "@atoms/04-headings/heading-4.twig",
+          "data": {
+            "heading4": {
+              "text": "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. "
+            }
           }
         }
-      }]
+      ]
     }
   },
   "stackedRows": [
@@ -111,7 +113,8 @@
           }
         }
       ]
-    },{
+    },
+    {
       "title": "",
       "id": "",
       "pageContent": [
@@ -253,8 +256,10 @@
               ]
             }
           }
-        }]
-    },{
+        }
+      ]
+    },
+    {
       "title": "About Us",
       "id": "",
       "pageContent": [
@@ -284,44 +289,51 @@
           }
         }
       ],
-      "sideBar": [{
-        "path": "@molecules/icon-links.twig",
-        "data": {
-          "iconLinks": {
-            "compHeading": {
-              "title": "Social",
-              "sub": true,
-              "color": "",
-              "id": "",
-              "centered": "",
-              "titleContext": "links for Executive Office of Health and Human Services"
-            },
-            "items": [{
-              "icon": "twitter",
-              "link": {
-                "href": "https://twitter.com/MassHHS",
-                "text": "@MassHHS",
-                "chevron": ""
-              }
-            },{
-              "icon": "flickr",
-              "link": {
-                "href": "https://www.flickr.com/photos/mass_hhs/",
-                "text": "Mass_HHS",
-                "chevron": ""
-              }
-            },{
-              "icon": "blog",
-              "link": {
-                "href": "https://blog.mass.gov/hhs",
-                "text": "blog.mass.gov/hhs",
-                "chevron": ""
-              }
-            }]
+      "sideBar": [
+        {
+          "path": "@molecules/icon-links.twig",
+          "data": {
+            "iconLinks": {
+              "compHeading": {
+                "title": "Social",
+                "sub": true,
+                "color": "",
+                "id": "",
+                "centered": "",
+                "titleContext": "links for Executive Office of Health and Human Services"
+              },
+              "items": [
+                {
+                  "icon": "twitter",
+                  "link": {
+                    "href": "https://twitter.com/MassHHS",
+                    "text": "@MassHHS",
+                    "chevron": ""
+                  }
+                },
+                {
+                  "icon": "flickr",
+                  "link": {
+                    "href": "https://www.flickr.com/photos/mass_hhs/",
+                    "text": "Mass_HHS",
+                    "chevron": ""
+                  }
+                },
+                {
+                  "icon": "blog",
+                  "link": {
+                    "href": "https://blog.mass.gov/hhs",
+                    "text": "blog.mass.gov/hhs",
+                    "chevron": ""
+                  }
+                }
+              ]
+            }
           }
         }
-      }]
-    },{
+      ]
+    },
+    {
       "title": "Board Members",
       "id": "",
       "pageContent": [
@@ -364,29 +376,6 @@
                             }
                           }
                         }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "layout": "stacked",
-                  "image": {
-                    "src": "",
-                    "alt": "placeholder image",
-                    "width": "172",
-                    "height": "228"
-                  },
-                  "eyebrow": "Featured Board Member",
-                  "title": {
-                    "href": "#",
-                    "text": "Featured Board Member's Name",
-                    "info": "",
-                    "property": ""
-                  },
-                  "emphasizedText": [
-                    "Featured Board Member's title"
-                  ],
-                  "contents": [
                       ]
                     },
                     {
@@ -1315,7 +1304,7 @@
             }
           }
         },
-                {
+        {
           "path": "@organisms/by-author/mapped-locations.twig",
           "data": {
             "mappedLocations": {

--- a/styleguide/source/_patterns/05-pages/organization~boards.json
+++ b/styleguide/source/_patterns/05-pages/organization~boards.json
@@ -364,8 +364,29 @@
                             }
                           }
                         }
-                      ]
-                    },
+                      }
+                    }
+                  ]
+                },
+                {
+                  "layout": "stacked",
+                  "image": {
+                    "src": "",
+                    "alt": "placeholder image",
+                    "width": "172",
+                    "height": "228"
+                  },
+                  "eyebrow": "Featured Board Member",
+                  "title": {
+                    "href": "#",
+                    "text": "Featured Board Member's Name",
+                    "info": "",
+                    "property": ""
+                  },
+                  "emphasizedText": [
+                    "Featured Board Member's title"
+                  ],
+                  "contents": [
                     {
                       "layout": "stacked",
                       "image": {

--- a/styleguide/source/_patterns/05-pages/organization~boards.json
+++ b/styleguide/source/_patterns/05-pages/organization~boards.json
@@ -387,6 +387,8 @@
                     "Featured Board Member's title"
                   ],
                   "contents": [
+                      ]
+                    },
                     {
                       "layout": "stacked",
                       "image": {

--- a/styleguide/source/assets/js/modules/teaserListingGroup.js
+++ b/styleguide/source/assets/js/modules/teaserListingGroup.js
@@ -13,6 +13,11 @@ export default function (window, document, $, undefined) {
         let totalShown = $root.data('totalVisible');
         let teaserItems = $root.find('.ma__general-teaser');
 
+        // Hide the toggle if the number of items is less than or equal to the number shown.
+        if (teaserItems.length <= totalShown) {
+          $toggle.hide();
+        }
+
         // set excess items to be hidden
         teaserItems.slice(totalShown, teaserItems.length).each((i, el) => {
             // Items can be siblings or within an <li>, add class to the <li> if present


### PR DESCRIPTION
Style adjustments to boards

## Description
Makes requested updates to layout and fixes some IE bugs

## Related Issue / Ticket

- [DP-9146](https://jira.mass.gov/browse/DP-9146)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1.  Changes can be viewed in Mayflower here: /?p=pages-organization-boards
Check in IE11 that the broken image tags do not appear for board members with no image included

## Screenshots
<img width="1416" alt="screen shot 2018-06-12 at 11 47 19 am" src="https://user-images.githubusercontent.com/18662734/41304671-6a7026ac-6e36-11e8-8aa6-97f7c525a8fb.png">


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
