### PR TITLE
DP-8804: Update Google Maps API to fix deprecation warning

### DIFF
--- a/changelogs/DP-8804.txt
+++ b/changelogs/DP-8804.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Updated
+Patch
+- DP-8804: Updates Google Maps API version used in Mayflower.

--- a/styleguide/source/_meta/_01-foot.twig
+++ b/styleguide/source/_meta/_01-foot.twig
@@ -49,7 +49,7 @@
       {% set mapLibraries = 'places' %}
     {% endif %}
 
-    <script src="//maps.googleapis.com/maps/api/js?key=AIzaSyD5HXUVAA4VyRXVX50taVe2hDY8hy2JSdA&v=3.28&libraries={{ mapLibraries }}&callback=initGoogleMaps"></script>
+    <script src="//maps.googleapis.com/maps/api/js?key=AIzaSyD5HXUVAA4VyRXVX50taVe2hDY8hy2JSdA&v=3&libraries={{ mapLibraries }}&callback=initGoogleMaps"></script>
 
     <script>
       try {


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
Updates the Google Maps API version used in Mayflower.  Note that this change just proves that Mayflower can work with newer versions of the Google Maps API - it doesn't actually change the implementation we're currently using in Drupal. 

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-8804)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Check the location listings pages.  These pages exercise pretty much every feature of our Google maps integration (geocoding addresses, maps with markers, zooming, etc).  If it functions the same as the latest Mayflower release, we should be in good shape.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
