### PR TITLE
DP-9297 Remove alt value from the state seal

### DIFF
--- a/changelogs/DP-9297.txt
+++ b/changelogs/DP-9297.txt
@@ -1,0 +1,28 @@
+___DESCRIPTION___
+Removed
+Minor
+- DP-1234: Removed alt value from the state seal since the text "Mass.gov" is duplicate to the content in the followed <span>. 
+
+___SEMANTIC VERSION (see below)___
+
+
+___POST DEPLOY STEPS___
+1. Do this
+2. Then do this
+
+___CHANGE TYPES___
+- Added for new features.
+- Changed for changes in existing functionality.
+- Deprecated for soon-to-be removed features.
+- Removed for now removed features.
+- Fixed for any bug fixes.
+- Security in case of vulnerabilities.
+
+Note: See http://keepachangelog.com/ for more info about changelogs.
+
+___CHANGE IMPACT___
+- Minor
+- Major
+- Patch
+
+Note: Refer to `docs/versioning.md` for more info about change impact according to semantic versioning.

--- a/styleguide/source/_patterns/01-atoms/09-media/site-logo.twig
+++ b/styleguide/source/_patterns/01-atoms/09-media/site-logo.twig
@@ -1,6 +1,6 @@
 <div class="ma__site-logo">
   <a href="{{ url.domain }}/" title="Mass.gov home page">
-    <img src="{{ urlDomain ~ '/' ~ directory }}/images/stateseal.png" alt="Mass.gov" height="45" />
+    <img src="{{ urlDomain ~ '/' ~ directory }}/images/stateseal.png" alt="" height="45" />
     <span>Mass.gov</span>
   </a>
 </div>


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Remove the alt value, Mass.gov, from the state seal image in the header since it is duplicate to the followed <span> content, Mass.gov, to prevent screen readers announce "Mass.gov" twice in a row.

## Related Issue / Ticket

- [DP-9297 \[a11y\] Duplicate content in header](https://jira.mass.gov/browse/DP-9297)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Check the source for the state seal in the header area and find the alt attribute is empty and the followed <span> has the content "Mass.gov" as its text alternative. 

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
